### PR TITLE
6 add core game functionality

### DIFF
--- a/workspace.json
+++ b/workspace.json
@@ -5,8 +5,8 @@
       {
         "type": "modBlock",
         "id": "W!JH}*8Sg$A)IDsU)nV1",
-        "x": 10,
-        "y": 10,
+        "x": 137,
+        "y": -85,
         "inputs": {
           "RULES": {
             "block": {
@@ -24,160 +24,633 @@
                 "ACTIONS": {
                   "block": {
                     "type": "SetVariable",
-                    "id": "eB[i6{2Cgs[KsUm[UCOI",
+                    "id": "4wo}9PrFA.Nl($Kg:^b^",
                     "inputs": {
                       "VALUE-0": {
                         "block": {
                           "type": "variableReferenceBlock",
-                          "id": "%LQ!tG;@ynLiabyDZi9(",
+                          "id": "z=7yjQhPT3*1Z{sJ:!vw",
                           "extraState": {
                             "isObjectVar": false
                           },
                           "fields": {
                             "OBJECTTYPE": "Global",
                             "VAR": {
-                              "id": "avhOM{5IU+T,cbtA-5?M"
+                              "id": "{EF$oQ94sNRA2*og65H/"
                             }
                           }
                         }
                       },
                       "VALUE-1": {
                         "block": {
-                          "type": "EmptyArray",
-                          "id": "n@xvWC4_-%6Cv|^TMk=^"
+                          "type": "Boolean",
+                          "id": "?D[F`N@*IRtmYl4zN#GE",
+                          "fields": {
+                            "BOOL": "TRUE"
+                          }
                         }
                       }
                     },
                     "next": {
                       "block": {
                         "type": "SetVariable",
-                        "id": "laQ+2mW-F_H{~V}ywk8e",
+                        "id": "bO7;bB:Q}ISI:(ehj({F",
                         "inputs": {
                           "VALUE-0": {
                             "block": {
                               "type": "variableReferenceBlock",
-                              "id": "r/d0%OC3vT=TlSumf/b,",
+                              "id": "G@-;v^}H}:0-!2-%fJvT",
                               "extraState": {
                                 "isObjectVar": false
                               },
                               "fields": {
                                 "OBJECTTYPE": "Global",
                                 "VAR": {
-                                  "id": "I;O66Sw;VrFU](bV9s}."
+                                  "id": "}^*LIdpxV;$%E-l3ayo="
                                 }
                               }
                             }
                           },
                           "VALUE-1": {
                             "block": {
-                              "type": "EmptyArray",
-                              "id": "2-#kP,#PXX)0GXHGd*E,"
+                              "type": "Boolean",
+                              "id": "~A_b[la$?YgjpUWl2mmV",
+                              "fields": {
+                                "BOOL": "FALSE"
+                              }
                             }
                           }
                         },
                         "next": {
                           "block": {
                             "type": "SetVariable",
-                            "id": "smF`e!I*Sh!!2MyUXzAs",
+                            "id": "+f(_uM2m_{p{6HM?KBJu",
                             "inputs": {
                               "VALUE-0": {
                                 "block": {
                                   "type": "variableReferenceBlock",
-                                  "id": "!ibm=s*wSpKT#`3b5EJQ",
+                                  "id": ".ZrKU85=i09$X8pc,C?U",
                                   "extraState": {
                                     "isObjectVar": false
                                   },
                                   "fields": {
                                     "OBJECTTYPE": "Global",
                                     "VAR": {
-                                      "id": "(ZHqM}3*6qf%Gv}2bOzk"
+                                      "id": "G8`8D):j~iWsK^BLzR?n"
                                     }
                                   }
                                 }
                               },
                               "VALUE-1": {
                                 "block": {
-                                  "type": "EmptyArray",
-                                  "id": "5%?,[zO.,.O68;qWAdYd"
+                                  "type": "Number",
+                                  "id": "bGcQiPHP4IpBI0`RE-Uj",
+                                  "fields": {
+                                    "NUM": 5
+                                  }
                                 }
                               }
                             },
                             "next": {
                               "block": {
-                                "type": "SetVariable",
-                                "id": "6NXn=7((W7ob}J8)t)BQ",
+                                "type": "EnableDefaultScoring",
+                                "id": "m%WTN!QAL0YhjNZHOjBc",
                                 "inputs": {
                                   "VALUE-0": {
                                     "block": {
-                                      "type": "variableReferenceBlock",
-                                      "id": "B:KL`PCJSj,82=m*pl8A",
-                                      "extraState": {
-                                        "isObjectVar": true
-                                      },
+                                      "type": "Boolean",
+                                      "id": "tz1/XXGzjJiX|uC5#/bD",
                                       "fields": {
-                                        "OBJECTTYPE": "TeamId",
-                                        "VAR": {
-                                          "id": "~!s}ovrs?jb7Yd/X[z2!"
-                                        }
-                                      },
-                                      "inputs": {
-                                        "OBJECT": {
-                                          "block": {
-                                            "type": "GetTeamId",
-                                            "id": "`R2tzia{K@u5z}9MyNyJ",
-                                            "inputs": {
-                                              "VALUE-0": {
-                                                "block": {
-                                                  "type": "Number",
-                                                  "id": "epQ||CEjt=zB_onvqv_!",
-                                                  "fields": {
-                                                    "NUM": 1
-                                                  }
-                                                }
-                                              }
-                                            }
-                                          }
-                                        }
+                                        "BOOL": "FALSE"
                                       }
-                                    }
-                                  },
-                                  "VALUE-1": {
-                                    "block": {
-                                      "type": "EmptyArray",
-                                      "id": "jM[q|y##+s]z82Z0uGVj"
                                     }
                                   }
                                 },
                                 "next": {
                                   "block": {
-                                    "type": "SetVariable",
-                                    "id": "N?f`nY)EiI)LzbX.NV,f",
+                                    "type": "EnableDefaultWinCondition",
+                                    "id": "};`4C;uCEW5~kl}F2Qy}",
                                     "inputs": {
                                       "VALUE-0": {
                                         "block": {
-                                          "type": "variableReferenceBlock",
-                                          "id": "GV]I@t|zEq6.us!+c1]{",
-                                          "extraState": {
-                                            "isObjectVar": true
-                                          },
+                                          "type": "Boolean",
+                                          "id": "MzCSxRxu5o!ZNn}8MZSd",
                                           "fields": {
-                                            "OBJECTTYPE": "TeamId",
-                                            "VAR": {
-                                              "id": "~!s}ovrs?jb7Yd/X[z2!"
+                                            "BOOL": "FALSE"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "next": {
+                                      "block": {
+                                        "type": "SetVariable",
+                                        "id": "ozVn*dwS|i2mL`)ls}]A",
+                                        "inputs": {
+                                          "VALUE-0": {
+                                            "block": {
+                                              "type": "variableReferenceBlock",
+                                              "id": "bW[9x]T`/(GKMS@uW{QN",
+                                              "extraState": {
+                                                "isObjectVar": false
+                                              },
+                                              "fields": {
+                                                "OBJECTTYPE": "Global",
+                                                "VAR": {
+                                                  "id": "*%AGr_rl5x3.om4(DqsJ"
+                                                }
+                                              }
                                             }
                                           },
-                                          "inputs": {
-                                            "OBJECT": {
+                                          "VALUE-1": {
+                                            "block": {
+                                              "type": "Text",
+                                              "id": "ywO]67Y7%F@!,oa1^B%w",
+                                              "fields": {
+                                                "TEXT": "Intro"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "next": {
+                                          "block": {
+                                            "type": "SetVariable",
+                                            "id": "JB2G-*6Q@Q7J2K:ZMI$9",
+                                            "inputs": {
+                                              "VALUE-0": {
+                                                "block": {
+                                                  "type": "variableReferenceBlock",
+                                                  "id": "S+szPZuVts(acm$GNVn]",
+                                                  "extraState": {
+                                                    "isObjectVar": false
+                                                  },
+                                                  "fields": {
+                                                    "OBJECTTYPE": "Global",
+                                                    "VAR": {
+                                                      "id": "**%O*!0`FJS;40@p6=u|"
+                                                    }
+                                                  }
+                                                }
+                                              },
+                                              "VALUE-1": {
+                                                "block": {
+                                                  "type": "Text",
+                                                  "id": "|?AHOnk/y?XPcu.gL*`s",
+                                                  "fields": {
+                                                    "TEXT": "in Progress"
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "next": {
                                               "block": {
-                                                "type": "GetTeamId",
-                                                "id": "(azVV^U7kFaWp2A,86gd",
+                                                "type": "SetVariable",
+                                                "id": "3c_XPSM7aqz`O+sj_RQI",
                                                 "inputs": {
                                                   "VALUE-0": {
                                                     "block": {
-                                                      "type": "Number",
-                                                      "id": "JQ-,|8Npn(heW$YyRJX9",
+                                                      "type": "variableReferenceBlock",
+                                                      "id": "pyF_TXCT)iSSD~xXnPo/",
+                                                      "extraState": {
+                                                        "isObjectVar": false
+                                                      },
                                                       "fields": {
-                                                        "NUM": 2
+                                                        "OBJECTTYPE": "Global",
+                                                        "VAR": {
+                                                          "id": "Xr?o?acUGgeUMdeaBx?x"
+                                                        }
+                                                      }
+                                                    }
+                                                  },
+                                                  "VALUE-1": {
+                                                    "block": {
+                                                      "type": "Text",
+                                                      "id": "-{fJ@oT)QR*EvN]Wfd6o",
+                                                      "fields": {
+                                                        "TEXT": "End Round"
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "next": {
+                                                  "block": {
+                                                    "type": "SetVariable",
+                                                    "id": "cI*Y:0fojAO4W.WLM*LG",
+                                                    "inputs": {
+                                                      "VALUE-0": {
+                                                        "block": {
+                                                          "type": "variableReferenceBlock",
+                                                          "id": "(X(8t$.}8rms:bfnaZN5",
+                                                          "extraState": {
+                                                            "isObjectVar": false
+                                                          },
+                                                          "fields": {
+                                                            "OBJECTTYPE": "Global",
+                                                            "VAR": {
+                                                              "id": "ML+?PN8B2+zUSlDEx$/,"
+                                                            }
+                                                          }
+                                                        }
+                                                      },
+                                                      "VALUE-1": {
+                                                        "block": {
+                                                          "type": "Text",
+                                                          "id": "M`;A#b6cnm*#nAuM.L/R",
+                                                          "fields": {
+                                                            "TEXT": "Next Round"
+                                                          }
+                                                        }
+                                                      }
+                                                    },
+                                                    "next": {
+                                                      "block": {
+                                                        "type": "SetVariable",
+                                                        "id": "jYTo7@Wack7VNmL6D]3l",
+                                                        "inputs": {
+                                                          "VALUE-0": {
+                                                            "block": {
+                                                              "type": "variableReferenceBlock",
+                                                              "id": "hLwy3Y{(V$6$A(zo+qjg",
+                                                              "extraState": {
+                                                                "isObjectVar": false
+                                                              },
+                                                              "fields": {
+                                                                "OBJECTTYPE": "Global",
+                                                                "VAR": {
+                                                                  "id": "=8OY*aWMGF4.T^k6uLUl"
+                                                                }
+                                                              }
+                                                            }
+                                                          },
+                                                          "VALUE-1": {
+                                                            "block": {
+                                                              "type": "GetVariable",
+                                                              "id": "zFF/3ESdj]7X6!EG9u%F",
+                                                              "inputs": {
+                                                                "VALUE-0": {
+                                                                  "block": {
+                                                                    "type": "variableReferenceBlock",
+                                                                    "id": "Gho-J8OKNf,9RINq2*}Z",
+                                                                    "extraState": {
+                                                                      "isObjectVar": false
+                                                                    },
+                                                                    "fields": {
+                                                                      "OBJECTTYPE": "Global",
+                                                                      "VAR": {
+                                                                        "id": "*%AGr_rl5x3.om4(DqsJ"
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        },
+                                                        "next": {
+                                                          "block": {
+                                                            "type": "SetGamemodeScore",
+                                                            "id": "+Vwvrig$)+a%ZAU}WPuM",
+                                                            "inputs": {
+                                                              "VALUE-0": {
+                                                                "block": {
+                                                                  "type": "GetTeamId",
+                                                                  "id": "_EaS(AMVN$Gp(|0rpcX2",
+                                                                  "inputs": {
+                                                                    "VALUE-0": {
+                                                                      "block": {
+                                                                        "type": "Number",
+                                                                        "id": "8@rq^Q0wn6VYQ]y)ofJs",
+                                                                        "fields": {
+                                                                          "NUM": 1
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              },
+                                                              "VALUE-1": {
+                                                                "block": {
+                                                                  "type": "Number",
+                                                                  "id": "l?vXVxq%jLv}Y=^T;1ml",
+                                                                  "fields": {
+                                                                    "NUM": 100
+                                                                  }
+                                                                }
+                                                              }
+                                                            },
+                                                            "next": {
+                                                              "block": {
+                                                                "type": "SetGamemodeScore",
+                                                                "id": "q-~Sv)#bZM$+a6Q*s[i^",
+                                                                "inputs": {
+                                                                  "VALUE-0": {
+                                                                    "block": {
+                                                                      "type": "GetTeamId",
+                                                                      "id": "4?-W`O7fUWhd~bw(q65.",
+                                                                      "inputs": {
+                                                                        "VALUE-0": {
+                                                                          "block": {
+                                                                            "type": "Number",
+                                                                            "id": "/%1]k@MVnsdVD7?p{i-:",
+                                                                            "fields": {
+                                                                              "NUM": 2
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  "VALUE-1": {
+                                                                    "block": {
+                                                                      "type": "Number",
+                                                                      "id": "x/=:`=+j_@3ZW#K~oakS",
+                                                                      "fields": {
+                                                                        "NUM": 4
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                },
+                                                                "next": {
+                                                                  "block": {
+                                                                    "type": "SetVariable",
+                                                                    "id": "eB[i6{2Cgs[KsUm[UCOI",
+                                                                    "inputs": {
+                                                                      "VALUE-0": {
+                                                                        "block": {
+                                                                          "type": "variableReferenceBlock",
+                                                                          "id": "%LQ!tG;@ynLiabyDZi9(",
+                                                                          "extraState": {
+                                                                            "isObjectVar": false
+                                                                          },
+                                                                          "fields": {
+                                                                            "OBJECTTYPE": "Global",
+                                                                            "VAR": {
+                                                                              "id": "avhOM{5IU+T,cbtA-5?M"
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      },
+                                                                      "VALUE-1": {
+                                                                        "block": {
+                                                                          "type": "EmptyArray",
+                                                                          "id": "n@xvWC4_-%6Cv|^TMk=^"
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    "next": {
+                                                                      "block": {
+                                                                        "type": "SetVariable",
+                                                                        "id": "laQ+2mW-F_H{~V}ywk8e",
+                                                                        "inputs": {
+                                                                          "VALUE-0": {
+                                                                            "block": {
+                                                                              "type": "variableReferenceBlock",
+                                                                              "id": "r/d0%OC3vT=TlSumf/b,",
+                                                                              "extraState": {
+                                                                                "isObjectVar": false
+                                                                              },
+                                                                              "fields": {
+                                                                                "OBJECTTYPE": "Global",
+                                                                                "VAR": {
+                                                                                  "id": "I;O66Sw;VrFU](bV9s}."
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          "VALUE-1": {
+                                                                            "block": {
+                                                                              "type": "EmptyArray",
+                                                                              "id": "2-#kP,#PXX)0GXHGd*E,"
+                                                                            }
+                                                                          }
+                                                                        },
+                                                                        "next": {
+                                                                          "block": {
+                                                                            "type": "SetVariable",
+                                                                            "id": "smF`e!I*Sh!!2MyUXzAs",
+                                                                            "inputs": {
+                                                                              "VALUE-0": {
+                                                                                "block": {
+                                                                                  "type": "variableReferenceBlock",
+                                                                                  "id": "!ibm=s*wSpKT#`3b5EJQ",
+                                                                                  "extraState": {
+                                                                                    "isObjectVar": false
+                                                                                  },
+                                                                                  "fields": {
+                                                                                    "OBJECTTYPE": "Global",
+                                                                                    "VAR": {
+                                                                                      "id": "(ZHqM}3*6qf%Gv}2bOzk"
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              },
+                                                                              "VALUE-1": {
+                                                                                "block": {
+                                                                                  "type": "EmptyArray",
+                                                                                  "id": "5%?,[zO.,.O68;qWAdYd"
+                                                                                }
+                                                                              }
+                                                                            },
+                                                                            "next": {
+                                                                              "block": {
+                                                                                "type": "SetVariable",
+                                                                                "id": "6NXn=7((W7ob}J8)t)BQ",
+                                                                                "inputs": {
+                                                                                  "VALUE-0": {
+                                                                                    "block": {
+                                                                                      "type": "variableReferenceBlock",
+                                                                                      "id": "B:KL`PCJSj,82=m*pl8A",
+                                                                                      "extraState": {
+                                                                                        "isObjectVar": true
+                                                                                      },
+                                                                                      "fields": {
+                                                                                        "OBJECTTYPE": "TeamId",
+                                                                                        "VAR": {
+                                                                                          "id": "~!s}ovrs?jb7Yd/X[z2!"
+                                                                                        }
+                                                                                      },
+                                                                                      "inputs": {
+                                                                                        "OBJECT": {
+                                                                                          "block": {
+                                                                                            "type": "GetTeamId",
+                                                                                            "id": "`R2tzia{K@u5z}9MyNyJ",
+                                                                                            "inputs": {
+                                                                                              "VALUE-0": {
+                                                                                                "block": {
+                                                                                                  "type": "Number",
+                                                                                                  "id": "epQ||CEjt=zB_onvqv_!",
+                                                                                                  "fields": {
+                                                                                                    "NUM": 1
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  },
+                                                                                  "VALUE-1": {
+                                                                                    "block": {
+                                                                                      "type": "EmptyArray",
+                                                                                      "id": "jM[q|y##+s]z82Z0uGVj"
+                                                                                    }
+                                                                                  }
+                                                                                },
+                                                                                "next": {
+                                                                                  "block": {
+                                                                                    "type": "SetVariable",
+                                                                                    "id": "N?f`nY)EiI)LzbX.NV,f",
+                                                                                    "inputs": {
+                                                                                      "VALUE-0": {
+                                                                                        "block": {
+                                                                                          "type": "variableReferenceBlock",
+                                                                                          "id": "GV]I@t|zEq6.us!+c1]{",
+                                                                                          "extraState": {
+                                                                                            "isObjectVar": true
+                                                                                          },
+                                                                                          "fields": {
+                                                                                            "OBJECTTYPE": "TeamId",
+                                                                                            "VAR": {
+                                                                                              "id": "~!s}ovrs?jb7Yd/X[z2!"
+                                                                                            }
+                                                                                          },
+                                                                                          "inputs": {
+                                                                                            "OBJECT": {
+                                                                                              "block": {
+                                                                                                "type": "GetTeamId",
+                                                                                                "id": "(azVV^U7kFaWp2A,86gd",
+                                                                                                "inputs": {
+                                                                                                  "VALUE-0": {
+                                                                                                    "block": {
+                                                                                                      "type": "Number",
+                                                                                                      "id": "JQ-,|8Npn(heW$YyRJX9",
+                                                                                                      "fields": {
+                                                                                                        "NUM": 2
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      },
+                                                                                      "VALUE-1": {
+                                                                                        "block": {
+                                                                                          "type": "EmptyArray",
+                                                                                          "id": "QN@`E@Gfxb_WFQF!{yBP"
+                                                                                        }
+                                                                                      }
+                                                                                    },
+                                                                                    "next": {
+                                                                                      "block": {
+                                                                                        "type": "SetVariable",
+                                                                                        "id": "7De!g2sTa,M5qFwugcc+",
+                                                                                        "inputs": {
+                                                                                          "VALUE-0": {
+                                                                                            "block": {
+                                                                                              "type": "variableReferenceBlock",
+                                                                                              "id": "@]|+5Yi#c+5f|0,%vO=)",
+                                                                                              "extraState": {
+                                                                                                "isObjectVar": false
+                                                                                              },
+                                                                                              "fields": {
+                                                                                                "OBJECTTYPE": "Global",
+                                                                                                "VAR": {
+                                                                                                  "id": "W?M=066mWT~Tf=[ON!`$"
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          },
+                                                                                          "VALUE-1": {
+                                                                                            "block": {
+                                                                                              "type": "GetCapturePoint",
+                                                                                              "id": "W7l4;@i6Zy/$+*wxJK7r",
+                                                                                              "inputs": {
+                                                                                                "VALUE-0": {
+                                                                                                  "block": {
+                                                                                                    "type": "MCOMsItem",
+                                                                                                    "id": "T[Ct6,4Uukf+la,BbW06",
+                                                                                                    "fields": {
+                                                                                                      "VALUE-0": "MCOMs",
+                                                                                                      "VALUE-1": "A"
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        },
+                                                                                        "next": {
+                                                                                          "block": {
+                                                                                            "type": "SetVariable",
+                                                                                            "id": "J8E5=G`AH*[4Kdv*s:H+",
+                                                                                            "inputs": {
+                                                                                              "VALUE-0": {
+                                                                                                "block": {
+                                                                                                  "type": "variableReferenceBlock",
+                                                                                                  "id": "pxBQy(!+ocyRKSons-~W",
+                                                                                                  "extraState": {
+                                                                                                    "isObjectVar": false
+                                                                                                  },
+                                                                                                  "fields": {
+                                                                                                    "OBJECTTYPE": "Global",
+                                                                                                    "VAR": {
+                                                                                                      "id": "ZCBg+S5Y0?xD[@GpnRJ."
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              },
+                                                                                              "VALUE-1": {
+                                                                                                "block": {
+                                                                                                  "type": "GetCapturePoint",
+                                                                                                  "id": "0%A@hp$}DUYp%+mGZSXj",
+                                                                                                  "inputs": {
+                                                                                                    "VALUE-0": {
+                                                                                                      "block": {
+                                                                                                        "type": "MCOMsItem",
+                                                                                                        "id": "B@k}Gm.ufBY,]7UUX,aU",
+                                                                                                        "fields": {
+                                                                                                          "VALUE-0": "MCOMs",
+                                                                                                          "VALUE-1": "B"
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            },
+                                                                                            "next": {
+                                                                                              "block": {
+                                                                                                "type": "subroutineInstanceBlock",
+                                                                                                "id": "U5`i8,Kgvr,CInh|-nO.",
+                                                                                                "extraState": {
+                                                                                                  "subroutineName": "MapDetect",
+                                                                                                  "parameters": []
+                                                                                                },
+                                                                                                "fields": {
+                                                                                                  "SUBROUTINE_NAME": "MapDetect"
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
                                                       }
                                                     }
                                                   }
@@ -185,25 +658,6 @@
                                               }
                                             }
                                           }
-                                        }
-                                      },
-                                      "VALUE-1": {
-                                        "block": {
-                                          "type": "EmptyArray",
-                                          "id": "QN@`E@Gfxb_WFQF!{yBP"
-                                        }
-                                      }
-                                    },
-                                    "next": {
-                                      "block": {
-                                        "type": "subroutineInstanceBlock",
-                                        "id": "U5`i8,Kgvr,CInh|-nO.",
-                                        "extraState": {
-                                          "subroutineName": "MapDetect",
-                                          "parameters": []
-                                        },
-                                        "fields": {
-                                          "SUBROUTINE_NAME": "MapDetect"
                                         }
                                       }
                                     }
@@ -221,111 +675,195 @@
               "next": {
                 "block": {
                   "type": "ruleBlock",
-                  "id": "]XNNLpeKd)baVT]_mu9p",
+                  "id": "0`|WUV)6^_6!H{Le5n*D",
                   "extraState": {
-                    "isOngoingEvent": true
+                    "isOngoingEvent": false
                   },
                   "fields": {
-                    "NAME": "Detect Play Area",
-                    "EVENTTYPE": "Ongoing",
-                    "OBJECTTYPE": "Player"
+                    "NAME": "MCOM Setup",
+                    "EVENTTYPE": "OnGameModeStarted"
                   },
                   "inputs": {
-                    "CONDITIONS": {
+                    "ACTIONS": {
                       "block": {
-                        "type": "conditionBlock",
-                        "id": "P,vyrsJAD/Zs}MPg/:VM",
-                        "inputs": {
-                          "CONDITION": {
-                            "block": {
-                              "type": "GetSoldierState",
-                              "id": "B[`iBDk[OdSZePPjFc_h",
-                              "inputs": {
-                                "VALUE-0": {
-                                  "block": {
-                                    "type": "EventPlayer",
-                                    "id": "0@+LzpcE=ZCY2$R4d-2K"
-                                  }
-                                },
-                                "VALUE-1": {
-                                  "block": {
-                                    "type": "SoldierStateBoolItem",
-                                    "id": "wa6wk=GX9$OZ@X5uX$9+",
-                                    "fields": {
-                                      "VALUE-0": "SoldierStateBool",
-                                      "VALUE-1": "IsAlive"
+                        "type": "subroutineInstanceBlock",
+                        "id": "v^)W:{v@etMxsH4}/hbl",
+                        "extraState": {
+                          "subroutineName": "MCOM_Setup",
+                          "parameters": []
+                        },
+                        "fields": {
+                          "SUBROUTINE_NAME": "MCOM_Setup"
+                        },
+                        "next": {
+                          "block": {
+                            "type": "subroutineInstanceBlock",
+                            "id": "T`+{^aUnu;/[sW@:k=Y1",
+                            "extraState": {
+                              "subroutineName": "RoundTimer",
+                              "parameters": []
+                            },
+                            "fields": {
+                              "SUBROUTINE_NAME": "RoundTimer"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "next": {
+                    "block": {
+                      "type": "ruleBlock",
+                      "id": "P*6O.l#,2(?[05EHP^HF",
+                      "extraState": {
+                        "isOngoingEvent": true
+                      },
+                      "fields": {
+                        "NAME": "InitialisePlayer",
+                        "EVENTTYPE": "Ongoing",
+                        "OBJECTTYPE": "Player"
+                      },
+                      "inputs": {
+                        "ACTIONS": {
+                          "block": {
+                            "type": "SetVariable",
+                            "id": "N$/#Q!OXdQ]t`.4*:1Gx",
+                            "inputs": {
+                              "VALUE-0": {
+                                "block": {
+                                  "type": "variableReferenceBlock",
+                                  "id": "KeK.EFncPB6zWABxV7{-",
+                                  "extraState": {
+                                    "isObjectVar": true
+                                  },
+                                  "fields": {
+                                    "OBJECTTYPE": "Player",
+                                    "VAR": {
+                                      "id": "IRu4,i0nyGI*8goT1`+u"
                                     }
+                                  },
+                                  "inputs": {
+                                    "OBJECT": {
+                                      "block": {
+                                        "type": "EventPlayer",
+                                        "id": "Vr6E/F*K%C=EO;k3T5jC"
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "VALUE-1": {
+                                "block": {
+                                  "type": "Boolean",
+                                  "id": "Trr}#,]b2wv?wiGy0Xh@",
+                                  "fields": {
+                                    "BOOL": "FALSE"
                                   }
                                 }
                               }
                             }
                           }
                         }
-                      }
-                    },
-                    "ACTIONS": {
-                      "block": {
-                        "type": "While",
-                        "id": "sYoK[itkTNhkOy={ooeP",
-                        "inputs": {
-                          "VALUE-0": {
-                            "block": {
-                              "type": "GetSoldierState",
-                              "id": "_l$^0ZYus(MOf[FPavJw",
-                              "inputs": {
-                                "VALUE-0": {
-                                  "block": {
-                                    "type": "EventPlayer",
-                                    "id": "Wr4[}@^NwtT%Y=f^[y_p"
-                                  }
-                                },
-                                "VALUE-1": {
-                                  "block": {
-                                    "type": "SoldierStateBoolItem",
-                                    "id": "z9n9J1KKv(m:vDUe*$0)",
-                                    "fields": {
-                                      "VALUE-0": "SoldierStateBool",
-                                      "VALUE-1": "IsAlive"
+                      },
+                      "next": {
+                        "block": {
+                          "type": "ruleBlock",
+                          "id": "A!DI32})}b_fx|@k)J#x",
+                          "extraState": {
+                            "isOngoingEvent": false
+                          },
+                          "fields": {
+                            "NAME": "PlayerUndeploy",
+                            "EVENTTYPE": "OnPlayerIrreversiblyDead"
+                          },
+                          "inputs": {
+                            "ACTIONS": {
+                              "block": {
+                                "type": "SetVariable",
+                                "id": "o)Y1Qur`(0qZp6Ra/84^",
+                                "inputs": {
+                                  "VALUE-0": {
+                                    "block": {
+                                      "type": "variableReferenceBlock",
+                                      "id": "NJ+s`VMN-#*:9v-W[D%a",
+                                      "extraState": {
+                                        "isObjectVar": true
+                                      },
+                                      "fields": {
+                                        "OBJECTTYPE": "Player",
+                                        "VAR": {
+                                          "id": "IRu4,i0nyGI*8goT1`+u"
+                                        }
+                                      },
+                                      "inputs": {
+                                        "OBJECT": {
+                                          "block": {
+                                            "type": "EventPlayer",
+                                            "id": "sav_w]~r,EBXV8Tn^yBK"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "VALUE-1": {
+                                    "block": {
+                                      "type": "Boolean",
+                                      "id": "QnuT*bTVhhKgX$]1np%X",
+                                      "fields": {
+                                        "BOOL": "FALSE"
+                                      }
                                     }
                                   }
                                 }
                               }
                             }
                           },
-                          "DO": {
+                          "next": {
                             "block": {
-                              "type": "subroutineInstanceBlock",
-                              "id": "k+3U}P(.1c}9!?dFeg.1",
+                              "type": "ruleBlock",
+                              "id": "*.cu,ZrU|IjWh*7UU*ld",
                               "extraState": {
-                                "subroutineName": "CheckBoundaries",
-                                "parameters": [
-                                  {
-                                    "types": "Array",
-                                    "name": "Location"
-                                  }
-                                ]
+                                "isOngoingEvent": false
                               },
                               "fields": {
-                                "SUBROUTINE_NAME": "CheckBoundaries"
+                                "NAME": "PlayerDied",
+                                "EVENTTYPE": "OnPlayerDied"
                               },
                               "inputs": {
-                                "PARAM-0": {
+                                "ACTIONS": {
                                   "block": {
-                                    "type": "GetVariable",
-                                    "id": "IwvP[G~!gV:%d?Y-=%]R",
+                                    "type": "SetVariable",
+                                    "id": "[`^gC-ZQ~Q)-[Z~PP5(J",
                                     "inputs": {
                                       "VALUE-0": {
                                         "block": {
                                           "type": "variableReferenceBlock",
-                                          "id": "FN*sr_;=ZS-j-($y#[0a",
+                                          "id": "SN(W^+VtXjhYU_sH0[AA",
                                           "extraState": {
-                                            "isObjectVar": false
+                                            "isObjectVar": true
                                           },
                                           "fields": {
-                                            "OBJECTTYPE": "Global",
+                                            "OBJECTTYPE": "Player",
                                             "VAR": {
-                                              "id": "avhOM{5IU+T,cbtA-5?M"
+                                              "id": "IRu4,i0nyGI*8goT1`+u"
                                             }
+                                          },
+                                          "inputs": {
+                                            "OBJECT": {
+                                              "block": {
+                                                "type": "EventPlayer",
+                                                "id": "lCt+@nF;@a@M=V(3Tgu^"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "VALUE-1": {
+                                        "block": {
+                                          "type": "Boolean",
+                                          "id": "qF~`.;Tf55s1+L6(yP_m",
+                                          "fields": {
+                                            "BOOL": "FALSE"
                                           }
                                         }
                                       }
@@ -335,39 +873,37 @@
                               },
                               "next": {
                                 "block": {
-                                  "type": "If",
-                                  "id": "[Z7Q8Mub{e~}irZ1,(Jk",
-                                  "extraState": {},
+                                  "type": "ruleBlock",
+                                  "id": "B`a9~,H+1U96R.bHje2w",
+                                  "extraState": {
+                                    "isOngoingEvent": false
+                                  },
+                                  "fields": {
+                                    "NAME": "Play Defence",
+                                    "EVENTTYPE": "OnPlayerJoinGame"
+                                  },
                                   "inputs": {
-                                    "VALUE-0": {
+                                    "CONDITIONS": {
                                       "block": {
-                                        "type": "Not",
-                                        "id": "P]$5A?]aq1c=0d;zNLqv",
+                                        "type": "conditionBlock",
+                                        "id": "Cv3ewU_u,P@h#9@k/k%s",
                                         "inputs": {
-                                          "VALUE-0": {
+                                          "CONDITION": {
                                             "block": {
                                               "type": "GetVariable",
-                                              "id": "4!I?*SvZ$wU=^ZnxP-YZ",
+                                              "id": "Zz])0tNHj46!/_cLYs7C",
                                               "inputs": {
                                                 "VALUE-0": {
                                                   "block": {
                                                     "type": "variableReferenceBlock",
-                                                    "id": "G58bbNUA,aAMEZ]@S*D1",
+                                                    "id": "^*cE[J,AaD$+S5|XJ-t9",
                                                     "extraState": {
-                                                      "isObjectVar": true
+                                                      "isObjectVar": false
                                                     },
                                                     "fields": {
-                                                      "OBJECTTYPE": "Player",
+                                                      "OBJECTTYPE": "Global",
                                                       "VAR": {
-                                                        "id": "RtgD|X+%@!)n$MrP;5vL"
-                                                      }
-                                                    },
-                                                    "inputs": {
-                                                      "OBJECT": {
-                                                        "block": {
-                                                          "type": "EventPlayer",
-                                                          "id": "jMI0@=gq~iO6+Tj]Z,{g"
-                                                        }
+                                                        "id": "}^*LIdpxV;$%E-l3ayo="
                                                       }
                                                     }
                                                   }
@@ -375,54 +911,35 @@
                                               }
                                             }
                                           }
-                                        }
-                                      }
-                                    },
-                                    "DO": {
-                                      "block": {
-                                        "type": "subroutineInstanceBlock",
-                                        "id": "Mo6@Z$_)[YuE=^2I~@#6",
-                                        "extraState": {
-                                          "subroutineName": "CheckBoundaries",
-                                          "parameters": [
-                                            {
-                                              "types": "Array",
-                                              "name": "Location"
-                                            }
-                                          ]
                                         },
-                                        "fields": {
-                                          "SUBROUTINE_NAME": "CheckBoundaries"
-                                        },
-                                        "inputs": {
-                                          "PARAM-0": {
-                                            "block": {
-                                              "type": "GetVariable",
-                                              "id": "dgQ}99zHDxBt:UX{v9gu",
-                                              "inputs": {
-                                                "VALUE-0": {
-                                                  "block": {
-                                                    "type": "variableReferenceBlock",
-                                                    "id": "XQkRlsJJ50+98@#RM:WW",
-                                                    "extraState": {
-                                                      "isObjectVar": true
-                                                    },
-                                                    "fields": {
-                                                      "OBJECTTYPE": "TeamId",
-                                                      "VAR": {
-                                                        "id": "~!s}ovrs?jb7Yd/X[z2!"
-                                                      }
-                                                    },
-                                                    "inputs": {
-                                                      "OBJECT": {
-                                                        "block": {
-                                                          "type": "GetTeamId",
-                                                          "id": "G8UD1lwARYQ3(4$sS2ph",
-                                                          "inputs": {
-                                                            "VALUE-0": {
-                                                              "block": {
-                                                                "type": "EventPlayer",
-                                                                "id": "o5yz7g[Xjqa]}WxxN=]?"
+                                        "next": {
+                                          "block": {
+                                            "type": "conditionBlock",
+                                            "id": "f#Bg!{`Y?LkNaOzmH1Av",
+                                            "inputs": {
+                                              "CONDITION": {
+                                                "block": {
+                                                  "type": "Not",
+                                                  "id": "Z;PlaBC+BV9SqnNP|%Wv",
+                                                  "inputs": {
+                                                    "VALUE-0": {
+                                                      "block": {
+                                                        "type": "GetSoldierState",
+                                                        "id": "rZiAy+V{3`^D^5a9iG5g",
+                                                        "inputs": {
+                                                          "VALUE-0": {
+                                                            "block": {
+                                                              "type": "EventPlayer",
+                                                              "id": "Yp/7H+!{$z1br1#j[Si]"
+                                                            }
+                                                          },
+                                                          "VALUE-1": {
+                                                            "block": {
+                                                              "type": "SoldierStateBoolItem",
+                                                              "id": "1QF+)CYqaj}6w(TYgA.%",
+                                                              "fields": {
+                                                                "VALUE-0": "SoldierStateBool",
+                                                                "VALUE-1": "IsAISoldier"
                                                               }
                                                             }
                                                           }
@@ -436,130 +953,126 @@
                                           }
                                         }
                                       }
+                                    },
+                                    "ACTIONS": {
+                                      "block": {
+                                        "type": "SetTeam",
+                                        "id": "gU_Y+e3Qp:FBU0BwFJz`",
+                                        "inputs": {
+                                          "VALUE-0": {
+                                            "block": {
+                                              "type": "EventPlayer",
+                                              "id": "Yu*CH)m-|b[E78QBsqV4"
+                                            }
+                                          },
+                                          "VALUE-1": {
+                                            "block": {
+                                              "type": "GetTeamId",
+                                              "id": "6B=|aY,^3i%%w^y=)z4_",
+                                              "inputs": {
+                                                "VALUE-0": {
+                                                  "block": {
+                                                    "type": "Number",
+                                                    "id": "m5Ph!u/B5d*uzFDJrVVR",
+                                                    "fields": {
+                                                      "NUM": 2
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
                                     }
                                   },
                                   "next": {
                                     "block": {
-                                      "type": "If",
-                                      "id": ":9xeNleWzJgH,!D$fGsH",
+                                      "type": "ruleBlock",
+                                      "id": "s3O8[h/t=NS_V43R~(**",
                                       "extraState": {
-                                        "elseif": 0,
-                                        "else": 1
+                                        "isOngoingEvent": true
+                                      },
+                                      "fields": {
+                                        "NAME": "GlobalTick",
+                                        "EVENTTYPE": "Ongoing",
+                                        "OBJECTTYPE": "Global"
                                       },
                                       "inputs": {
-                                        "VALUE-0": {
+                                        "CONDITIONS": {
                                           "block": {
-                                            "type": "GetVariable",
-                                            "id": "3s::Rg:Pbj8_F!%,S!{6",
+                                            "type": "conditionBlock",
+                                            "id": "gU8chKWk7@uWx]j#q!hL",
+                                            "inputs": {
+                                              "CONDITION": {
+                                                "block": {
+                                                  "type": "Equals",
+                                                  "id": "uVw.)6kX^],rhoEavce/",
+                                                  "inputs": {
+                                                    "VALUE-0": {
+                                                      "block": {
+                                                        "type": "GetVariable",
+                                                        "id": "u]cNFzg!N1B+#?KznBfB",
+                                                        "inputs": {
+                                                          "VALUE-0": {
+                                                            "block": {
+                                                              "type": "variableReferenceBlock",
+                                                              "id": "XRM}ka)MOd%-Z{V}IzwH",
+                                                              "extraState": {
+                                                                "isObjectVar": false
+                                                              },
+                                                              "fields": {
+                                                                "OBJECTTYPE": "Global",
+                                                                "VAR": {
+                                                                  "id": "!76]mYssfI{X9uUcqv2%"
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    },
+                                                    "VALUE-1": {
+                                                      "block": {
+                                                        "type": "Number",
+                                                        "id": "L!Z?pTCMn)x)RSKbD0n8",
+                                                        "fields": {
+                                                          "NUM": 2
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "ACTIONS": {
+                                          "block": {
+                                            "type": "SetVariable",
+                                            "id": "}vTN-*osF~VD;u_(E~AA",
                                             "inputs": {
                                               "VALUE-0": {
                                                 "block": {
                                                   "type": "variableReferenceBlock",
-                                                  "id": "igadu6nWqeJ;*B0nR-q}",
+                                                  "id": "}nvU/%c.7,[Lqu1Ke6pP",
                                                   "extraState": {
-                                                    "isObjectVar": true
+                                                    "isObjectVar": false
                                                   },
                                                   "fields": {
-                                                    "OBJECTTYPE": "Player",
+                                                    "OBJECTTYPE": "Global",
                                                     "VAR": {
-                                                      "id": "RtgD|X+%@!)n$MrP;5vL"
-                                                    }
-                                                  },
-                                                  "inputs": {
-                                                    "OBJECT": {
-                                                      "block": {
-                                                        "type": "EventPlayer",
-                                                        "id": "u5GC/=ms+mEq+N~Gv#^@"
-                                                      }
-                                                    }
-                                                  }
-                                                }
-                                              }
-                                            }
-                                          }
-                                        },
-                                        "DO": {
-                                          "block": {
-                                            "type": "DisplayCustomNotificationMessage",
-                                            "id": "4Gj2I=27p^;fdzc/2rW#",
-                                            "inputs": {
-                                              "VALUE-0": {
-                                                "block": {
-                                                  "type": "Message",
-                                                  "id": "sA+D9,YSnb?t_}t|DIpv",
-                                                  "inputs": {
-                                                    "VALUE-0": {
-                                                      "block": {
-                                                        "type": "Text",
-                                                        "id": "7M6]*=OCF#ki3sqG#~*=",
-                                                        "fields": {
-                                                          "TEXT": "In Play Area"
-                                                        }
-                                                      }
+                                                      "id": "!76]mYssfI{X9uUcqv2%"
                                                     }
                                                   }
                                                 }
                                               },
                                               "VALUE-1": {
                                                 "block": {
-                                                  "type": "CustomMessagesItem",
-                                                  "id": "7]CMFV+GF]gZA_=-HJaB",
-                                                  "fields": {
-                                                    "VALUE-0": "CustomMessages",
-                                                    "VALUE-1": "HeaderText"
-                                                  }
-                                                }
-                                              },
-                                              "VALUE-2": {
-                                                "block": {
                                                   "type": "Number",
-                                                  "id": "QwCAh?Pcn8_8Ij!R]s~-",
+                                                  "id": ";Q$hGQ#D31Whn.)pXiu|",
                                                   "fields": {
-                                                    "NUM": 2
-                                                  }
-                                                }
-                                              }
-                                            }
-                                          }
-                                        },
-                                        "ELSE": {
-                                          "block": {
-                                            "type": "DisplayCustomNotificationMessage",
-                                            "id": "/hD;UbVg(`+[WwTn9yV{",
-                                            "inputs": {
-                                              "VALUE-0": {
-                                                "block": {
-                                                  "type": "Message",
-                                                  "id": ".9go5IS#WZ-;x_TW)]n|",
-                                                  "inputs": {
-                                                    "VALUE-0": {
-                                                      "block": {
-                                                        "type": "Text",
-                                                        "id": "/`WHrN}HOlT$,s6?f}lv",
-                                                        "fields": {
-                                                          "TEXT": "Out Of Bounds"
-                                                        }
-                                                      }
-                                                    }
-                                                  }
-                                                }
-                                              },
-                                              "VALUE-1": {
-                                                "block": {
-                                                  "type": "CustomMessagesItem",
-                                                  "id": "2?[BlMl}aj1+Pm25=27h",
-                                                  "fields": {
-                                                    "VALUE-0": "CustomMessages",
-                                                    "VALUE-1": "HeaderText"
-                                                  }
-                                                }
-                                              },
-                                              "VALUE-2": {
-                                                "block": {
-                                                  "type": "Number",
-                                                  "id": "bz!Rmcn=aj`?EYl%~T=;",
-                                                  "fields": {
-                                                    "NUM": 2
+                                                    "NUM": 1
                                                   }
                                                 }
                                               }
@@ -569,15 +1082,2706 @@
                                       },
                                       "next": {
                                         "block": {
-                                          "type": "Wait",
-                                          "id": "y@QRXp%BJ~Xuk{_dLj59",
+                                          "type": "ruleBlock",
+                                          "id": "[!3qrVW;Ne9(ne^@gEBN",
+                                          "extraState": {
+                                            "isOngoingEvent": true
+                                          },
+                                          "fields": {
+                                            "NAME": "GlobalTick",
+                                            "EVENTTYPE": "Ongoing",
+                                            "OBJECTTYPE": "Global"
+                                          },
                                           "inputs": {
-                                            "VALUE-0": {
+                                            "CONDITIONS": {
                                               "block": {
-                                                "type": "Number",
-                                                "id": "!h3:7j{Pr8Z)ktDX6yCg",
+                                                "type": "conditionBlock",
+                                                "id": "F#92U7,a?wyU(,BFMXoy",
+                                                "inputs": {
+                                                  "CONDITION": {
+                                                    "block": {
+                                                      "type": "Equals",
+                                                      "id": "(A`ov!w3D87Ir26vE`~f",
+                                                      "inputs": {
+                                                        "VALUE-0": {
+                                                          "block": {
+                                                            "type": "GetVariable",
+                                                            "id": "fn:o).IA7ek(T1`d$6Qn",
+                                                            "inputs": {
+                                                              "VALUE-0": {
+                                                                "block": {
+                                                                  "type": "variableReferenceBlock",
+                                                                  "id": "o.y5X141I,t6lTe)MOq=",
+                                                                  "extraState": {
+                                                                    "isObjectVar": false
+                                                                  },
+                                                                  "fields": {
+                                                                    "OBJECTTYPE": "Global",
+                                                                    "VAR": {
+                                                                      "id": "!76]mYssfI{X9uUcqv2%"
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        },
+                                                        "VALUE-1": {
+                                                          "block": {
+                                                            "type": "Number",
+                                                            "id": "RTJeDB${f8zLo4v^lpo5",
+                                                            "fields": {
+                                                              "NUM": 0
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "ACTIONS": {
+                                              "block": {
+                                                "type": "subroutineInstanceBlock",
+                                                "id": "Z9p!+}ec/sC3M;[r)F^4",
+                                                "extraState": {
+                                                  "subroutineName": "EveryTickGlobal",
+                                                  "parameters": []
+                                                },
                                                 "fields": {
-                                                  "NUM": 0.1
+                                                  "SUBROUTINE_NAME": "EveryTickGlobal"
+                                                },
+                                                "next": {
+                                                  "block": {
+                                                    "type": "SetVariable",
+                                                    "id": "7a7|T@seBB6=4Dpj7ncM",
+                                                    "inputs": {
+                                                      "VALUE-0": {
+                                                        "block": {
+                                                          "type": "variableReferenceBlock",
+                                                          "id": "ebP*Ge~}gf/2Bu#wo8b,",
+                                                          "extraState": {
+                                                            "isObjectVar": false
+                                                          },
+                                                          "fields": {
+                                                            "OBJECTTYPE": "Global",
+                                                            "VAR": {
+                                                              "id": "!76]mYssfI{X9uUcqv2%"
+                                                            }
+                                                          }
+                                                        }
+                                                      },
+                                                      "VALUE-1": {
+                                                        "block": {
+                                                          "type": "Number",
+                                                          "id": "Yl3s}[G:5:c#)%FKbAq0",
+                                                          "fields": {
+                                                            "NUM": 2
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          },
+                                          "next": {
+                                            "block": {
+                                              "type": "ruleBlock",
+                                              "id": "r6Mz)SHr-Gia[#@MC=jt",
+                                              "extraState": {
+                                                "isOngoingEvent": true
+                                              },
+                                              "fields": {
+                                                "NAME": "GlobalTick",
+                                                "EVENTTYPE": "Ongoing",
+                                                "OBJECTTYPE": "Global"
+                                              },
+                                              "inputs": {
+                                                "CONDITIONS": {
+                                                  "block": {
+                                                    "type": "conditionBlock",
+                                                    "id": "U6aU:{u9A[O=y?0a9T.%",
+                                                    "inputs": {
+                                                      "CONDITION": {
+                                                        "block": {
+                                                          "type": "Equals",
+                                                          "id": "a7nu!t0bq(SZI_B8hzJs",
+                                                          "inputs": {
+                                                            "VALUE-0": {
+                                                              "block": {
+                                                                "type": "GetVariable",
+                                                                "id": "}s;ShiBmVWZZF@{/|NLH",
+                                                                "inputs": {
+                                                                  "VALUE-0": {
+                                                                    "block": {
+                                                                      "type": "variableReferenceBlock",
+                                                                      "id": "pu2qJp|t=Jezq/0Ktf#c",
+                                                                      "extraState": {
+                                                                        "isObjectVar": false
+                                                                      },
+                                                                      "fields": {
+                                                                        "OBJECTTYPE": "Global",
+                                                                        "VAR": {
+                                                                          "id": "!76]mYssfI{X9uUcqv2%"
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            },
+                                                            "VALUE-1": {
+                                                              "block": {
+                                                                "type": "Number",
+                                                                "id": "e1Q`GS?%ahs{%PC-a!=c",
+                                                                "fields": {
+                                                                  "NUM": 1
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "ACTIONS": {
+                                                  "block": {
+                                                    "type": "subroutineInstanceBlock",
+                                                    "id": "@]m$/x:lUaBJ*ynwQ#u-",
+                                                    "extraState": {
+                                                      "subroutineName": "EveryTickGlobal",
+                                                      "parameters": []
+                                                    },
+                                                    "fields": {
+                                                      "SUBROUTINE_NAME": "EveryTickGlobal"
+                                                    },
+                                                    "next": {
+                                                      "block": {
+                                                        "type": "SetVariable",
+                                                        "id": "=jJ0[[j;5K2nbT5rU+HC",
+                                                        "inputs": {
+                                                          "VALUE-0": {
+                                                            "block": {
+                                                              "type": "variableReferenceBlock",
+                                                              "id": ")x$-M|Jv.HJVMY%Nke=m",
+                                                              "extraState": {
+                                                                "isObjectVar": false
+                                                              },
+                                                              "fields": {
+                                                                "OBJECTTYPE": "Global",
+                                                                "VAR": {
+                                                                  "id": "!76]mYssfI{X9uUcqv2%"
+                                                                }
+                                                              }
+                                                            }
+                                                          },
+                                                          "VALUE-1": {
+                                                            "block": {
+                                                              "type": "Number",
+                                                              "id": "nID=3XypEw+mTQbxLwq:",
+                                                              "fields": {
+                                                                "NUM": 0
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              },
+                                              "next": {
+                                                "block": {
+                                                  "type": "ruleBlock",
+                                                  "id": ".8EHr)$=OR;^lL^@r~qd",
+                                                  "extraState": {
+                                                    "isOngoingEvent": true
+                                                  },
+                                                  "fields": {
+                                                    "NAME": "EnableControls",
+                                                    "EVENTTYPE": "Ongoing",
+                                                    "OBJECTTYPE": "Player"
+                                                  },
+                                                  "inputs": {
+                                                    "CONDITIONS": {
+                                                      "block": {
+                                                        "type": "conditionBlock",
+                                                        "id": "AckQB$,x?2Y2!Ko]cL~$",
+                                                        "inputs": {
+                                                          "CONDITION": {
+                                                            "block": {
+                                                              "type": "GetSoldierState",
+                                                              "id": "b;,Gn%yWxHxlt^G6{cne",
+                                                              "inputs": {
+                                                                "VALUE-0": {
+                                                                  "block": {
+                                                                    "type": "EventPlayer",
+                                                                    "id": "i%3!U}2%b%p9ZTg7f+4`"
+                                                                  }
+                                                                },
+                                                                "VALUE-1": {
+                                                                  "block": {
+                                                                    "type": "SoldierStateBoolItem",
+                                                                    "id": "_xDq{9qX:,:ERA^LZduE",
+                                                                    "fields": {
+                                                                      "VALUE-0": "SoldierStateBool",
+                                                                      "VALUE-1": "IsAlive"
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        },
+                                                        "next": {
+                                                          "block": {
+                                                            "type": "conditionBlock",
+                                                            "id": "l9|vuzm9{:Lut6?0GcyO",
+                                                            "inputs": {
+                                                              "CONDITION": {
+                                                                "block": {
+                                                                  "type": "Equals",
+                                                                  "id": "mY$~eEfMkO}7WAS$/6p8",
+                                                                  "inputs": {
+                                                                    "VALUE-0": {
+                                                                      "block": {
+                                                                        "type": "GetVariable",
+                                                                        "id": "xC@o^{~URGM;:8fq,Y?z",
+                                                                        "inputs": {
+                                                                          "VALUE-0": {
+                                                                            "block": {
+                                                                              "type": "variableReferenceBlock",
+                                                                              "id": "C9-2h#N`=vK5bVsj=%_!",
+                                                                              "extraState": {
+                                                                                "isObjectVar": false
+                                                                              },
+                                                                              "fields": {
+                                                                                "OBJECTTYPE": "Global",
+                                                                                "VAR": {
+                                                                                  "id": "=8OY*aWMGF4.T^k6uLUl"
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    "VALUE-1": {
+                                                                      "block": {
+                                                                        "type": "GetVariable",
+                                                                        "id": "G%PB7`Kr6AeO_T,xjYXK",
+                                                                        "inputs": {
+                                                                          "VALUE-0": {
+                                                                            "block": {
+                                                                              "type": "variableReferenceBlock",
+                                                                              "id": "W){-F~?:C_9g7wvnSc:x",
+                                                                              "extraState": {
+                                                                                "isObjectVar": false
+                                                                              },
+                                                                              "fields": {
+                                                                                "OBJECTTYPE": "Global",
+                                                                                "VAR": {
+                                                                                  "id": "**%O*!0`FJS;40@p6=u|"
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    },
+                                                    "ACTIONS": {
+                                                      "block": {
+                                                        "type": "EnableAllInputRestrictions",
+                                                        "id": ":3KRcI+T@u7(Za}a3r^8",
+                                                        "inputs": {
+                                                          "VALUE-0": {
+                                                            "block": {
+                                                              "type": "EventPlayer",
+                                                              "id": "jmI2a?AMJAF=LZ+LMk]_"
+                                                            }
+                                                          },
+                                                          "VALUE-1": {
+                                                            "block": {
+                                                              "type": "Boolean",
+                                                              "id": "|{x97Xk45ouPle)62NcF",
+                                                              "fields": {
+                                                                "BOOL": "FALSE"
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  },
+                                                  "next": {
+                                                    "block": {
+                                                      "type": "ruleBlock",
+                                                      "id": "E*PpTE4%gua[oe%xp#dJ",
+                                                      "extraState": {
+                                                        "isOngoingEvent": true
+                                                      },
+                                                      "fields": {
+                                                        "NAME": "DisableControls",
+                                                        "EVENTTYPE": "Ongoing",
+                                                        "OBJECTTYPE": "Player"
+                                                      },
+                                                      "inputs": {
+                                                        "CONDITIONS": {
+                                                          "block": {
+                                                            "type": "conditionBlock",
+                                                            "id": "h_mFjc)Fen+LaXe.{wv7",
+                                                            "inputs": {
+                                                              "CONDITION": {
+                                                                "block": {
+                                                                  "type": "GetSoldierState",
+                                                                  "id": "_8#]k2?~m4#ui8$iO59j",
+                                                                  "inputs": {
+                                                                    "VALUE-0": {
+                                                                      "block": {
+                                                                        "type": "EventPlayer",
+                                                                        "id": "G$l[:8A}x#+d?,xn}2/$"
+                                                                      }
+                                                                    },
+                                                                    "VALUE-1": {
+                                                                      "block": {
+                                                                        "type": "SoldierStateBoolItem",
+                                                                        "id": "R8@PqfS0s9XE?MZ4jFn*",
+                                                                        "fields": {
+                                                                          "VALUE-0": "SoldierStateBool",
+                                                                          "VALUE-1": "IsAlive"
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            },
+                                                            "next": {
+                                                              "block": {
+                                                                "type": "conditionBlock",
+                                                                "id": "#4X}-}EAZ*J1AxFUVy*W",
+                                                                "inputs": {
+                                                                  "CONDITION": {
+                                                                    "block": {
+                                                                      "type": "Not",
+                                                                      "id": "ChdnSV:}Dljs7?_#D`+K",
+                                                                      "inputs": {
+                                                                        "VALUE-0": {
+                                                                          "block": {
+                                                                            "type": "Equals",
+                                                                            "id": "7m@g-tEzGJG!v/IH3bz4",
+                                                                            "inputs": {
+                                                                              "VALUE-0": {
+                                                                                "block": {
+                                                                                  "type": "GetVariable",
+                                                                                  "id": "gUgVNqY@iy9$a*;ND}!z",
+                                                                                  "inputs": {
+                                                                                    "VALUE-0": {
+                                                                                      "block": {
+                                                                                        "type": "variableReferenceBlock",
+                                                                                        "id": "gT0Md$!4(,]-c)0g/WO(",
+                                                                                        "extraState": {
+                                                                                          "isObjectVar": false
+                                                                                        },
+                                                                                        "fields": {
+                                                                                          "OBJECTTYPE": "Global",
+                                                                                          "VAR": {
+                                                                                            "id": "=8OY*aWMGF4.T^k6uLUl"
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              },
+                                                                              "VALUE-1": {
+                                                                                "block": {
+                                                                                  "type": "GetVariable",
+                                                                                  "id": "NH4v=7mp5]I;7olk}1Zl",
+                                                                                  "inputs": {
+                                                                                    "VALUE-0": {
+                                                                                      "block": {
+                                                                                        "type": "variableReferenceBlock",
+                                                                                        "id": "6u`dj==I*(vFxJzWVo(n",
+                                                                                        "extraState": {
+                                                                                          "isObjectVar": false
+                                                                                        },
+                                                                                        "fields": {
+                                                                                          "OBJECTTYPE": "Global",
+                                                                                          "VAR": {
+                                                                                            "id": "**%O*!0`FJS;40@p6=u|"
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        },
+                                                        "ACTIONS": {
+                                                          "block": {
+                                                            "type": "EnableInputRestriction",
+                                                            "id": "drR[aLB4n2~H+6Il92r7",
+                                                            "inputs": {
+                                                              "VALUE-0": {
+                                                                "block": {
+                                                                  "type": "EventPlayer",
+                                                                  "id": "k[jdsTUt},`m$]?Xb.P("
+                                                                }
+                                                              },
+                                                              "VALUE-1": {
+                                                                "block": {
+                                                                  "type": "RestrictedInputsItem",
+                                                                  "id": "(!uyaKC|-`,1Og]7%8!)",
+                                                                  "fields": {
+                                                                    "VALUE-0": "RestrictedInputs",
+                                                                    "VALUE-1": "FireWeapon"
+                                                                  }
+                                                                }
+                                                              },
+                                                              "VALUE-2": {
+                                                                "block": {
+                                                                  "type": "Boolean",
+                                                                  "id": "K%e6a,Mi=z[8Y?DE4Rib",
+                                                                  "fields": {
+                                                                    "BOOL": "TRUE"
+                                                                  }
+                                                                }
+                                                              }
+                                                            },
+                                                            "next": {
+                                                              "block": {
+                                                                "type": "EnableInputRestriction",
+                                                                "id": "_H6YoKjP7Z$*+@XZ,{+c",
+                                                                "inputs": {
+                                                                  "VALUE-0": {
+                                                                    "block": {
+                                                                      "type": "EventPlayer",
+                                                                      "id": "2=.Vl%3k:JyJJE/zoR@)"
+                                                                    }
+                                                                  },
+                                                                  "VALUE-1": {
+                                                                    "block": {
+                                                                      "type": "RestrictedInputsItem",
+                                                                      "id": "en{xP[dz8P$,lmh?.OkA",
+                                                                      "fields": {
+                                                                        "VALUE-0": "RestrictedInputs",
+                                                                        "VALUE-1": "MoveForwardBack"
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  "VALUE-2": {
+                                                                    "block": {
+                                                                      "type": "Boolean",
+                                                                      "id": "G.4D0|7aN|twk!=|{P.N",
+                                                                      "fields": {
+                                                                        "BOOL": "TRUE"
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                },
+                                                                "next": {
+                                                                  "block": {
+                                                                    "type": "EnableInputRestriction",
+                                                                    "id": "{NPa)giy(sGVK*t#2@8q",
+                                                                    "inputs": {
+                                                                      "VALUE-0": {
+                                                                        "block": {
+                                                                          "type": "EventPlayer",
+                                                                          "id": ",qMeD}%vq=VY).O`mN`M"
+                                                                        }
+                                                                      },
+                                                                      "VALUE-1": {
+                                                                        "block": {
+                                                                          "type": "RestrictedInputsItem",
+                                                                          "id": "vPX)!@Oegu#%k8V0*]8J",
+                                                                          "fields": {
+                                                                            "VALUE-0": "RestrictedInputs",
+                                                                            "VALUE-1": "MoveLeftRight"
+                                                                          }
+                                                                        }
+                                                                      },
+                                                                      "VALUE-2": {
+                                                                        "block": {
+                                                                          "type": "Boolean",
+                                                                          "id": "qWPlpD4o7Eg$qcAor^FA",
+                                                                          "fields": {
+                                                                            "BOOL": "TRUE"
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      },
+                                                      "next": {
+                                                        "block": {
+                                                          "type": "ruleBlock",
+                                                          "id": "hU=|OP]4@gSY$8^ihL]t",
+                                                          "extraState": {
+                                                            "isOngoingEvent": false
+                                                          },
+                                                          "fields": {
+                                                            "NAME": "Teleport",
+                                                            "EVENTTYPE": "OnPlayerDeployed"
+                                                          },
+                                                          "inputs": {
+                                                            "ACTIONS": {
+                                                              "block": {
+                                                                "type": "SetVariable",
+                                                                "id": "BroC^6pc(RPW21h~pVFC",
+                                                                "inputs": {
+                                                                  "VALUE-0": {
+                                                                    "block": {
+                                                                      "type": "variableReferenceBlock",
+                                                                      "id": "iPQaziS71vjOli/q~pUo",
+                                                                      "extraState": {
+                                                                        "isObjectVar": true
+                                                                      },
+                                                                      "fields": {
+                                                                        "OBJECTTYPE": "Player",
+                                                                        "VAR": {
+                                                                          "id": "IRu4,i0nyGI*8goT1`+u"
+                                                                        }
+                                                                      },
+                                                                      "inputs": {
+                                                                        "OBJECT": {
+                                                                          "block": {
+                                                                            "type": "EventPlayer",
+                                                                            "id": "*7t0-#}r!m4slG!K(M:]"
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  "VALUE-1": {
+                                                                    "block": {
+                                                                      "type": "Boolean",
+                                                                      "id": "@+x)CVnaWV9yDA8H[+)V",
+                                                                      "fields": {
+                                                                        "BOOL": "TRUE"
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                },
+                                                                "next": {
+                                                                  "block": {
+                                                                    "type": "SetVariable",
+                                                                    "id": "sd=h:DiAX@8jkcY:5!34",
+                                                                    "inputs": {
+                                                                      "VALUE-0": {
+                                                                        "block": {
+                                                                          "type": "variableReferenceBlock",
+                                                                          "id": "wfyDD(Otn`[PzSAHYX1%",
+                                                                          "extraState": {
+                                                                            "isObjectVar": true
+                                                                          },
+                                                                          "fields": {
+                                                                            "OBJECTTYPE": "Player",
+                                                                            "VAR": {
+                                                                              "id": "Ja]@k]U!U8$Jv5S~jX*y"
+                                                                            }
+                                                                          },
+                                                                          "inputs": {
+                                                                            "OBJECT": {
+                                                                              "block": {
+                                                                                "type": "EventPlayer",
+                                                                                "id": "R*-/JFHga^[M|dTQ7rdg"
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      },
+                                                                      "VALUE-1": {
+                                                                        "block": {
+                                                                          "type": "EmptyArray",
+                                                                          "id": "YIysv5y$b.f{e?!fST14"
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    "next": {
+                                                                      "block": {
+                                                                        "type": "SetVariable",
+                                                                        "id": "a;6L|s*3a%G=3%x|H5VU",
+                                                                        "inputs": {
+                                                                          "VALUE-0": {
+                                                                            "block": {
+                                                                              "type": "variableReferenceBlock",
+                                                                              "id": "8%}/}6B/)%I.w:ata)vU",
+                                                                              "extraState": {
+                                                                                "isObjectVar": true
+                                                                              },
+                                                                              "fields": {
+                                                                                "OBJECTTYPE": "Player",
+                                                                                "VAR": {
+                                                                                  "id": "Ja]@k]U!U8$Jv5S~jX*y"
+                                                                                }
+                                                                              },
+                                                                              "inputs": {
+                                                                                "OBJECT": {
+                                                                                  "block": {
+                                                                                    "type": "EventPlayer",
+                                                                                    "id": "}yTss!iXP,STd}^/oNm^"
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          "VALUE-1": {
+                                                                            "block": {
+                                                                              "type": "FilteredArray",
+                                                                              "id": "h7:1$S~D^!_;_z!HgMw_",
+                                                                              "inputs": {
+                                                                                "VALUE-0": {
+                                                                                  "block": {
+                                                                                    "type": "AllPlayers",
+                                                                                    "id": "K+MlW+hK6C5{G]pUd7b6"
+                                                                                  }
+                                                                                },
+                                                                                "VALUE-1": {
+                                                                                  "block": {
+                                                                                    "type": "And",
+                                                                                    "id": "T#+JWsP2tiVUb32`2Q*R",
+                                                                                    "inputs": {
+                                                                                      "VALUE-0": {
+                                                                                        "block": {
+                                                                                          "type": "GetSoldierState",
+                                                                                          "id": "[Os0Yl3Fq8t+hk%~T,,o",
+                                                                                          "inputs": {
+                                                                                            "VALUE-0": {
+                                                                                              "block": {
+                                                                                                "type": "CurrentArrayElement",
+                                                                                                "id": "DC?A~~OU+X(8E-/Y__LU"
+                                                                                              }
+                                                                                            },
+                                                                                            "VALUE-1": {
+                                                                                              "block": {
+                                                                                                "type": "SoldierStateBoolItem",
+                                                                                                "id": "t)-e4ML+wEkbU%xH%D[9",
+                                                                                                "fields": {
+                                                                                                  "VALUE-0": "SoldierStateBool",
+                                                                                                  "VALUE-1": "IsAlive"
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      },
+                                                                                      "VALUE-1": {
+                                                                                        "block": {
+                                                                                          "type": "And",
+                                                                                          "id": "w5yNiA/_PMb!Eqpfl]pH",
+                                                                                          "inline": false,
+                                                                                          "inputs": {
+                                                                                            "VALUE-0": {
+                                                                                              "block": {
+                                                                                                "type": "Equals",
+                                                                                                "id": "+M`*aA)=T5P@A;J-D|MT",
+                                                                                                "inputs": {
+                                                                                                  "VALUE-0": {
+                                                                                                    "block": {
+                                                                                                      "type": "GetTeamId",
+                                                                                                      "id": "Q6f/qJt+d%o:,^IX~7KF",
+                                                                                                      "inputs": {
+                                                                                                        "VALUE-0": {
+                                                                                                          "block": {
+                                                                                                            "type": "CurrentArrayElement",
+                                                                                                            "id": "]Y4I5`}c)^0_%%]84AEk"
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  },
+                                                                                                  "VALUE-1": {
+                                                                                                    "block": {
+                                                                                                      "type": "GetTeamId",
+                                                                                                      "id": "1`d~}.,G,2448VL}z*T%",
+                                                                                                      "inputs": {
+                                                                                                        "VALUE-0": {
+                                                                                                          "block": {
+                                                                                                            "type": "EventPlayer",
+                                                                                                            "id": "3ANSXnCET%T;Jv^yEHNt"
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            },
+                                                                                            "VALUE-1": {
+                                                                                              "block": {
+                                                                                                "type": "NotEqualTo",
+                                                                                                "id": "[_F^zzU3g-zQpQGJ[F(N",
+                                                                                                "inputs": {
+                                                                                                  "VALUE-0": {
+                                                                                                    "block": {
+                                                                                                      "type": "CurrentArrayElement",
+                                                                                                      "id": "XuTz],i/OcnY:{lK]dh^"
+                                                                                                    }
+                                                                                                  },
+                                                                                                  "VALUE-1": {
+                                                                                                    "block": {
+                                                                                                      "type": "EventPlayer",
+                                                                                                      "id": "xDSoWL:O?I+KtG4}-nRO"
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        },
+                                                                        "next": {
+                                                                          "block": {
+                                                                            "type": "If",
+                                                                            "id": "yxVT?m8(NhlD;*3s3!fQ",
+                                                                            "extraState": {
+                                                                              "elseif": 0,
+                                                                              "else": 1
+                                                                            },
+                                                                            "inputs": {
+                                                                              "VALUE-0": {
+                                                                                "block": {
+                                                                                  "type": "GreaterThan",
+                                                                                  "id": "0/jo,|RvRE^zIwDj(nLa",
+                                                                                  "inputs": {
+                                                                                    "VALUE-0": {
+                                                                                      "block": {
+                                                                                        "type": "CountOf",
+                                                                                        "id": "@N}Mk}kP:}OIhLj%RyiK",
+                                                                                        "inputs": {
+                                                                                          "VALUE-0": {
+                                                                                            "block": {
+                                                                                              "type": "GetVariable",
+                                                                                              "id": "ORC5U_.I6xJu+zdG_1sU",
+                                                                                              "inputs": {
+                                                                                                "VALUE-0": {
+                                                                                                  "block": {
+                                                                                                    "type": "variableReferenceBlock",
+                                                                                                    "id": "s_Do~$UMpb[:3;F]Rjc6",
+                                                                                                    "extraState": {
+                                                                                                      "isObjectVar": true
+                                                                                                    },
+                                                                                                    "fields": {
+                                                                                                      "OBJECTTYPE": "Player",
+                                                                                                      "VAR": {
+                                                                                                        "id": "Ja]@k]U!U8$Jv5S~jX*y"
+                                                                                                      }
+                                                                                                    },
+                                                                                                    "inputs": {
+                                                                                                      "OBJECT": {
+                                                                                                        "block": {
+                                                                                                          "type": "EventPlayer",
+                                                                                                          "id": "z(1qRs@Gi/Uj4%Z:Iap}"
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    },
+                                                                                    "VALUE-1": {
+                                                                                      "block": {
+                                                                                        "type": "Number",
+                                                                                        "id": "MEu5C(jCPKdAj%Ixzin^",
+                                                                                        "fields": {
+                                                                                          "NUM": 0
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              },
+                                                                              "DO": {
+                                                                                "block": {
+                                                                                  "type": "If",
+                                                                                  "id": "Z4d:z~bfAd`0GQ?y;`q8",
+                                                                                  "extraState": {},
+                                                                                  "inputs": {
+                                                                                    "VALUE-0": {
+                                                                                      "block": {
+                                                                                        "type": "IsTrueForAll",
+                                                                                        "id": "F^a{wu#T(_lA_:U^K*Yr",
+                                                                                        "inputs": {
+                                                                                          "VALUE-0": {
+                                                                                            "block": {
+                                                                                              "type": "GetVariable",
+                                                                                              "id": "wOEC0K9bez9_f`ezP!`4",
+                                                                                              "inputs": {
+                                                                                                "VALUE-0": {
+                                                                                                  "block": {
+                                                                                                    "type": "variableReferenceBlock",
+                                                                                                    "id": "[@i+%5.Ib.17rC/!5hUs",
+                                                                                                    "extraState": {
+                                                                                                      "isObjectVar": true
+                                                                                                    },
+                                                                                                    "fields": {
+                                                                                                      "OBJECTTYPE": "Player",
+                                                                                                      "VAR": {
+                                                                                                        "id": "Ja]@k]U!U8$Jv5S~jX*y"
+                                                                                                      }
+                                                                                                    },
+                                                                                                    "inputs": {
+                                                                                                      "OBJECT": {
+                                                                                                        "block": {
+                                                                                                          "type": "EventPlayer",
+                                                                                                          "id": "^N@=Az%uh75s;xn6wiwp"
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          },
+                                                                                          "VALUE-1": {
+                                                                                            "block": {
+                                                                                              "type": "GreaterThan",
+                                                                                              "id": "u$-eheG!#XE}PsDL?i04",
+                                                                                              "inputs": {
+                                                                                                "VALUE-0": {
+                                                                                                  "block": {
+                                                                                                    "type": "DistanceBetween",
+                                                                                                    "id": "4s1n{)keq]SmLw_kI4oL",
+                                                                                                    "inline": false,
+                                                                                                    "inputs": {
+                                                                                                      "VALUE-0": {
+                                                                                                        "block": {
+                                                                                                          "type": "GetSoldierState",
+                                                                                                          "id": "AEY=XM:!2%9Q?RM6UR}4",
+                                                                                                          "inputs": {
+                                                                                                            "VALUE-0": {
+                                                                                                              "block": {
+                                                                                                                "type": "CurrentArrayElement",
+                                                                                                                "id": "S.Zl(,lib~lbK+tLN=OV"
+                                                                                                              }
+                                                                                                            },
+                                                                                                            "VALUE-1": {
+                                                                                                              "block": {
+                                                                                                                "type": "SoldierStateVectorItem",
+                                                                                                                "id": "=HK[na*;s$J+u+qv*?$a",
+                                                                                                                "fields": {
+                                                                                                                  "VALUE-0": "SoldierStateVector",
+                                                                                                                  "VALUE-1": "GetPosition"
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      },
+                                                                                                      "VALUE-1": {
+                                                                                                        "block": {
+                                                                                                          "type": "GetSoldierState",
+                                                                                                          "id": "`7dSn+DS_=khYa-^!RyO",
+                                                                                                          "inputs": {
+                                                                                                            "VALUE-0": {
+                                                                                                              "block": {
+                                                                                                                "type": "EventPlayer",
+                                                                                                                "id": "#fiHijw@%B$g9?G0JFU]"
+                                                                                                              }
+                                                                                                            },
+                                                                                                            "VALUE-1": {
+                                                                                                              "block": {
+                                                                                                                "type": "SoldierStateVectorItem",
+                                                                                                                "id": "l-0J,[89Un29zlb.Jwz_",
+                                                                                                                "fields": {
+                                                                                                                  "VALUE-0": "SoldierStateVector",
+                                                                                                                  "VALUE-1": "GetPosition"
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                },
+                                                                                                "VALUE-1": {
+                                                                                                  "block": {
+                                                                                                    "type": "Number",
+                                                                                                    "id": "}KV1IK]QbP=FI2OIEyeE",
+                                                                                                    "fields": {
+                                                                                                      "NUM": 15
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    },
+                                                                                    "DO": {
+                                                                                      "block": {
+                                                                                        "type": "Teleport",
+                                                                                        "id": "YCL_5+WLz(Z90}|b+QVK",
+                                                                                        "inputs": {
+                                                                                          "VALUE-0": {
+                                                                                            "block": {
+                                                                                              "type": "EventPlayer",
+                                                                                              "id": "[SS2/,wEnpTPS`@:[+HS"
+                                                                                            }
+                                                                                          },
+                                                                                          "VALUE-1": {
+                                                                                            "block": {
+                                                                                              "type": "GetVariable",
+                                                                                              "id": "RoPVO^4[VfR)G?0P/[qU",
+                                                                                              "inputs": {
+                                                                                                "VALUE-0": {
+                                                                                                  "block": {
+                                                                                                    "type": "variableReferenceBlock",
+                                                                                                    "id": "+?qodHm%UYBFWEg0LQ~}",
+                                                                                                    "extraState": {
+                                                                                                      "isObjectVar": true
+                                                                                                    },
+                                                                                                    "fields": {
+                                                                                                      "OBJECTTYPE": "TeamId",
+                                                                                                      "VAR": {
+                                                                                                        "id": ")85N/!w[yu2n1i{J:kG%"
+                                                                                                      }
+                                                                                                    },
+                                                                                                    "inputs": {
+                                                                                                      "OBJECT": {
+                                                                                                        "block": {
+                                                                                                          "type": "GetTeamId",
+                                                                                                          "id": "|mwy|:.mMFdVtQ{z`DT(",
+                                                                                                          "inputs": {
+                                                                                                            "VALUE-0": {
+                                                                                                              "block": {
+                                                                                                                "type": "EventPlayer",
+                                                                                                                "id": "E*~uNcDH[oL6ve[+hCvY"
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          },
+                                                                                          "VALUE-2": {
+                                                                                            "block": {
+                                                                                              "type": "Number",
+                                                                                              "id": ",M6f--hC%Kx%WE/utR!7",
+                                                                                              "fields": {
+                                                                                                "NUM": 0
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              },
+                                                                              "ELSE": {
+                                                                                "block": {
+                                                                                  "type": "Teleport",
+                                                                                  "id": "^u%`C1HU4-O:+@G9L0=w",
+                                                                                  "inputs": {
+                                                                                    "VALUE-0": {
+                                                                                      "block": {
+                                                                                        "type": "EventPlayer",
+                                                                                        "id": "lW}tU8bS=aTY||=Pl!ZS"
+                                                                                      }
+                                                                                    },
+                                                                                    "VALUE-1": {
+                                                                                      "block": {
+                                                                                        "type": "GetVariable",
+                                                                                        "id": "=?a-njy4WUisrMbdca$X",
+                                                                                        "inputs": {
+                                                                                          "VALUE-0": {
+                                                                                            "block": {
+                                                                                              "type": "variableReferenceBlock",
+                                                                                              "id": "{+8Y1/g]Lo?f9@Seq/:_",
+                                                                                              "extraState": {
+                                                                                                "isObjectVar": true
+                                                                                              },
+                                                                                              "fields": {
+                                                                                                "OBJECTTYPE": "TeamId",
+                                                                                                "VAR": {
+                                                                                                  "id": ")85N/!w[yu2n1i{J:kG%"
+                                                                                                }
+                                                                                              },
+                                                                                              "inputs": {
+                                                                                                "OBJECT": {
+                                                                                                  "block": {
+                                                                                                    "type": "GetTeamId",
+                                                                                                    "id": "jcA}RpEwTCxH?R/`l+?=",
+                                                                                                    "inputs": {
+                                                                                                      "VALUE-0": {
+                                                                                                        "block": {
+                                                                                                          "type": "EventPlayer",
+                                                                                                          "id": "@69[W|3P`ao?,k%v~]#f"
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    },
+                                                                                    "VALUE-2": {
+                                                                                      "block": {
+                                                                                        "type": "Number",
+                                                                                        "id": "T,RNz*QzJHtW]x@5T)Oa",
+                                                                                        "fields": {
+                                                                                          "NUM": 0
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            },
+                                                                            "next": {
+                                                                              "block": {
+                                                                                "type": "subroutineInstanceBlock",
+                                                                                "id": "vEdtg{@3#|:Ou?cC~}Ab",
+                                                                                "extraState": {
+                                                                                  "subroutineName": "CheckBoundaries",
+                                                                                  "parameters": [
+                                                                                    {
+                                                                                      "types": "Array",
+                                                                                      "name": "Location"
+                                                                                    }
+                                                                                  ]
+                                                                                },
+                                                                                "fields": {
+                                                                                  "SUBROUTINE_NAME": "CheckBoundaries"
+                                                                                },
+                                                                                "inputs": {
+                                                                                  "PARAM-0": {
+                                                                                    "block": {
+                                                                                      "type": "GetVariable",
+                                                                                      "id": "+DC8aA=x0O3J?0L^_[Bl",
+                                                                                      "inputs": {
+                                                                                        "VALUE-0": {
+                                                                                          "block": {
+                                                                                            "type": "variableReferenceBlock",
+                                                                                            "id": "oAn,G[_/3Mv2-7mH]+nl",
+                                                                                            "extraState": {
+                                                                                              "isObjectVar": false
+                                                                                            },
+                                                                                            "fields": {
+                                                                                              "OBJECTTYPE": "Global",
+                                                                                              "VAR": {
+                                                                                                "id": "avhOM{5IU+T,cbtA-5?M"
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                },
+                                                                                "next": {
+                                                                                  "block": {
+                                                                                    "type": "If",
+                                                                                    "id": "l%z=5uWd2m@Vo@Z.0f4D",
+                                                                                    "extraState": {},
+                                                                                    "inputs": {
+                                                                                      "VALUE-0": {
+                                                                                        "block": {
+                                                                                          "type": "Not",
+                                                                                          "id": "$B#6znkq;wp;ci81czNf",
+                                                                                          "inputs": {
+                                                                                            "VALUE-0": {
+                                                                                              "block": {
+                                                                                                "type": "GetVariable",
+                                                                                                "id": "83/{MnyYEQoUy(M^lP2W",
+                                                                                                "inputs": {
+                                                                                                  "VALUE-0": {
+                                                                                                    "block": {
+                                                                                                      "type": "variableReferenceBlock",
+                                                                                                      "id": "8Xd*dEAiQhn=K%!`Ow?_",
+                                                                                                      "extraState": {
+                                                                                                        "isObjectVar": true
+                                                                                                      },
+                                                                                                      "fields": {
+                                                                                                        "OBJECTTYPE": "Player",
+                                                                                                        "VAR": {
+                                                                                                          "id": "RtgD|X+%@!)n$MrP;5vL"
+                                                                                                        }
+                                                                                                      },
+                                                                                                      "inputs": {
+                                                                                                        "OBJECT": {
+                                                                                                          "block": {
+                                                                                                            "type": "EventPlayer",
+                                                                                                            "id": "y+wO@=0;oy-/pvNf*TIo"
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      },
+                                                                                      "DO": {
+                                                                                        "block": {
+                                                                                          "type": "subroutineInstanceBlock",
+                                                                                          "id": "8sP4m+O0DeH]k?WHK4Oj",
+                                                                                          "extraState": {
+                                                                                            "subroutineName": "CheckBoundaries",
+                                                                                            "parameters": [
+                                                                                              {
+                                                                                                "types": "Array",
+                                                                                                "name": "Location"
+                                                                                              }
+                                                                                            ]
+                                                                                          },
+                                                                                          "fields": {
+                                                                                            "SUBROUTINE_NAME": "CheckBoundaries"
+                                                                                          },
+                                                                                          "inputs": {
+                                                                                            "PARAM-0": {
+                                                                                              "block": {
+                                                                                                "type": "GetVariable",
+                                                                                                "id": "fXwVA)bhqG==XLNhxPjj",
+                                                                                                "inputs": {
+                                                                                                  "VALUE-0": {
+                                                                                                    "block": {
+                                                                                                      "type": "variableReferenceBlock",
+                                                                                                      "id": "e}j_zGf|8VF|-@u;(#0*",
+                                                                                                      "extraState": {
+                                                                                                        "isObjectVar": true
+                                                                                                      },
+                                                                                                      "fields": {
+                                                                                                        "OBJECTTYPE": "TeamId",
+                                                                                                        "VAR": {
+                                                                                                          "id": "~!s}ovrs?jb7Yd/X[z2!"
+                                                                                                        }
+                                                                                                      },
+                                                                                                      "inputs": {
+                                                                                                        "OBJECT": {
+                                                                                                          "block": {
+                                                                                                            "type": "GetTeamId",
+                                                                                                            "id": "N8U[%]Op|!:;|{_HhV(l",
+                                                                                                            "inputs": {
+                                                                                                              "VALUE-0": {
+                                                                                                                "block": {
+                                                                                                                  "type": "EventPlayer",
+                                                                                                                  "id": ":b%V3_33|cMjvp^6p0W^"
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          },
+                                                                                          "next": {
+                                                                                            "block": {
+                                                                                              "type": "If",
+                                                                                              "id": "/cX+vDlEl:C](w5zzk~g",
+                                                                                              "extraState": {},
+                                                                                              "inputs": {
+                                                                                                "VALUE-0": {
+                                                                                                  "block": {
+                                                                                                    "type": "Not",
+                                                                                                    "id": "UPO;wG--jx?E|nEzl^n3",
+                                                                                                    "inputs": {
+                                                                                                      "VALUE-0": {
+                                                                                                        "block": {
+                                                                                                          "type": "GetVariable",
+                                                                                                          "id": "XEe2Fmurk%P`_jp3HJ4$",
+                                                                                                          "inputs": {
+                                                                                                            "VALUE-0": {
+                                                                                                              "block": {
+                                                                                                                "type": "variableReferenceBlock",
+                                                                                                                "id": "pfl*Ksr)lAH|TPdfcw}A",
+                                                                                                                "extraState": {
+                                                                                                                  "isObjectVar": true
+                                                                                                                },
+                                                                                                                "fields": {
+                                                                                                                  "OBJECTTYPE": "Player",
+                                                                                                                  "VAR": {
+                                                                                                                    "id": "RtgD|X+%@!)n$MrP;5vL"
+                                                                                                                  }
+                                                                                                                },
+                                                                                                                "inputs": {
+                                                                                                                  "OBJECT": {
+                                                                                                                    "block": {
+                                                                                                                      "type": "EventPlayer",
+                                                                                                                      "id": "Q:0V@g|$h:Nkc:70[~hE"
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                },
+                                                                                                "DO": {
+                                                                                                  "block": {
+                                                                                                    "type": "Teleport",
+                                                                                                    "id": "D~M+NAmA)njPSF~@j0nr",
+                                                                                                    "inputs": {
+                                                                                                      "VALUE-0": {
+                                                                                                        "block": {
+                                                                                                          "type": "EventPlayer",
+                                                                                                          "id": "tAp$_CzH4,pS#%N_(=sD"
+                                                                                                        }
+                                                                                                      },
+                                                                                                      "VALUE-1": {
+                                                                                                        "block": {
+                                                                                                          "type": "GetVariable",
+                                                                                                          "id": "`nLs@Fg=5OqPU(.z^uWf",
+                                                                                                          "inputs": {
+                                                                                                            "VALUE-0": {
+                                                                                                              "block": {
+                                                                                                                "type": "variableReferenceBlock",
+                                                                                                                "id": "+q^2R;_CCy@iCYz?|3y%",
+                                                                                                                "extraState": {
+                                                                                                                  "isObjectVar": true
+                                                                                                                },
+                                                                                                                "fields": {
+                                                                                                                  "OBJECTTYPE": "TeamId",
+                                                                                                                  "VAR": {
+                                                                                                                    "id": ")85N/!w[yu2n1i{J:kG%"
+                                                                                                                  }
+                                                                                                                },
+                                                                                                                "inputs": {
+                                                                                                                  "OBJECT": {
+                                                                                                                    "block": {
+                                                                                                                      "type": "GetTeamId",
+                                                                                                                      "id": "LZ.hAb)Z2kC9hJR(.f)q",
+                                                                                                                      "inputs": {
+                                                                                                                        "VALUE-0": {
+                                                                                                                          "block": {
+                                                                                                                            "type": "EventPlayer",
+                                                                                                                            "id": "p=1f,{pbL_oRX*uDy#_S"
+                                                                                                                          }
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      },
+                                                                                                      "VALUE-2": {
+                                                                                                        "block": {
+                                                                                                          "type": "Number",
+                                                                                                          "id": "H@9r:xy(bjoiJIcAk3IG",
+                                                                                                          "fields": {
+                                                                                                            "NUM": 0
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          },
+                                                          "next": {
+                                                            "block": {
+                                                              "type": "ruleBlock",
+                                                              "id": "]XNNLpeKd)baVT]_mu9p",
+                                                              "extraState": {
+                                                                "isOngoingEvent": true
+                                                              },
+                                                              "fields": {
+                                                                "NAME": "Detect Play Area",
+                                                                "EVENTTYPE": "Ongoing",
+                                                                "OBJECTTYPE": "Player"
+                                                              },
+                                                              "inputs": {
+                                                                "CONDITIONS": {
+                                                                  "block": {
+                                                                    "type": "conditionBlock",
+                                                                    "id": "k@JZTbQ7;tpuB[btZe){",
+                                                                    "inputs": {
+                                                                      "CONDITION": {
+                                                                        "block": {
+                                                                          "type": "GetVariable",
+                                                                          "id": "`X)A9,S{)kOEcuGxB[=I",
+                                                                          "inputs": {
+                                                                            "VALUE-0": {
+                                                                              "block": {
+                                                                                "type": "variableReferenceBlock",
+                                                                                "id": ",eFH%u^H,t[ugEp2jz6b",
+                                                                                "extraState": {
+                                                                                  "isObjectVar": true
+                                                                                },
+                                                                                "fields": {
+                                                                                  "OBJECTTYPE": "Player",
+                                                                                  "VAR": {
+                                                                                    "id": "IRu4,i0nyGI*8goT1`+u"
+                                                                                  }
+                                                                                },
+                                                                                "inputs": {
+                                                                                  "OBJECT": {
+                                                                                    "block": {
+                                                                                      "type": "EventPlayer",
+                                                                                      "id": "[D2B$y]y-6?U$MF^KMmu"
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                },
+                                                                "ACTIONS": {
+                                                                  "block": {
+                                                                    "type": "Wait",
+                                                                    "id": "v0ids-sbJS]YfuDF:b]2",
+                                                                    "inputs": {
+                                                                      "VALUE-0": {
+                                                                        "block": {
+                                                                          "type": "Number",
+                                                                          "id": "qzQVgnyDQL=TD4sfY=nn",
+                                                                          "fields": {
+                                                                            "NUM": 1.5
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    "next": {
+                                                                      "block": {
+                                                                        "type": "While",
+                                                                        "id": "sYoK[itkTNhkOy={ooeP",
+                                                                        "inputs": {
+                                                                          "VALUE-0": {
+                                                                            "block": {
+                                                                              "type": "GetVariable",
+                                                                              "id": "|D^n4%H]aB_B`h@VEZlS",
+                                                                              "inputs": {
+                                                                                "VALUE-0": {
+                                                                                  "block": {
+                                                                                    "type": "variableReferenceBlock",
+                                                                                    "id": "_sgBaBcV[@fHJ5(,/1g}",
+                                                                                    "extraState": {
+                                                                                      "isObjectVar": true
+                                                                                    },
+                                                                                    "fields": {
+                                                                                      "OBJECTTYPE": "Player",
+                                                                                      "VAR": {
+                                                                                        "id": "IRu4,i0nyGI*8goT1`+u"
+                                                                                      }
+                                                                                    },
+                                                                                    "inputs": {
+                                                                                      "OBJECT": {
+                                                                                        "block": {
+                                                                                          "type": "EventPlayer",
+                                                                                          "id": "JE9)H68b9$qu$gRIwoml"
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          "DO": {
+                                                                            "block": {
+                                                                              "type": "subroutineInstanceBlock",
+                                                                              "id": "k+3U}P(.1c}9!?dFeg.1",
+                                                                              "extraState": {
+                                                                                "subroutineName": "CheckBoundaries",
+                                                                                "parameters": [
+                                                                                  {
+                                                                                    "types": "Array",
+                                                                                    "name": "Location"
+                                                                                  }
+                                                                                ]
+                                                                              },
+                                                                              "fields": {
+                                                                                "SUBROUTINE_NAME": "CheckBoundaries"
+                                                                              },
+                                                                              "inputs": {
+                                                                                "PARAM-0": {
+                                                                                  "block": {
+                                                                                    "type": "GetVariable",
+                                                                                    "id": "IwvP[G~!gV:%d?Y-=%]R",
+                                                                                    "inputs": {
+                                                                                      "VALUE-0": {
+                                                                                        "block": {
+                                                                                          "type": "variableReferenceBlock",
+                                                                                          "id": "FN*sr_;=ZS-j-($y#[0a",
+                                                                                          "extraState": {
+                                                                                            "isObjectVar": false
+                                                                                          },
+                                                                                          "fields": {
+                                                                                            "OBJECTTYPE": "Global",
+                                                                                            "VAR": {
+                                                                                              "id": "avhOM{5IU+T,cbtA-5?M"
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              },
+                                                                              "next": {
+                                                                                "block": {
+                                                                                  "type": "If",
+                                                                                  "id": "[Z7Q8Mub{e~}irZ1,(Jk",
+                                                                                  "extraState": {},
+                                                                                  "inputs": {
+                                                                                    "VALUE-0": {
+                                                                                      "block": {
+                                                                                        "type": "Not",
+                                                                                        "id": "P]$5A?]aq1c=0d;zNLqv",
+                                                                                        "inputs": {
+                                                                                          "VALUE-0": {
+                                                                                            "block": {
+                                                                                              "type": "GetVariable",
+                                                                                              "id": "4!I?*SvZ$wU=^ZnxP-YZ",
+                                                                                              "inputs": {
+                                                                                                "VALUE-0": {
+                                                                                                  "block": {
+                                                                                                    "type": "variableReferenceBlock",
+                                                                                                    "id": "G58bbNUA,aAMEZ]@S*D1",
+                                                                                                    "extraState": {
+                                                                                                      "isObjectVar": true
+                                                                                                    },
+                                                                                                    "fields": {
+                                                                                                      "OBJECTTYPE": "Player",
+                                                                                                      "VAR": {
+                                                                                                        "id": "RtgD|X+%@!)n$MrP;5vL"
+                                                                                                      }
+                                                                                                    },
+                                                                                                    "inputs": {
+                                                                                                      "OBJECT": {
+                                                                                                        "block": {
+                                                                                                          "type": "EventPlayer",
+                                                                                                          "id": "jMI0@=gq~iO6+Tj]Z,{g"
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    },
+                                                                                    "DO": {
+                                                                                      "block": {
+                                                                                        "type": "subroutineInstanceBlock",
+                                                                                        "id": "Mo6@Z$_)[YuE=^2I~@#6",
+                                                                                        "extraState": {
+                                                                                          "subroutineName": "CheckBoundaries",
+                                                                                          "parameters": [
+                                                                                            {
+                                                                                              "types": "Array",
+                                                                                              "name": "Location"
+                                                                                            }
+                                                                                          ]
+                                                                                        },
+                                                                                        "fields": {
+                                                                                          "SUBROUTINE_NAME": "CheckBoundaries"
+                                                                                        },
+                                                                                        "inputs": {
+                                                                                          "PARAM-0": {
+                                                                                            "block": {
+                                                                                              "type": "GetVariable",
+                                                                                              "id": "dgQ}99zHDxBt:UX{v9gu",
+                                                                                              "inputs": {
+                                                                                                "VALUE-0": {
+                                                                                                  "block": {
+                                                                                                    "type": "variableReferenceBlock",
+                                                                                                    "id": "XQkRlsJJ50+98@#RM:WW",
+                                                                                                    "extraState": {
+                                                                                                      "isObjectVar": true
+                                                                                                    },
+                                                                                                    "fields": {
+                                                                                                      "OBJECTTYPE": "TeamId",
+                                                                                                      "VAR": {
+                                                                                                        "id": "~!s}ovrs?jb7Yd/X[z2!"
+                                                                                                      }
+                                                                                                    },
+                                                                                                    "inputs": {
+                                                                                                      "OBJECT": {
+                                                                                                        "block": {
+                                                                                                          "type": "GetTeamId",
+                                                                                                          "id": "G8UD1lwARYQ3(4$sS2ph",
+                                                                                                          "inputs": {
+                                                                                                            "VALUE-0": {
+                                                                                                              "block": {
+                                                                                                                "type": "EventPlayer",
+                                                                                                                "id": "o5yz7g[Xjqa]}WxxN=]?"
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  },
+                                                                                  "next": {
+                                                                                    "block": {
+                                                                                      "type": "If",
+                                                                                      "id": ":9xeNleWzJgH,!D$fGsH",
+                                                                                      "extraState": {
+                                                                                        "elseif": 0,
+                                                                                        "else": 1
+                                                                                      },
+                                                                                      "inputs": {
+                                                                                        "VALUE-0": {
+                                                                                          "block": {
+                                                                                            "type": "GetVariable",
+                                                                                            "id": "3s::Rg:Pbj8_F!%,S!{6",
+                                                                                            "inputs": {
+                                                                                              "VALUE-0": {
+                                                                                                "block": {
+                                                                                                  "type": "variableReferenceBlock",
+                                                                                                  "id": "igadu6nWqeJ;*B0nR-q}",
+                                                                                                  "extraState": {
+                                                                                                    "isObjectVar": true
+                                                                                                  },
+                                                                                                  "fields": {
+                                                                                                    "OBJECTTYPE": "Player",
+                                                                                                    "VAR": {
+                                                                                                      "id": "RtgD|X+%@!)n$MrP;5vL"
+                                                                                                    }
+                                                                                                  },
+                                                                                                  "inputs": {
+                                                                                                    "OBJECT": {
+                                                                                                      "block": {
+                                                                                                        "type": "EventPlayer",
+                                                                                                        "id": "u5GC/=ms+mEq+N~Gv#^@"
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        },
+                                                                                        "DO": {
+                                                                                          "block": {
+                                                                                            "type": "DisplayCustomNotificationMessage",
+                                                                                            "id": "}=lEdZbl/!oq7MhQo8!~",
+                                                                                            "inputs": {
+                                                                                              "VALUE-0": {
+                                                                                                "block": {
+                                                                                                  "type": "Message",
+                                                                                                  "id": "1uEoHtb5su]3QeACMcCk",
+                                                                                                  "inputs": {
+                                                                                                    "VALUE-0": {
+                                                                                                      "block": {
+                                                                                                        "type": "Text",
+                                                                                                        "id": "Mgt^]kVQEU1;T;P.-)ov",
+                                                                                                        "fields": {
+                                                                                                          "TEXT": "Debug: In Play Area"
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              },
+                                                                                              "VALUE-1": {
+                                                                                                "block": {
+                                                                                                  "type": "CustomMessagesItem",
+                                                                                                  "id": "RS*YO;U{7lM-O!HU`1df",
+                                                                                                  "fields": {
+                                                                                                    "VALUE-0": "CustomMessages",
+                                                                                                    "VALUE-1": "MessageText1"
+                                                                                                  }
+                                                                                                }
+                                                                                              },
+                                                                                              "VALUE-2": {
+                                                                                                "block": {
+                                                                                                  "type": "Number",
+                                                                                                  "id": "dly?axRNk)ze:X7kMK)(",
+                                                                                                  "fields": {
+                                                                                                    "NUM": 0.3
+                                                                                                  }
+                                                                                                }
+                                                                                              },
+                                                                                              "VALUE-3": {
+                                                                                                "block": {
+                                                                                                  "type": "EventPlayer",
+                                                                                                  "id": "C:X:|zx@|KiLDH(}r/Lw"
+                                                                                                }
+                                                                                              }
+                                                                                            },
+                                                                                            "next": {
+                                                                                              "block": {
+                                                                                                "type": "SetVariable",
+                                                                                                "id": "mMbuqKe=p;[i5,#3Te5S",
+                                                                                                "inputs": {
+                                                                                                  "VALUE-0": {
+                                                                                                    "block": {
+                                                                                                      "type": "variableReferenceBlock",
+                                                                                                      "id": "]oD3utvv|Po.T54p7nxa",
+                                                                                                      "extraState": {
+                                                                                                        "isObjectVar": true
+                                                                                                      },
+                                                                                                      "fields": {
+                                                                                                        "OBJECTTYPE": "Player",
+                                                                                                        "VAR": {
+                                                                                                          "id": "_-Lg+r#4h2a6}2ISA-:J"
+                                                                                                        }
+                                                                                                      },
+                                                                                                      "inputs": {
+                                                                                                        "OBJECT": {
+                                                                                                          "block": {
+                                                                                                            "type": "EventPlayer",
+                                                                                                            "id": "W.r|zj*k-@X*-`t%tk,V"
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  },
+                                                                                                  "VALUE-1": {
+                                                                                                    "block": {
+                                                                                                      "type": "GetSoldierState",
+                                                                                                      "id": "XUy:JS(S+x{20VlyC$W-",
+                                                                                                      "inputs": {
+                                                                                                        "VALUE-0": {
+                                                                                                          "block": {
+                                                                                                            "type": "EventPlayer",
+                                                                                                            "id": "2k^8A}6_4@3JH5]Ybp/D"
+                                                                                                          }
+                                                                                                        },
+                                                                                                        "VALUE-1": {
+                                                                                                          "block": {
+                                                                                                            "type": "SoldierStateVectorItem",
+                                                                                                            "id": "mfT6mi{3lD,MsJLL%6K^",
+                                                                                                            "fields": {
+                                                                                                              "VALUE-0": "SoldierStateVector",
+                                                                                                              "VALUE-1": "GetPosition"
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        },
+                                                                                        "ELSE": {
+                                                                                          "block": {
+                                                                                            "type": "DisplayCustomNotificationMessage",
+                                                                                            "id": "/hD;UbVg(`+[WwTn9yV{",
+                                                                                            "inputs": {
+                                                                                              "VALUE-0": {
+                                                                                                "block": {
+                                                                                                  "type": "Message",
+                                                                                                  "id": ".9go5IS#WZ-;x_TW)]n|",
+                                                                                                  "inputs": {
+                                                                                                    "VALUE-0": {
+                                                                                                      "block": {
+                                                                                                        "type": "Text",
+                                                                                                        "id": "/`WHrN}HOlT$,s6?f}lv",
+                                                                                                        "fields": {
+                                                                                                          "TEXT": "OUT OF BOUNDS"
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              },
+                                                                                              "VALUE-1": {
+                                                                                                "block": {
+                                                                                                  "type": "CustomMessagesItem",
+                                                                                                  "id": "2?[BlMl}aj1+Pm25=27h",
+                                                                                                  "fields": {
+                                                                                                    "VALUE-0": "CustomMessages",
+                                                                                                    "VALUE-1": "HeaderText"
+                                                                                                  }
+                                                                                                }
+                                                                                              },
+                                                                                              "VALUE-2": {
+                                                                                                "block": {
+                                                                                                  "type": "Number",
+                                                                                                  "id": "bz!Rmcn=aj`?EYl%~T=;",
+                                                                                                  "fields": {
+                                                                                                    "NUM": 1
+                                                                                                  }
+                                                                                                }
+                                                                                              },
+                                                                                              "VALUE-3": {
+                                                                                                "block": {
+                                                                                                  "type": "EventPlayer",
+                                                                                                  "id": "t*j8Jbt0A~(KrxqJ}C=l"
+                                                                                                }
+                                                                                              }
+                                                                                            },
+                                                                                            "next": {
+                                                                                              "block": {
+                                                                                                "type": "subroutineInstanceBlock",
+                                                                                                "id": "`Hj6yQ~d2o=Y@I46D,}s",
+                                                                                                "extraState": {
+                                                                                                  "subroutineName": "yaw",
+                                                                                                  "parameters": []
+                                                                                                },
+                                                                                                "fields": {
+                                                                                                  "SUBROUTINE_NAME": "yaw"
+                                                                                                },
+                                                                                                "next": {
+                                                                                                  "block": {
+                                                                                                    "type": "Teleport",
+                                                                                                    "id": "d+Zaw[MaC*IaGaNIQ%rS",
+                                                                                                    "inputs": {
+                                                                                                      "VALUE-0": {
+                                                                                                        "block": {
+                                                                                                          "type": "EventPlayer",
+                                                                                                          "id": "94Q%n;~j#C77]Jo=)cvd"
+                                                                                                        }
+                                                                                                      },
+                                                                                                      "VALUE-1": {
+                                                                                                        "block": {
+                                                                                                          "type": "GetVariable",
+                                                                                                          "id": "UrpuYOk!O~5~)C{U#zAn",
+                                                                                                          "inputs": {
+                                                                                                            "VALUE-0": {
+                                                                                                              "block": {
+                                                                                                                "type": "variableReferenceBlock",
+                                                                                                                "id": "wx4[qP_^c2|]OpmjHMe6",
+                                                                                                                "extraState": {
+                                                                                                                  "isObjectVar": true
+                                                                                                                },
+                                                                                                                "fields": {
+                                                                                                                  "OBJECTTYPE": "Player",
+                                                                                                                  "VAR": {
+                                                                                                                    "id": "_-Lg+r#4h2a6}2ISA-:J"
+                                                                                                                  }
+                                                                                                                },
+                                                                                                                "inputs": {
+                                                                                                                  "OBJECT": {
+                                                                                                                    "block": {
+                                                                                                                      "type": "EventPlayer",
+                                                                                                                      "id": "7L~ce|M5*5MRErnsWJf}"
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      },
+                                                                                                      "VALUE-2": {
+                                                                                                        "block": {
+                                                                                                          "type": "GetVariable",
+                                                                                                          "id": "m}AxLWt}H3.^Q5OD5U$!",
+                                                                                                          "inputs": {
+                                                                                                            "VALUE-0": {
+                                                                                                              "block": {
+                                                                                                                "type": "variableReferenceBlock",
+                                                                                                                "id": "7sMoh#n+wB63#s~V3gB6",
+                                                                                                                "extraState": {
+                                                                                                                  "isObjectVar": true
+                                                                                                                },
+                                                                                                                "fields": {
+                                                                                                                  "OBJECTTYPE": "Player",
+                                                                                                                  "VAR": {
+                                                                                                                    "id": "Q5Zu0keSSA7tlAfVDnKZ"
+                                                                                                                  }
+                                                                                                                },
+                                                                                                                "inputs": {
+                                                                                                                  "OBJECT": {
+                                                                                                                    "block": {
+                                                                                                                      "type": "EventPlayer",
+                                                                                                                      "id": "z|APx0WgRh|6WHw/EP6k"
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      },
+                                                                                      "next": {
+                                                                                        "block": {
+                                                                                          "type": "Wait",
+                                                                                          "id": "y@QRXp%BJ~Xuk{_dLj59",
+                                                                                          "inputs": {
+                                                                                            "VALUE-0": {
+                                                                                              "block": {
+                                                                                                "type": "Number",
+                                                                                                "id": "!h3:7j{Pr8Z)ktDX6yCg",
+                                                                                                "fields": {
+                                                                                                  "NUM": 0.2
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              },
+                                                              "next": {
+                                                                "block": {
+                                                                  "type": "ruleBlock",
+                                                                  "id": ";]qD3c?*zqHjuo]+N3[U",
+                                                                  "extraState": {
+                                                                    "isOngoingEvent": false
+                                                                  },
+                                                                  "fields": {
+                                                                    "NAME": "Stop Tracking Fuse",
+                                                                    "EVENTTYPE": "OnMCOMDefused"
+                                                                  },
+                                                                  "inputs": {
+                                                                    "ACTIONS": {
+                                                                      "block": {
+                                                                        "type": "If",
+                                                                        "id": "2_(/SJL$TI!/HU*2ze=Z",
+                                                                        "extraState": {
+                                                                          "elseif": 0,
+                                                                          "else": 1
+                                                                        },
+                                                                        "inputs": {
+                                                                          "VALUE-0": {
+                                                                            "block": {
+                                                                              "type": "Equals",
+                                                                              "id": "XQx-hd~riC*:1%chEo}W",
+                                                                              "inputs": {
+                                                                                "VALUE-0": {
+                                                                                  "block": {
+                                                                                    "type": "EventMCOM",
+                                                                                    "id": "0JG];:Rq=LF$X/9;7zpM"
+                                                                                  }
+                                                                                },
+                                                                                "VALUE-1": {
+                                                                                  "block": {
+                                                                                    "type": "GetVariable",
+                                                                                    "id": "~|9!HR?)E-Ljd*j=E(DX",
+                                                                                    "inputs": {
+                                                                                      "VALUE-0": {
+                                                                                        "block": {
+                                                                                          "type": "variableReferenceBlock",
+                                                                                          "id": ".8okNMbFM;:UQMNyc/6P",
+                                                                                          "extraState": {
+                                                                                            "isObjectVar": false
+                                                                                          },
+                                                                                          "fields": {
+                                                                                            "OBJECTTYPE": "Global",
+                                                                                            "VAR": {
+                                                                                              "id": "W?M=066mWT~Tf=[ON!`$"
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          "DO": {
+                                                                            "block": {
+                                                                              "type": "SetMCOMFuseTime",
+                                                                              "id": "7GGSqpCjJh:h~e{5^_0[",
+                                                                              "inputs": {
+                                                                                "VALUE-0": {
+                                                                                  "block": {
+                                                                                    "type": "GetVariable",
+                                                                                    "id": "dq@AwLvo{JGG2UR}b]GA",
+                                                                                    "inputs": {
+                                                                                      "VALUE-0": {
+                                                                                        "block": {
+                                                                                          "type": "variableReferenceBlock",
+                                                                                          "id": "f~Rf{w-A+RJzeWiq*Tu)",
+                                                                                          "extraState": {
+                                                                                            "isObjectVar": false
+                                                                                          },
+                                                                                          "fields": {
+                                                                                            "OBJECTTYPE": "Global",
+                                                                                            "VAR": {
+                                                                                              "id": "W?M=066mWT~Tf=[ON!`$"
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                },
+                                                                                "VALUE-1": {
+                                                                                  "block": {
+                                                                                    "type": "GetVariable",
+                                                                                    "id": "+/=2lxrmaEv-ygDTcl@~",
+                                                                                    "inputs": {
+                                                                                      "VALUE-0": {
+                                                                                        "block": {
+                                                                                          "type": "variableReferenceBlock",
+                                                                                          "id": "YFI2Vu3YYleU]`u[zfAs",
+                                                                                          "extraState": {
+                                                                                            "isObjectVar": false
+                                                                                          },
+                                                                                          "fields": {
+                                                                                            "OBJECTTYPE": "Global",
+                                                                                            "VAR": {
+                                                                                              "id": "WmLAWml]VVTbibIk]jA/"
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          "ELSE": {
+                                                                            "block": {
+                                                                              "type": "SetMCOMFuseTime",
+                                                                              "id": "Ff^;*H;vNg99A|:3jv2}",
+                                                                              "inputs": {
+                                                                                "VALUE-0": {
+                                                                                  "block": {
+                                                                                    "type": "GetVariable",
+                                                                                    "id": "dNM%r;k?;c;$?q[ki*V@",
+                                                                                    "inputs": {
+                                                                                      "VALUE-0": {
+                                                                                        "block": {
+                                                                                          "type": "variableReferenceBlock",
+                                                                                          "id": "[-LnGPd|y5K:,E[8a1+U",
+                                                                                          "extraState": {
+                                                                                            "isObjectVar": false
+                                                                                          },
+                                                                                          "fields": {
+                                                                                            "OBJECTTYPE": "Global",
+                                                                                            "VAR": {
+                                                                                              "id": "ZCBg+S5Y0?xD[@GpnRJ."
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                },
+                                                                                "VALUE-1": {
+                                                                                  "block": {
+                                                                                    "type": "GetVariable",
+                                                                                    "id": "Tdhl:8w[XZFHjN5E0e!-",
+                                                                                    "inputs": {
+                                                                                      "VALUE-0": {
+                                                                                        "block": {
+                                                                                          "type": "variableReferenceBlock",
+                                                                                          "id": "pUz=qU2i*iGb^1$//Py/",
+                                                                                          "extraState": {
+                                                                                            "isObjectVar": false
+                                                                                          },
+                                                                                          "fields": {
+                                                                                            "OBJECTTYPE": "Global",
+                                                                                            "VAR": {
+                                                                                              "id": "c[z#A9bNIqE/7|%xj;-G"
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  "next": {
+                                                                    "block": {
+                                                                      "type": "ruleBlock",
+                                                                      "id": "tSMy,ctWSdNm*N@E*%ko",
+                                                                      "extraState": {
+                                                                        "isOngoingEvent": false
+                                                                      },
+                                                                      "fields": {
+                                                                        "NAME": "MCOM Destroyed",
+                                                                        "EVENTTYPE": "OnMCOMDestroyed"
+                                                                      },
+                                                                      "inputs": {
+                                                                        "ACTIONS": {
+                                                                          "block": {
+                                                                            "type": "If",
+                                                                            "id": "^J#@bTLLdVxW~GBL(}4A",
+                                                                            "extraState": {
+                                                                              "elseif": 0,
+                                                                              "else": 1
+                                                                            },
+                                                                            "inputs": {
+                                                                              "VALUE-0": {
+                                                                                "block": {
+                                                                                  "type": "Equals",
+                                                                                  "id": "2R#W3rFUXm,H+|^m]{t|",
+                                                                                  "inputs": {
+                                                                                    "VALUE-0": {
+                                                                                      "block": {
+                                                                                        "type": "EventMCOM",
+                                                                                        "id": "s_r5P!qwCr!Xcb4#54=q"
+                                                                                      }
+                                                                                    },
+                                                                                    "VALUE-1": {
+                                                                                      "block": {
+                                                                                        "type": "GetVariable",
+                                                                                        "id": ";Iv)_XHu;Y=um{=S;QLq",
+                                                                                        "inputs": {
+                                                                                          "VALUE-0": {
+                                                                                            "block": {
+                                                                                              "type": "variableReferenceBlock",
+                                                                                              "id": "|^U6*o9,L]eNjtmwo#jT",
+                                                                                              "extraState": {
+                                                                                                "isObjectVar": false
+                                                                                              },
+                                                                                              "fields": {
+                                                                                                "OBJECTTYPE": "Global",
+                                                                                                "VAR": {
+                                                                                                  "id": "W?M=066mWT~Tf=[ON!`$"
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              },
+                                                                              "DO": {
+                                                                                "block": {
+                                                                                  "type": "EnableObjective",
+                                                                                  "id": "u!50Q#45N9L(oO]wrc,#",
+                                                                                  "inputs": {
+                                                                                    "VALUE-0": {
+                                                                                      "block": {
+                                                                                        "type": "GetCapturePoint",
+                                                                                        "id": "D)abzk%JJ2k%f3~dA10:",
+                                                                                        "inputs": {
+                                                                                          "VALUE-0": {
+                                                                                            "block": {
+                                                                                              "type": "MCOMsItem",
+                                                                                              "id": "kv]}gwq/}#QEvW|FhMr(",
+                                                                                              "fields": {
+                                                                                                "VALUE-0": "MCOMs",
+                                                                                                "VALUE-1": "E"
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    },
+                                                                                    "VALUE-1": {
+                                                                                      "block": {
+                                                                                        "type": "Boolean",
+                                                                                        "id": "%#E9A^H#AfSvzFe;NgJY",
+                                                                                        "fields": {
+                                                                                          "BOOL": "FALSE"
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              },
+                                                                              "ELSE": {
+                                                                                "block": {
+                                                                                  "type": "EnableObjective",
+                                                                                  "id": "^6G~dW4-:|G06DE_zv[U",
+                                                                                  "inputs": {
+                                                                                    "VALUE-0": {
+                                                                                      "block": {
+                                                                                        "type": "GetCapturePoint",
+                                                                                        "id": "_7*:#ek!i]sv^mAafp[-",
+                                                                                        "inputs": {
+                                                                                          "VALUE-0": {
+                                                                                            "block": {
+                                                                                              "type": "MCOMsItem",
+                                                                                              "id": "z|Yp/LgXOHPA0a]$^Y0$",
+                                                                                              "fields": {
+                                                                                                "VALUE-0": "MCOMs",
+                                                                                                "VALUE-1": "F"
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    },
+                                                                                    "VALUE-1": {
+                                                                                      "block": {
+                                                                                        "type": "Boolean",
+                                                                                        "id": "n5(9H*$a%~~%B*T#=w1@",
+                                                                                        "fields": {
+                                                                                          "BOOL": "FALSE"
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            },
+                                                                            "next": {
+                                                                              "block": {
+                                                                                "type": "SetGamemodeScore",
+                                                                                "id": "i18g1ZmTmZ4!|IlPUA9`",
+                                                                                "inputs": {
+                                                                                  "VALUE-0": {
+                                                                                    "block": {
+                                                                                      "type": "GetTeamId",
+                                                                                      "id": "sLrkQ|XXD9@fE;ek`{CF",
+                                                                                      "inputs": {
+                                                                                        "VALUE-0": {
+                                                                                          "block": {
+                                                                                            "type": "Number",
+                                                                                            "id": "d1`~f2X)Gd#%(gxxpq1!",
+                                                                                            "fields": {
+                                                                                              "NUM": 2
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  },
+                                                                                  "VALUE-1": {
+                                                                                    "block": {
+                                                                                      "type": "Subtract",
+                                                                                      "id": "hk5qsrqF?:1rB#:I|9hr",
+                                                                                      "inputs": {
+                                                                                        "VALUE-0": {
+                                                                                          "block": {
+                                                                                            "type": "GetGamemodeScore",
+                                                                                            "id": "}-cKcshyk@h|0~*AjskS",
+                                                                                            "inputs": {
+                                                                                              "VALUE-0": {
+                                                                                                "block": {
+                                                                                                  "type": "GetTeamId",
+                                                                                                  "id": "g`DDYD|Qu4%Lo[y%$OuH",
+                                                                                                  "inputs": {
+                                                                                                    "VALUE-0": {
+                                                                                                      "block": {
+                                                                                                        "type": "Number",
+                                                                                                        "id": "s;7s;fP[t1xByc!}nMtn",
+                                                                                                        "fields": {
+                                                                                                          "NUM": 2
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        },
+                                                                                        "VALUE-1": {
+                                                                                          "block": {
+                                                                                            "type": "Number",
+                                                                                            "id": "T#Tr^e~qA_+I_MGy8]OC",
+                                                                                            "fields": {
+                                                                                              "NUM": 1
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                },
+                                                                                "next": {
+                                                                                  "block": {
+                                                                                    "type": "If",
+                                                                                    "id": "]{4?#wcGXN5VY4%LvYc2",
+                                                                                    "extraState": {
+                                                                                      "elseif": 1,
+                                                                                      "else": 1
+                                                                                    },
+                                                                                    "inputs": {
+                                                                                      "VALUE-0": {
+                                                                                        "block": {
+                                                                                          "type": "Equals",
+                                                                                          "id": "gZ;711z,J~-kymN]KB07",
+                                                                                          "inputs": {
+                                                                                            "VALUE-0": {
+                                                                                              "block": {
+                                                                                                "type": "GetGamemodeScore",
+                                                                                                "id": "}sMJMZwvxi7#DOnj9I{K",
+                                                                                                "inputs": {
+                                                                                                  "VALUE-0": {
+                                                                                                    "block": {
+                                                                                                      "type": "GetTeamId",
+                                                                                                      "id": "dn_0HU-SjWX/(yA:JDM3",
+                                                                                                      "inputs": {
+                                                                                                        "VALUE-0": {
+                                                                                                          "block": {
+                                                                                                            "type": "Number",
+                                                                                                            "id": "D#5HvhOS{3uUkkCGn_(z",
+                                                                                                            "fields": {
+                                                                                                              "NUM": 2
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            },
+                                                                                            "VALUE-1": {
+                                                                                              "block": {
+                                                                                                "type": "Number",
+                                                                                                "id": "(V82MEHInu#IfglzI5Et",
+                                                                                                "fields": {
+                                                                                                  "NUM": 2
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      },
+                                                                                      "DO": {
+                                                                                        "block": {
+                                                                                          "type": "SetVariable",
+                                                                                          "id": "I(|-d%N@nDD1IZ$Oi%C5",
+                                                                                          "inputs": {
+                                                                                            "VALUE-0": {
+                                                                                              "block": {
+                                                                                                "type": "variableReferenceBlock",
+                                                                                                "id": "=XPP;dY;21NYC:i/usIi",
+                                                                                                "extraState": {
+                                                                                                  "isObjectVar": false
+                                                                                                },
+                                                                                                "fields": {
+                                                                                                  "OBJECTTYPE": "Global",
+                                                                                                  "VAR": {
+                                                                                                    "id": "=8OY*aWMGF4.T^k6uLUl"
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            },
+                                                                                            "VALUE-1": {
+                                                                                              "block": {
+                                                                                                "type": "GetVariable",
+                                                                                                "id": "8WvKniysVuj=4|3**-w/",
+                                                                                                "inputs": {
+                                                                                                  "VALUE-0": {
+                                                                                                    "block": {
+                                                                                                      "type": "variableReferenceBlock",
+                                                                                                      "id": "`_~=|Vr6K#Qnywb*rD3w",
+                                                                                                      "extraState": {
+                                                                                                        "isObjectVar": false
+                                                                                                      },
+                                                                                                      "fields": {
+                                                                                                        "OBJECTTYPE": "Global",
+                                                                                                        "VAR": {
+                                                                                                          "id": "Xr?o?acUGgeUMdeaBx?x"
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          },
+                                                                                          "next": {
+                                                                                            "block": {
+                                                                                              "type": "Wait",
+                                                                                              "id": "{r59qWj9?k3BApT/!BII",
+                                                                                              "inputs": {
+                                                                                                "VALUE-0": {
+                                                                                                  "block": {
+                                                                                                    "type": "Number",
+                                                                                                    "id": "}zrwF4|Y7T1D:Js[%;1#",
+                                                                                                    "fields": {
+                                                                                                      "NUM": 3
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              },
+                                                                                              "next": {
+                                                                                                "block": {
+                                                                                                  "type": "UnspawnAllPlayers",
+                                                                                                  "id": "!3%10T|*H;D!|=}2U0hj",
+                                                                                                  "next": {
+                                                                                                    "block": {
+                                                                                                      "type": "EnablePlayerSpawning",
+                                                                                                      "id": "IA:T8=0iS1;Fuyn-2j9%",
+                                                                                                      "inputs": {
+                                                                                                        "VALUE-0": {
+                                                                                                          "block": {
+                                                                                                            "type": "Boolean",
+                                                                                                            "id": "=]TgqI:US3;biMT#R-j3",
+                                                                                                            "fields": {
+                                                                                                              "BOOL": "FALSE"
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      },
+                                                                                                      "next": {
+                                                                                                        "block": {
+                                                                                                          "type": "SetVariable",
+                                                                                                          "id": "N,P!]CIrH.jdN++YQHuK",
+                                                                                                          "inputs": {
+                                                                                                            "VALUE-0": {
+                                                                                                              "block": {
+                                                                                                                "type": "variableReferenceBlock",
+                                                                                                                "id": "fJ4LS,O2_]@U@v.6f}AE",
+                                                                                                                "extraState": {
+                                                                                                                  "isObjectVar": false
+                                                                                                                },
+                                                                                                                "fields": {
+                                                                                                                  "OBJECTTYPE": "Global",
+                                                                                                                  "VAR": {
+                                                                                                                    "id": ";2]y+lLHsxSWFYjcQjhk"
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            },
+                                                                                                            "VALUE-1": {
+                                                                                                              "block": {
+                                                                                                                "type": "Number",
+                                                                                                                "id": "?0XLKZ*,)4#es`-W,|WC",
+                                                                                                                "fields": {
+                                                                                                                  "NUM": 1
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          },
+                                                                                                          "next": {
+                                                                                                            "block": {
+                                                                                                              "type": "subroutineInstanceBlock",
+                                                                                                              "id": "j8vIyg^xQjp.CvgUOX(=",
+                                                                                                              "extraState": {
+                                                                                                                "subroutineName": "MapDetect",
+                                                                                                                "parameters": []
+                                                                                                              },
+                                                                                                              "fields": {
+                                                                                                                "SUBROUTINE_NAME": "MapDetect"
+                                                                                                              },
+                                                                                                              "next": {
+                                                                                                                "block": {
+                                                                                                                  "type": "SetVariable",
+                                                                                                                  "id": "HjVx4N0;`4vbblr-#VV@",
+                                                                                                                  "inputs": {
+                                                                                                                    "VALUE-0": {
+                                                                                                                      "block": {
+                                                                                                                        "type": "variableReferenceBlock",
+                                                                                                                        "id": "j10m_8gXSQG7bW{]Ao7j",
+                                                                                                                        "extraState": {
+                                                                                                                          "isObjectVar": false
+                                                                                                                        },
+                                                                                                                        "fields": {
+                                                                                                                          "OBJECTTYPE": "Global",
+                                                                                                                          "VAR": {
+                                                                                                                            "id": "W?M=066mWT~Tf=[ON!`$"
+                                                                                                                          }
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    },
+                                                                                                                    "VALUE-1": {
+                                                                                                                      "block": {
+                                                                                                                        "type": "GetCapturePoint",
+                                                                                                                        "id": "Q@,mF-V=zYJ:{_0%$kM-",
+                                                                                                                        "inputs": {
+                                                                                                                          "VALUE-0": {
+                                                                                                                            "block": {
+                                                                                                                              "type": "MCOMsItem",
+                                                                                                                              "id": "z+jum4dO5r[t$[;mRpP}",
+                                                                                                                              "fields": {
+                                                                                                                                "VALUE-0": "MCOMs",
+                                                                                                                                "VALUE-1": "C"
+                                                                                                                              }
+                                                                                                                            }
+                                                                                                                          }
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    }
+                                                                                                                  },
+                                                                                                                  "next": {
+                                                                                                                    "block": {
+                                                                                                                      "type": "SetVariable",
+                                                                                                                      "id": "hw+)DYAI=WnwIa2,oWh_",
+                                                                                                                      "inputs": {
+                                                                                                                        "VALUE-0": {
+                                                                                                                          "block": {
+                                                                                                                            "type": "variableReferenceBlock",
+                                                                                                                            "id": "fXYV[J;r0)[s^3)sn5SM",
+                                                                                                                            "extraState": {
+                                                                                                                              "isObjectVar": false
+                                                                                                                            },
+                                                                                                                            "fields": {
+                                                                                                                              "OBJECTTYPE": "Global",
+                                                                                                                              "VAR": {
+                                                                                                                                "id": "ZCBg+S5Y0?xD[@GpnRJ."
+                                                                                                                              }
+                                                                                                                            }
+                                                                                                                          }
+                                                                                                                        },
+                                                                                                                        "VALUE-1": {
+                                                                                                                          "block": {
+                                                                                                                            "type": "GetCapturePoint",
+                                                                                                                            "id": "kH[hm8VOT5;|^,%91;(A",
+                                                                                                                            "inputs": {
+                                                                                                                              "VALUE-0": {
+                                                                                                                                "block": {
+                                                                                                                                  "type": "MCOMsItem",
+                                                                                                                                  "id": "B[w1_2ZEoBM1^!V6!nJE",
+                                                                                                                                  "fields": {
+                                                                                                                                    "VALUE-0": "MCOMs",
+                                                                                                                                    "VALUE-1": "D"
+                                                                                                                                  }
+                                                                                                                                }
+                                                                                                                              }
+                                                                                                                            }
+                                                                                                                          }
+                                                                                                                        }
+                                                                                                                      },
+                                                                                                                      "next": {
+                                                                                                                        "block": {
+                                                                                                                          "type": "subroutineInstanceBlock",
+                                                                                                                          "id": "x2%.vK]Tt/h]:P*{#RB@",
+                                                                                                                          "extraState": {
+                                                                                                                            "subroutineName": "MCOM_Setup",
+                                                                                                                            "parameters": []
+                                                                                                                          },
+                                                                                                                          "fields": {
+                                                                                                                            "SUBROUTINE_NAME": "MCOM_Setup"
+                                                                                                                          },
+                                                                                                                          "next": {
+                                                                                                                            "block": {
+                                                                                                                              "type": "Wait",
+                                                                                                                              "id": "ew?@aW~E9rrNY_h(Gc8+",
+                                                                                                                              "inputs": {
+                                                                                                                                "VALUE-0": {
+                                                                                                                                  "block": {
+                                                                                                                                    "type": "Number",
+                                                                                                                                    "id": "I1p)SKb:6G@*gDrc]zx@",
+                                                                                                                                    "fields": {
+                                                                                                                                      "NUM": 5
+                                                                                                                                    }
+                                                                                                                                  }
+                                                                                                                                }
+                                                                                                                              },
+                                                                                                                              "next": {
+                                                                                                                                "block": {
+                                                                                                                                  "type": "EnablePlayerSpawning",
+                                                                                                                                  "id": "xLC/X5{JUmior[#;rea;",
+                                                                                                                                  "inputs": {
+                                                                                                                                    "VALUE-0": {
+                                                                                                                                      "block": {
+                                                                                                                                        "type": "Boolean",
+                                                                                                                                        "id": "K/$L_Z.#t8x.!D~#b!uE",
+                                                                                                                                        "fields": {
+                                                                                                                                          "BOOL": "TRUE"
+                                                                                                                                        }
+                                                                                                                                      }
+                                                                                                                                    }
+                                                                                                                                  },
+                                                                                                                                  "next": {
+                                                                                                                                    "block": {
+                                                                                                                                      "type": "subroutineInstanceBlock",
+                                                                                                                                      "id": "tvN04M,pK!E,r{e4JcEm",
+                                                                                                                                      "extraState": {
+                                                                                                                                        "subroutineName": "RoundTimer",
+                                                                                                                                        "parameters": []
+                                                                                                                                      },
+                                                                                                                                      "fields": {
+                                                                                                                                        "SUBROUTINE_NAME": "RoundTimer"
+                                                                                                                                      }
+                                                                                                                                    }
+                                                                                                                                  }
+                                                                                                                                }
+                                                                                                                              }
+                                                                                                                            }
+                                                                                                                          }
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      },
+                                                                                      "IF1": {
+                                                                                        "block": {
+                                                                                          "type": "Equals",
+                                                                                          "id": "*%:x/RZGy#YM{egiw0Z^",
+                                                                                          "inputs": {
+                                                                                            "VALUE-0": {
+                                                                                              "block": {
+                                                                                                "type": "GetGamemodeScore",
+                                                                                                "id": "LL|o@IbaB(sB*:%Ri]W{",
+                                                                                                "inputs": {
+                                                                                                  "VALUE-0": {
+                                                                                                    "block": {
+                                                                                                      "type": "GetTeamId",
+                                                                                                      "id": "p!,$tp*@`!^:ZQZx(v^8",
+                                                                                                      "inputs": {
+                                                                                                        "VALUE-0": {
+                                                                                                          "block": {
+                                                                                                            "type": "Number",
+                                                                                                            "id": "Pb9MP~5G+0A|ws!^x_,q",
+                                                                                                            "fields": {
+                                                                                                              "NUM": 2
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            },
+                                                                                            "VALUE-1": {
+                                                                                              "block": {
+                                                                                                "type": "Number",
+                                                                                                "id": "+:7C7Wz7v|I0CnvfSTrt",
+                                                                                                "fields": {
+                                                                                                  "NUM": 0
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      },
+                                                                                      "DO1": {
+                                                                                        "block": {
+                                                                                          "type": "EndRound",
+                                                                                          "id": "oFW2U5u[|gGPIRW]hZ^+",
+                                                                                          "inputs": {
+                                                                                            "VALUE-0": {
+                                                                                              "block": {
+                                                                                                "type": "GetTeamId",
+                                                                                                "id": "a5U#4xz((gz1,/vB.7C2",
+                                                                                                "inputs": {
+                                                                                                  "VALUE-0": {
+                                                                                                    "block": {
+                                                                                                      "type": "Number",
+                                                                                                      "id": "l1t8y_~~c9QC3|h6lkm(",
+                                                                                                      "fields": {
+                                                                                                        "NUM": 1
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
                                                 }
                                               }
                                             }
@@ -603,8 +3807,8 @@
       {
         "type": "subroutineBlock",
         "id": "TKR8L^`ezCu=jaVlWuBF",
-        "x": 1379,
-        "y": 53,
+        "x": 3779,
+        "y": -43,
         "extraState": {
           "subroutineName": "MapDetect",
           "parameters": []
@@ -650,46 +3854,6 @@
                     }
                   }
                 }
-              },
-              "next": {
-                "block": {
-                  "type": "If",
-                  "id": "42Rvn+fo*)$ZXOWX4ao(",
-                  "extraState": {},
-                  "inputs": {
-                    "VALUE-0": {
-                      "block": {
-                        "type": "IsCurrentMap",
-                        "id": "]L/b6!2w02L*SUSBv1`%",
-                        "inputs": {
-                          "VALUE-0": {
-                            "block": {
-                              "type": "MapsItem",
-                              "id": "lA%Wqh/#;nr+cdQ,Y}?_",
-                              "fields": {
-                                "VALUE-0": "Maps",
-                                "VALUE-1": "TheWall"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "DO": {
-                      "block": {
-                        "type": "subroutineInstanceBlock",
-                        "id": "j5@8B:m2St;yM`g|~NWM",
-                        "extraState": {
-                          "subroutineName": "Renewal",
-                          "parameters": []
-                        },
-                        "fields": {
-                          "SUBROUTINE_NAME": "Renewal"
-                        }
-                      }
-                    }
-                  }
-                }
               }
             }
           }
@@ -698,10 +3862,10 @@
       {
         "type": "subroutineBlock",
         "id": "-C/,-xUX#gbm/3Ci.vHe",
-        "x": 3840,
-        "y": -41,
+        "x": 3918,
+        "y": 4173,
         "extraState": {
-          "subroutineName": "Append",
+          "subroutineName": "Team2_HQ_Boundaries",
           "parameters": [
             {
               "types": "Vector",
@@ -710,7 +3874,7 @@
           ]
         },
         "fields": {
-          "SUBROUTINE_NAME": "Append"
+          "SUBROUTINE_NAME": "Team2_HQ_Boundaries"
         },
         "inputs": {
           "ACTIONS": {
@@ -723,12 +3887,31 @@
                     "type": "variableReferenceBlock",
                     "id": "89O4w*-}C)[_y]Y-tHmq",
                     "extraState": {
-                      "isObjectVar": false
+                      "isObjectVar": true
                     },
                     "fields": {
-                      "OBJECTTYPE": "Global",
+                      "OBJECTTYPE": "TeamId",
                       "VAR": {
-                        "id": "(ZHqM}3*6qf%Gv}2bOzk"
+                        "id": "~!s}ovrs?jb7Yd/X[z2!"
+                      }
+                    },
+                    "inputs": {
+                      "OBJECT": {
+                        "block": {
+                          "type": "GetTeamId",
+                          "id": "*=.cTH:%hS;1@FL_jpp,",
+                          "inputs": {
+                            "VALUE-0": {
+                              "block": {
+                                "type": "Number",
+                                "id": "[+[:vaW4y-V;R8i`KxkM",
+                                "fields": {
+                                  "NUM": 2
+                                }
+                              }
+                            }
+                          }
+                        }
                       }
                     }
                   }
@@ -748,12 +3931,31 @@
                                 "type": "variableReferenceBlock",
                                 "id": "sX5uf~{FB2]{`iqb}un#",
                                 "extraState": {
-                                  "isObjectVar": false
+                                  "isObjectVar": true
                                 },
                                 "fields": {
-                                  "OBJECTTYPE": "Global",
+                                  "OBJECTTYPE": "TeamId",
                                   "VAR": {
-                                    "id": "(ZHqM}3*6qf%Gv}2bOzk"
+                                    "id": "~!s}ovrs?jb7Yd/X[z2!"
+                                  }
+                                },
+                                "inputs": {
+                                  "OBJECT": {
+                                    "block": {
+                                      "type": "GetTeamId",
+                                      "id": "/Ng;U*BLi.,Kv$*Tz9*_",
+                                      "inputs": {
+                                        "VALUE-0": {
+                                          "block": {
+                                            "type": "Number",
+                                            "id": "s%gFrG`;C=??frrwG^]#",
+                                            "fields": {
+                                              "NUM": 2
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
                                   }
                                 }
                               }
@@ -781,21 +3983,2753 @@
       {
         "type": "subroutineBlock",
         "id": "+xP2brC[ZHe00`bFc[{+",
-        "x": 2591,
-        "y": 19,
+        "x": 5068,
+        "y": -101,
         "extraState": {
           "subroutineName": "Orbital",
           "parameters": []
         },
         "fields": {
           "SUBROUTINE_NAME": "Orbital"
+        },
+        "inputs": {
+          "ACTIONS": {
+            "block": {
+              "type": "If",
+              "id": "[`wzaW{#b[rbrV(i0.%`",
+              "extraState": {
+                "elseif": 0,
+                "else": 1
+              },
+              "inputs": {
+                "VALUE-0": {
+                  "block": {
+                    "type": "Equals",
+                    "id": "KV7140CT|d2dylWgk4G|",
+                    "inputs": {
+                      "VALUE-0": {
+                        "block": {
+                          "type": "GetVariable",
+                          "id": "U5f_yr/P[T~tIqY-dHqU",
+                          "inputs": {
+                            "VALUE-0": {
+                              "block": {
+                                "type": "variableReferenceBlock",
+                                "id": "AWhQi{0w#93FxX1Zdo?0",
+                                "extraState": {
+                                  "isObjectVar": false
+                                },
+                                "fields": {
+                                  "OBJECTTYPE": "Global",
+                                  "VAR": {
+                                    "id": ";2]y+lLHsxSWFYjcQjhk"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "VALUE-1": {
+                        "block": {
+                          "type": "Number",
+                          "id": "F6Jm,=RzQ*EQnV!2`}nQ",
+                          "fields": {
+                            "NUM": 0
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "DO": {
+                  "block": {
+                    "type": "SetVariable",
+                    "id": "}h0P8xVvVG:MUmIg/Mza",
+                    "inputs": {
+                      "VALUE-0": {
+                        "block": {
+                          "type": "variableReferenceBlock",
+                          "id": "JJNBQYHx|H,AEf#:u?0%",
+                          "extraState": {
+                            "isObjectVar": false
+                          },
+                          "fields": {
+                            "OBJECTTYPE": "Global",
+                            "VAR": {
+                              "id": "avhOM{5IU+T,cbtA-5?M"
+                            }
+                          }
+                        }
+                      },
+                      "VALUE-1": {
+                        "block": {
+                          "type": "EmptyArray",
+                          "id": "A=SNBQ%d`O)Z}-lBO([5"
+                        }
+                      }
+                    },
+                    "next": {
+                      "block": {
+                        "type": "subroutineInstanceBlock",
+                        "id": ":-DXh1:Gtrkf.3cusBAg",
+                        "extraState": {
+                          "subroutineName": "PlayArea",
+                          "parameters": [
+                            {
+                              "types": "Vector",
+                              "name": "Vector"
+                            }
+                          ]
+                        },
+                        "fields": {
+                          "SUBROUTINE_NAME": "PlayArea"
+                        },
+                        "inputs": {
+                          "PARAM-0": {
+                            "block": {
+                              "type": "CreateVector",
+                              "id": "-+=(|L|}sT=i0y3pL{d7",
+                              "inputs": {
+                                "VALUE-0": {
+                                  "block": {
+                                    "type": "Number",
+                                    "id": "NUzaxAvWKF$O;Pk)B[4#",
+                                    "fields": {
+                                      "NUM": -781
+                                    }
+                                  }
+                                },
+                                "VALUE-1": {
+                                  "block": {
+                                    "type": "Number",
+                                    "id": "-v^Z*=m(96H~AYxuf=5G",
+                                    "fields": {
+                                      "NUM": 124
+                                    }
+                                  }
+                                },
+                                "VALUE-2": {
+                                  "block": {
+                                    "type": "Number",
+                                    "id": "*hSpHMuqDF^A5LwQsyl?",
+                                    "fields": {
+                                      "NUM": 1321
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "next": {
+                          "block": {
+                            "type": "subroutineInstanceBlock",
+                            "id": "/[Z7NQd^=uM/5NZbKVG7",
+                            "extraState": {
+                              "subroutineName": "PlayArea",
+                              "parameters": [
+                                {
+                                  "types": "Vector",
+                                  "name": "Vector"
+                                }
+                              ]
+                            },
+                            "fields": {
+                              "SUBROUTINE_NAME": "PlayArea"
+                            },
+                            "inputs": {
+                              "PARAM-0": {
+                                "block": {
+                                  "type": "CreateVector",
+                                  "id": ",)uk_b}:.5#h_QC(L6eM",
+                                  "inputs": {
+                                    "VALUE-0": {
+                                      "block": {
+                                        "type": "Number",
+                                        "id": "|pG3ICt%=@+WeiusgYbN",
+                                        "fields": {
+                                          "NUM": -906
+                                        }
+                                      }
+                                    },
+                                    "VALUE-1": {
+                                      "block": {
+                                        "type": "Number",
+                                        "id": "j[[RBGT~N^LZ`{LqOp[.",
+                                        "fields": {
+                                          "NUM": 127
+                                        }
+                                      }
+                                    },
+                                    "VALUE-2": {
+                                      "block": {
+                                        "type": "Number",
+                                        "id": "|)#$-xiFV}bE,3vcn]N_",
+                                        "fields": {
+                                          "NUM": 1395
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "next": {
+                              "block": {
+                                "type": "subroutineInstanceBlock",
+                                "id": "B;jH{bg*Fq+k81MV{]i-",
+                                "extraState": {
+                                  "subroutineName": "PlayArea",
+                                  "parameters": [
+                                    {
+                                      "types": "Vector",
+                                      "name": "Vector"
+                                    }
+                                  ]
+                                },
+                                "fields": {
+                                  "SUBROUTINE_NAME": "PlayArea"
+                                },
+                                "inputs": {
+                                  "PARAM-0": {
+                                    "block": {
+                                      "type": "CreateVector",
+                                      "id": "Egyx0oMd4I^[}DZV)76]",
+                                      "inputs": {
+                                        "VALUE-0": {
+                                          "block": {
+                                            "type": "Number",
+                                            "id": "f*T%RLH^lDYh8b5-,q%]",
+                                            "fields": {
+                                              "NUM": -839
+                                            }
+                                          }
+                                        },
+                                        "VALUE-1": {
+                                          "block": {
+                                            "type": "Number",
+                                            "id": "GI1FU):CX,z#93r}aoO$",
+                                            "fields": {
+                                              "NUM": 143
+                                            }
+                                          }
+                                        },
+                                        "VALUE-2": {
+                                          "block": {
+                                            "type": "Number",
+                                            "id": "Rc+(+?,9g4T7[_OT:|r|",
+                                            "fields": {
+                                              "NUM": 1617
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "next": {
+                                  "block": {
+                                    "type": "subroutineInstanceBlock",
+                                    "id": "glt|i5Cn5/#6k]X4kcI;",
+                                    "extraState": {
+                                      "subroutineName": "PlayArea",
+                                      "parameters": [
+                                        {
+                                          "types": "Vector",
+                                          "name": "Vector"
+                                        }
+                                      ]
+                                    },
+                                    "fields": {
+                                      "SUBROUTINE_NAME": "PlayArea"
+                                    },
+                                    "inputs": {
+                                      "PARAM-0": {
+                                        "block": {
+                                          "type": "CreateVector",
+                                          "id": "9m)t$2Pcgw0FkY*A#E%!",
+                                          "inputs": {
+                                            "VALUE-0": {
+                                              "block": {
+                                                "type": "Number",
+                                                "id": "AY^?[#gcfA)51SLP,#la",
+                                                "fields": {
+                                                  "NUM": -679
+                                                }
+                                              }
+                                            },
+                                            "VALUE-1": {
+                                              "block": {
+                                                "type": "Number",
+                                                "id": "=j[w*5I##_Vm*BzvW!56",
+                                                "fields": {
+                                                  "NUM": 125.5
+                                                }
+                                              }
+                                            },
+                                            "VALUE-2": {
+                                              "block": {
+                                                "type": "Number",
+                                                "id": "+Ex9^REx8R`Jq2$as2A1",
+                                                "fields": {
+                                                  "NUM": 1599
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "next": {
+                                      "block": {
+                                        "type": "subroutineInstanceBlock",
+                                        "id": "sIn$Z2O:-f!0==dPZ_f5",
+                                        "extraState": {
+                                          "subroutineName": "PlayArea",
+                                          "parameters": [
+                                            {
+                                              "types": "Vector",
+                                              "name": "Vector"
+                                            }
+                                          ]
+                                        },
+                                        "fields": {
+                                          "SUBROUTINE_NAME": "PlayArea"
+                                        },
+                                        "inputs": {
+                                          "PARAM-0": {
+                                            "block": {
+                                              "type": "CreateVector",
+                                              "id": "`M6%{mhy%g@^b.Cfh%2P",
+                                              "inputs": {
+                                                "VALUE-0": {
+                                                  "block": {
+                                                    "type": "Number",
+                                                    "id": "D7UbjS{4-wsiEc3CBck,",
+                                                    "fields": {
+                                                      "NUM": -662
+                                                    }
+                                                  }
+                                                },
+                                                "VALUE-1": {
+                                                  "block": {
+                                                    "type": "Number",
+                                                    "id": "2%%=b7+2cRe+l#U4PP,g",
+                                                    "fields": {
+                                                      "NUM": 122
+                                                    }
+                                                  }
+                                                },
+                                                "VALUE-2": {
+                                                  "block": {
+                                                    "type": "Number",
+                                                    "id": "41VVJ2Pw4rF##{gQ](@N",
+                                                    "fields": {
+                                                      "NUM": 1452
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "next": {
+                                          "block": {
+                                            "type": "SetVariable",
+                                            "id": "UNT|q4L.~]~0S%Amzkz7",
+                                            "inputs": {
+                                              "VALUE-0": {
+                                                "block": {
+                                                  "type": "variableReferenceBlock",
+                                                  "id": "p,QQ#k*o/zPwNG8,)qZc",
+                                                  "extraState": {
+                                                    "isObjectVar": true
+                                                  },
+                                                  "fields": {
+                                                    "OBJECTTYPE": "TeamId",
+                                                    "VAR": {
+                                                      "id": "~!s}ovrs?jb7Yd/X[z2!"
+                                                    }
+                                                  },
+                                                  "inputs": {
+                                                    "OBJECT": {
+                                                      "block": {
+                                                        "type": "GetTeamId",
+                                                        "id": "]-l};xh))YZ0jnJ56zd)",
+                                                        "inputs": {
+                                                          "VALUE-0": {
+                                                            "block": {
+                                                              "type": "Number",
+                                                              "id": "mFg}/Q2hFdh/.PCU5~5Y",
+                                                              "fields": {
+                                                                "NUM": 1
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              },
+                                              "VALUE-1": {
+                                                "block": {
+                                                  "type": "EmptyArray",
+                                                  "id": ";LKv7B(j[nao4n)wT2`U"
+                                                }
+                                              }
+                                            },
+                                            "next": {
+                                              "block": {
+                                                "type": "subroutineInstanceBlock",
+                                                "id": "cosci!3U[C59!+0FQqo4",
+                                                "extraState": {
+                                                  "subroutineName": "Team1_HQ_Boundaries",
+                                                  "parameters": [
+                                                    {
+                                                      "types": "Vector",
+                                                      "name": "Vector"
+                                                    }
+                                                  ]
+                                                },
+                                                "fields": {
+                                                  "SUBROUTINE_NAME": "Team1_HQ_Boundaries"
+                                                },
+                                                "inputs": {
+                                                  "PARAM-0": {
+                                                    "block": {
+                                                      "type": "CreateVector",
+                                                      "id": "dzdO~K/N`h^iV^`{T2W,",
+                                                      "inputs": {
+                                                        "VALUE-0": {
+                                                          "block": {
+                                                            "type": "Number",
+                                                            "id": "vgN87Tci/qi2Vv8OC4Oj",
+                                                            "fields": {
+                                                              "NUM": -781
+                                                            }
+                                                          }
+                                                        },
+                                                        "VALUE-1": {
+                                                          "block": {
+                                                            "type": "Number",
+                                                            "id": "w@I4unSvV6jaKfUq_;_z",
+                                                            "fields": {
+                                                              "NUM": 124
+                                                            }
+                                                          }
+                                                        },
+                                                        "VALUE-2": {
+                                                          "block": {
+                                                            "type": "Number",
+                                                            "id": "5=Proy{n;2y@d^g:#Oo)",
+                                                            "fields": {
+                                                              "NUM": 1321
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "next": {
+                                                  "block": {
+                                                    "type": "subroutineInstanceBlock",
+                                                    "id": "3?9QfA2uAL0li!dlZ(KQ",
+                                                    "extraState": {
+                                                      "subroutineName": "Team1_HQ_Boundaries",
+                                                      "parameters": [
+                                                        {
+                                                          "types": "Vector",
+                                                          "name": "Vector"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "fields": {
+                                                      "SUBROUTINE_NAME": "Team1_HQ_Boundaries"
+                                                    },
+                                                    "inputs": {
+                                                      "PARAM-0": {
+                                                        "block": {
+                                                          "type": "CreateVector",
+                                                          "id": "6j*uzouIW.!/#+qf1vkt",
+                                                          "inputs": {
+                                                            "VALUE-0": {
+                                                              "block": {
+                                                                "type": "Number",
+                                                                "id": "_4%zrtu;{.)z2?C2Hvcm",
+                                                                "fields": {
+                                                                  "NUM": -662
+                                                                }
+                                                              }
+                                                            },
+                                                            "VALUE-1": {
+                                                              "block": {
+                                                                "type": "Number",
+                                                                "id": "qygF4m2WLr=:K[z3%U:J",
+                                                                "fields": {
+                                                                  "NUM": 122
+                                                                }
+                                                              }
+                                                            },
+                                                            "VALUE-2": {
+                                                              "block": {
+                                                                "type": "Number",
+                                                                "id": "-laIEK}ws7AiuD8kL4n}",
+                                                                "fields": {
+                                                                  "NUM": 1452
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    },
+                                                    "next": {
+                                                      "block": {
+                                                        "type": "subroutineInstanceBlock",
+                                                        "id": "#;*@!)Aru))%uUY-)|BO",
+                                                        "extraState": {
+                                                          "subroutineName": "Team1_HQ_Boundaries",
+                                                          "parameters": [
+                                                            {
+                                                              "types": "Vector",
+                                                              "name": "Vector"
+                                                            }
+                                                          ]
+                                                        },
+                                                        "fields": {
+                                                          "SUBROUTINE_NAME": "Team1_HQ_Boundaries"
+                                                        },
+                                                        "inputs": {
+                                                          "PARAM-0": {
+                                                            "block": {
+                                                              "type": "CreateVector",
+                                                              "id": "6`s-Jg2tI4h0pMzL%^lj",
+                                                              "inputs": {
+                                                                "VALUE-0": {
+                                                                  "block": {
+                                                                    "type": "Number",
+                                                                    "id": "Dx/m;5c.,@A)J7e^:Lty",
+                                                                    "fields": {
+                                                                      "NUM": -547
+                                                                    }
+                                                                  }
+                                                                },
+                                                                "VALUE-1": {
+                                                                  "block": {
+                                                                    "type": "Number",
+                                                                    "id": "zZ|xf5u4kyYf7l_:be@~",
+                                                                    "fields": {
+                                                                      "NUM": 118
+                                                                    }
+                                                                  }
+                                                                },
+                                                                "VALUE-2": {
+                                                                  "block": {
+                                                                    "type": "Number",
+                                                                    "id": "?4v[wnT{R(vHg)~swu77",
+                                                                    "fields": {
+                                                                      "NUM": 1385
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        },
+                                                        "next": {
+                                                          "block": {
+                                                            "type": "subroutineInstanceBlock",
+                                                            "id": "w|b4v)N.RbWDTq69`C*J",
+                                                            "extraState": {
+                                                              "subroutineName": "Team1_HQ_Boundaries",
+                                                              "parameters": [
+                                                                {
+                                                                  "types": "Vector",
+                                                                  "name": "Vector"
+                                                                }
+                                                              ]
+                                                            },
+                                                            "fields": {
+                                                              "SUBROUTINE_NAME": "Team1_HQ_Boundaries"
+                                                            },
+                                                            "inputs": {
+                                                              "PARAM-0": {
+                                                                "block": {
+                                                                  "type": "CreateVector",
+                                                                  "id": "Cql$8h]27o+hCuhqcjLg",
+                                                                  "inputs": {
+                                                                    "VALUE-0": {
+                                                                      "block": {
+                                                                        "type": "Number",
+                                                                        "id": "NON(KyxK=(#OH|}#:gQi",
+                                                                        "fields": {
+                                                                          "NUM": -606
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    "VALUE-1": {
+                                                                      "block": {
+                                                                        "type": "Number",
+                                                                        "id": "Ce%znV]G[fBi#hqbN+U]",
+                                                                        "fields": {
+                                                                          "NUM": 161
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    "VALUE-2": {
+                                                                      "block": {
+                                                                        "type": "Number",
+                                                                        "id": "ELO{vpgUX1GCJyV~WlL3",
+                                                                        "fields": {
+                                                                          "NUM": 1224
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            },
+                                                            "next": {
+                                                              "block": {
+                                                                "type": "subroutineInstanceBlock",
+                                                                "id": "+x@k!=KG@zG5uC6KQKj-",
+                                                                "extraState": {
+                                                                  "subroutineName": "Team1_HQ_Boundaries",
+                                                                  "parameters": [
+                                                                    {
+                                                                      "types": "Vector",
+                                                                      "name": "Vector"
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                "fields": {
+                                                                  "SUBROUTINE_NAME": "Team1_HQ_Boundaries"
+                                                                },
+                                                                "inputs": {
+                                                                  "PARAM-0": {
+                                                                    "block": {
+                                                                      "type": "CreateVector",
+                                                                      "id": "~QYKY,%T0.=nk?QU@)um",
+                                                                      "inputs": {
+                                                                        "VALUE-0": {
+                                                                          "block": {
+                                                                            "type": "Number",
+                                                                            "id": "GbM_8Aam]9t2oIk5?!N/",
+                                                                            "fields": {
+                                                                              "NUM": -775
+                                                                            }
+                                                                          }
+                                                                        },
+                                                                        "VALUE-1": {
+                                                                          "block": {
+                                                                            "type": "Number",
+                                                                            "id": "8vJd08QP*2Q^N/HwGu_P",
+                                                                            "fields": {
+                                                                              "NUM": 139
+                                                                            }
+                                                                          }
+                                                                        },
+                                                                        "VALUE-2": {
+                                                                          "block": {
+                                                                            "type": "Number",
+                                                                            "id": ".mJqH}TiU3f~shqMxceT",
+                                                                            "fields": {
+                                                                              "NUM": 1193
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                },
+                                                                "next": {
+                                                                  "block": {
+                                                                    "type": "SetVariable",
+                                                                    "id": "S`V`Vzc%`zh~(ue(Am}t",
+                                                                    "inputs": {
+                                                                      "VALUE-0": {
+                                                                        "block": {
+                                                                          "type": "variableReferenceBlock",
+                                                                          "id": "@,:*(.w~,7QXQFS|Etep",
+                                                                          "extraState": {
+                                                                            "isObjectVar": true
+                                                                          },
+                                                                          "fields": {
+                                                                            "OBJECTTYPE": "TeamId",
+                                                                            "VAR": {
+                                                                              "id": "~!s}ovrs?jb7Yd/X[z2!"
+                                                                            }
+                                                                          },
+                                                                          "inputs": {
+                                                                            "OBJECT": {
+                                                                              "block": {
+                                                                                "type": "GetTeamId",
+                                                                                "id": "**)tr`[SDi#F7tpsXj^)",
+                                                                                "inputs": {
+                                                                                  "VALUE-0": {
+                                                                                    "block": {
+                                                                                      "type": "Number",
+                                                                                      "id": "Bq`{s[NpDoh^)hYv%~#;",
+                                                                                      "fields": {
+                                                                                        "NUM": 2
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      },
+                                                                      "VALUE-1": {
+                                                                        "block": {
+                                                                          "type": "EmptyArray",
+                                                                          "id": "S?%TEgWC4`o0}*Sm0Klo"
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    "next": {
+                                                                      "block": {
+                                                                        "type": "subroutineInstanceBlock",
+                                                                        "id": "F?-Z.f]An:KuX}tdU_v;",
+                                                                        "extraState": {
+                                                                          "subroutineName": "Team2_HQ_Boundaries",
+                                                                          "parameters": [
+                                                                            {
+                                                                              "types": "Vector",
+                                                                              "name": "Vector"
+                                                                            }
+                                                                          ]
+                                                                        },
+                                                                        "fields": {
+                                                                          "SUBROUTINE_NAME": "Team2_HQ_Boundaries"
+                                                                        },
+                                                                        "inputs": {
+                                                                          "PARAM-0": {
+                                                                            "block": {
+                                                                              "type": "CreateVector",
+                                                                              "id": "mnDr$T:f1`DjO(DFr`_,",
+                                                                              "inputs": {
+                                                                                "VALUE-0": {
+                                                                                  "block": {
+                                                                                    "type": "Number",
+                                                                                    "id": "H%PA*?-|Zh?L!as}t~k%",
+                                                                                    "fields": {
+                                                                                      "NUM": -906
+                                                                                    }
+                                                                                  }
+                                                                                },
+                                                                                "VALUE-1": {
+                                                                                  "block": {
+                                                                                    "type": "Number",
+                                                                                    "id": "CtBmUNC-stAZT=#174IP",
+                                                                                    "fields": {
+                                                                                      "NUM": 127
+                                                                                    }
+                                                                                  }
+                                                                                },
+                                                                                "VALUE-2": {
+                                                                                  "block": {
+                                                                                    "type": "Number",
+                                                                                    "id": "t(6-Hj|aR0lVXB2TEzQS",
+                                                                                    "fields": {
+                                                                                      "NUM": 1395
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        },
+                                                                        "next": {
+                                                                          "block": {
+                                                                            "type": "subroutineInstanceBlock",
+                                                                            "id": "VA[7Qyc15wWZ3fRh6QAP",
+                                                                            "extraState": {
+                                                                              "subroutineName": "Team2_HQ_Boundaries",
+                                                                              "parameters": [
+                                                                                {
+                                                                                  "types": "Vector",
+                                                                                  "name": "Vector"
+                                                                                }
+                                                                              ]
+                                                                            },
+                                                                            "fields": {
+                                                                              "SUBROUTINE_NAME": "Team2_HQ_Boundaries"
+                                                                            },
+                                                                            "inputs": {
+                                                                              "PARAM-0": {
+                                                                                "block": {
+                                                                                  "type": "CreateVector",
+                                                                                  "id": ")_BFiN!/fag,1-E~{|Lw",
+                                                                                  "inputs": {
+                                                                                    "VALUE-0": {
+                                                                                      "block": {
+                                                                                        "type": "Number",
+                                                                                        "id": "kep*1v1?bpM+.8Evw/de",
+                                                                                        "fields": {
+                                                                                          "NUM": -1119
+                                                                                        }
+                                                                                      }
+                                                                                    },
+                                                                                    "VALUE-1": {
+                                                                                      "block": {
+                                                                                        "type": "Number",
+                                                                                        "id": "7#WtO;m#lT,#0e;nhJM!",
+                                                                                        "fields": {
+                                                                                          "NUM": 218
+                                                                                        }
+                                                                                      }
+                                                                                    },
+                                                                                    "VALUE-2": {
+                                                                                      "block": {
+                                                                                        "type": "Number",
+                                                                                        "id": "isk6D=?m0S^7Q*rrkF2Z",
+                                                                                        "fields": {
+                                                                                          "NUM": 1579
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            },
+                                                                            "next": {
+                                                                              "block": {
+                                                                                "type": "subroutineInstanceBlock",
+                                                                                "id": "6,OV^u:|h@-GJ!XWx]Ya",
+                                                                                "extraState": {
+                                                                                  "subroutineName": "Team2_HQ_Boundaries",
+                                                                                  "parameters": [
+                                                                                    {
+                                                                                      "types": "Vector",
+                                                                                      "name": "Vector"
+                                                                                    }
+                                                                                  ]
+                                                                                },
+                                                                                "fields": {
+                                                                                  "SUBROUTINE_NAME": "Team2_HQ_Boundaries"
+                                                                                },
+                                                                                "inputs": {
+                                                                                  "PARAM-0": {
+                                                                                    "block": {
+                                                                                      "type": "CreateVector",
+                                                                                      "id": "^5+b^/?*xwPHcT4p%ws[",
+                                                                                      "inputs": {
+                                                                                        "VALUE-0": {
+                                                                                          "block": {
+                                                                                            "type": "Number",
+                                                                                            "id": "tHHB5~b#Q.=AT_9}s^jH",
+                                                                                            "fields": {
+                                                                                              "NUM": -1041
+                                                                                            }
+                                                                                          }
+                                                                                        },
+                                                                                        "VALUE-1": {
+                                                                                          "block": {
+                                                                                            "type": "Number",
+                                                                                            "id": "K]UeBE07tIQ{6-)RO~nK",
+                                                                                            "fields": {
+                                                                                              "NUM": 190
+                                                                                            }
+                                                                                          }
+                                                                                        },
+                                                                                        "VALUE-2": {
+                                                                                          "block": {
+                                                                                            "type": "Number",
+                                                                                            "id": "Z)QY[?SrQP!*f%;t)dNH",
+                                                                                            "fields": {
+                                                                                              "NUM": 1824
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                },
+                                                                                "next": {
+                                                                                  "block": {
+                                                                                    "type": "subroutineInstanceBlock",
+                                                                                    "id": "$V[J=1P0BD0h14mYT3%I",
+                                                                                    "extraState": {
+                                                                                      "subroutineName": "Team2_HQ_Boundaries",
+                                                                                      "parameters": [
+                                                                                        {
+                                                                                          "types": "Vector",
+                                                                                          "name": "Vector"
+                                                                                        }
+                                                                                      ]
+                                                                                    },
+                                                                                    "fields": {
+                                                                                      "SUBROUTINE_NAME": "Team2_HQ_Boundaries"
+                                                                                    },
+                                                                                    "inputs": {
+                                                                                      "PARAM-0": {
+                                                                                        "block": {
+                                                                                          "type": "CreateVector",
+                                                                                          "id": "M_08,m`}`p+!v1hUYc06",
+                                                                                          "inputs": {
+                                                                                            "VALUE-0": {
+                                                                                              "block": {
+                                                                                                "type": "Number",
+                                                                                                "id": "i7rTk{IX1=Pu};uzXn=#",
+                                                                                                "fields": {
+                                                                                                  "NUM": -839
+                                                                                                }
+                                                                                              }
+                                                                                            },
+                                                                                            "VALUE-1": {
+                                                                                              "block": {
+                                                                                                "type": "Number",
+                                                                                                "id": "UQ*?qV0p^4?:yfz11:Cl",
+                                                                                                "fields": {
+                                                                                                  "NUM": 143
+                                                                                                }
+                                                                                              }
+                                                                                            },
+                                                                                            "VALUE-2": {
+                                                                                              "block": {
+                                                                                                "type": "Number",
+                                                                                                "id": "3~D)}l!qbad7b0xo::/K",
+                                                                                                "fields": {
+                                                                                                  "NUM": 1617
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    },
+                                                                                    "next": {
+                                                                                      "block": {
+                                                                                        "type": "SetVariable",
+                                                                                        "id": "kiM(M}+2}~yoCG[CWk_L",
+                                                                                        "inputs": {
+                                                                                          "VALUE-0": {
+                                                                                            "block": {
+                                                                                              "type": "variableReferenceBlock",
+                                                                                              "id": "`9Qhs4gqR4iCm=(f5DU4",
+                                                                                              "extraState": {
+                                                                                                "isObjectVar": true
+                                                                                              },
+                                                                                              "fields": {
+                                                                                                "OBJECTTYPE": "TeamId",
+                                                                                                "VAR": {
+                                                                                                  "id": ")85N/!w[yu2n1i{J:kG%"
+                                                                                                }
+                                                                                              },
+                                                                                              "inputs": {
+                                                                                                "OBJECT": {
+                                                                                                  "block": {
+                                                                                                    "type": "GetTeamId",
+                                                                                                    "id": "uNTR}L-*`GzhAv-Eu%#:",
+                                                                                                    "inputs": {
+                                                                                                      "VALUE-0": {
+                                                                                                        "block": {
+                                                                                                          "type": "Number",
+                                                                                                          "id": "521W]wa#4*;qSHC.fG`T",
+                                                                                                          "fields": {
+                                                                                                            "NUM": 1
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          },
+                                                                                          "VALUE-1": {
+                                                                                            "block": {
+                                                                                              "type": "CreateVector",
+                                                                                              "id": ",c3[YrN31PBo#~W_0IQY",
+                                                                                              "inputs": {
+                                                                                                "VALUE-0": {
+                                                                                                  "block": {
+                                                                                                    "type": "Number",
+                                                                                                    "id": ";-.#-rXDAX0E:H$s4}cF",
+                                                                                                    "fields": {
+                                                                                                      "NUM": -692.5
+                                                                                                    }
+                                                                                                  }
+                                                                                                },
+                                                                                                "VALUE-1": {
+                                                                                                  "block": {
+                                                                                                    "type": "Number",
+                                                                                                    "id": "e55WfJ~B?zp:dYeDb`L4",
+                                                                                                    "fields": {
+                                                                                                      "NUM": 113
+                                                                                                    }
+                                                                                                  }
+                                                                                                },
+                                                                                                "VALUE-2": {
+                                                                                                  "block": {
+                                                                                                    "type": "Number",
+                                                                                                    "id": "-I5+~=Y9#?Vy`S)uiI5A",
+                                                                                                    "fields": {
+                                                                                                      "NUM": 1259
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        },
+                                                                                        "next": {
+                                                                                          "block": {
+                                                                                            "type": "SetVariable",
+                                                                                            "id": "v#8XNd;},QR?kGI]i:i=",
+                                                                                            "inputs": {
+                                                                                              "VALUE-0": {
+                                                                                                "block": {
+                                                                                                  "type": "variableReferenceBlock",
+                                                                                                  "id": "]./TKwQ}QOQhivu=4/w#",
+                                                                                                  "extraState": {
+                                                                                                    "isObjectVar": true
+                                                                                                  },
+                                                                                                  "fields": {
+                                                                                                    "OBJECTTYPE": "TeamId",
+                                                                                                    "VAR": {
+                                                                                                      "id": ")85N/!w[yu2n1i{J:kG%"
+                                                                                                    }
+                                                                                                  },
+                                                                                                  "inputs": {
+                                                                                                    "OBJECT": {
+                                                                                                      "block": {
+                                                                                                        "type": "GetTeamId",
+                                                                                                        "id": "X=N8ZDz`zTPTnZ=b(xt^",
+                                                                                                        "inputs": {
+                                                                                                          "VALUE-0": {
+                                                                                                            "block": {
+                                                                                                              "type": "Number",
+                                                                                                              "id": "P=BV`s_oqVf3:|C0M_43",
+                                                                                                              "fields": {
+                                                                                                                "NUM": 2
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              },
+                                                                                              "VALUE-1": {
+                                                                                                "block": {
+                                                                                                  "type": "CreateVector",
+                                                                                                  "id": "FNO3*fk@y}Aa0.~9w6{o",
+                                                                                                  "inputs": {
+                                                                                                    "VALUE-0": {
+                                                                                                      "block": {
+                                                                                                        "type": "Number",
+                                                                                                        "id": "~X.a@@FWZvdoj^i)4r}M",
+                                                                                                        "fields": {
+                                                                                                          "NUM": -961.4
+                                                                                                        }
+                                                                                                      }
+                                                                                                    },
+                                                                                                    "VALUE-1": {
+                                                                                                      "block": {
+                                                                                                        "type": "Number",
+                                                                                                        "id": "l65o{E!/!$Q)~1Uv[C7a",
+                                                                                                        "fields": {
+                                                                                                          "NUM": 109.9
+                                                                                                        }
+                                                                                                      }
+                                                                                                    },
+                                                                                                    "VALUE-2": {
+                                                                                                      "block": {
+                                                                                                        "type": "Number",
+                                                                                                        "id": "VXeqS2Th{t*/~D[e`JF[",
+                                                                                                        "fields": {
+                                                                                                          "NUM": 1571.4
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            },
+                                                                                            "next": {
+                                                                                              "block": {
+                                                                                                "type": "SetVariable",
+                                                                                                "id": "S+rl_7OMNgf2qks{Qe3a",
+                                                                                                "inputs": {
+                                                                                                  "VALUE-0": {
+                                                                                                    "block": {
+                                                                                                      "type": "variableReferenceBlock",
+                                                                                                      "id": "j*mO5L#vezZXX[NybFZe",
+                                                                                                      "extraState": {
+                                                                                                        "isObjectVar": false
+                                                                                                      },
+                                                                                                      "fields": {
+                                                                                                        "OBJECTTYPE": "Global",
+                                                                                                        "VAR": {
+                                                                                                          "id": "]dWwQ+kkD!f)85rwAEAQ"
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  },
+                                                                                                  "VALUE-1": {
+                                                                                                    "block": {
+                                                                                                      "type": "CreateVector",
+                                                                                                      "id": "{AekFd(+z;zfh25w=Dds",
+                                                                                                      "inputs": {
+                                                                                                        "VALUE-0": {
+                                                                                                          "block": {
+                                                                                                            "type": "Number",
+                                                                                                            "id": "qH2YAE2)-nQBs|q%dVh;",
+                                                                                                            "fields": {
+                                                                                                              "NUM": -739.9
+                                                                                                            }
+                                                                                                          }
+                                                                                                        },
+                                                                                                        "VALUE-1": {
+                                                                                                          "block": {
+                                                                                                            "type": "Number",
+                                                                                                            "id": "ijd(dN_#u;,VR/A@2^lI",
+                                                                                                            "fields": {
+                                                                                                              "NUM": 102.1
+                                                                                                            }
+                                                                                                          }
+                                                                                                        },
+                                                                                                        "VALUE-2": {
+                                                                                                          "block": {
+                                                                                                            "type": "Number",
+                                                                                                            "id": "8o:r$#fMd6F;$}qigJmM",
+                                                                                                            "fields": {
+                                                                                                              "NUM": 1434.5
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                },
+                                                                                                "next": {
+                                                                                                  "block": {
+                                                                                                    "type": "SetVariable",
+                                                                                                    "id": "!mA5:c3Eyt8y8fG3ekA9",
+                                                                                                    "inputs": {
+                                                                                                      "VALUE-0": {
+                                                                                                        "block": {
+                                                                                                          "type": "variableReferenceBlock",
+                                                                                                          "id": "~-99c:{.|fy1)xy;d*^t",
+                                                                                                          "extraState": {
+                                                                                                            "isObjectVar": false
+                                                                                                          },
+                                                                                                          "fields": {
+                                                                                                            "OBJECTTYPE": "Global",
+                                                                                                            "VAR": {
+                                                                                                              "id": "eF$rR9X[_su_hNxhGZ`R"
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      },
+                                                                                                      "VALUE-1": {
+                                                                                                        "block": {
+                                                                                                          "type": "Number",
+                                                                                                          "id": "TNu|RKvr=5kIlRP,`23X",
+                                                                                                          "fields": {
+                                                                                                            "NUM": 1.43
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    },
+                                                                                                    "next": {
+                                                                                                      "block": {
+                                                                                                        "type": "SetVariable",
+                                                                                                        "id": "@0a(J62lTsreFMTzkmz{",
+                                                                                                        "inputs": {
+                                                                                                          "VALUE-0": {
+                                                                                                            "block": {
+                                                                                                              "type": "variableReferenceBlock",
+                                                                                                              "id": "ag.`m@sQoxDcS:^G;2T/",
+                                                                                                              "extraState": {
+                                                                                                                "isObjectVar": false
+                                                                                                              },
+                                                                                                              "fields": {
+                                                                                                                "OBJECTTYPE": "Global",
+                                                                                                                "VAR": {
+                                                                                                                  "id": "s;)yD}A?@5f!E58$,z[c"
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          },
+                                                                                                          "VALUE-1": {
+                                                                                                            "block": {
+                                                                                                              "type": "CreateVector",
+                                                                                                              "id": "z/eNuL9VE*yNy7xYW-0e",
+                                                                                                              "inputs": {
+                                                                                                                "VALUE-0": {
+                                                                                                                  "block": {
+                                                                                                                    "type": "Number",
+                                                                                                                    "id": "W:d$j9)T7.J5/qMu$/$u",
+                                                                                                                    "fields": {
+                                                                                                                      "NUM": -828.6
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                },
+                                                                                                                "VALUE-1": {
+                                                                                                                  "block": {
+                                                                                                                    "type": "Number",
+                                                                                                                    "id": "PVQ}o)EJF}@ve$IV5QF6",
+                                                                                                                    "fields": {
+                                                                                                                      "NUM": 121.55
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                },
+                                                                                                                "VALUE-2": {
+                                                                                                                  "block": {
+                                                                                                                    "type": "Number",
+                                                                                                                    "id": "b~bXXL]hBFus_UaVgI/M",
+                                                                                                                    "fields": {
+                                                                                                                      "NUM": 1508.9
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        },
+                                                                                                        "next": {
+                                                                                                          "block": {
+                                                                                                            "type": "SetVariable",
+                                                                                                            "id": "qq3WBO2BBv#nccQVR8^q",
+                                                                                                            "inputs": {
+                                                                                                              "VALUE-0": {
+                                                                                                                "block": {
+                                                                                                                  "type": "variableReferenceBlock",
+                                                                                                                  "id": "oD*G$/YJYPNY+Vq6(si8",
+                                                                                                                  "extraState": {
+                                                                                                                    "isObjectVar": false
+                                                                                                                  },
+                                                                                                                  "fields": {
+                                                                                                                    "OBJECTTYPE": "Global",
+                                                                                                                    "VAR": {
+                                                                                                                      "id": "x8Nn45#O(#5EaIGY=`@u"
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              },
+                                                                                                              "VALUE-1": {
+                                                                                                                "block": {
+                                                                                                                  "type": "Number",
+                                                                                                                  "id": "obKC,)/ZO]db%;Ah%cxT",
+                                                                                                                  "fields": {
+                                                                                                                    "NUM": 1.1
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "ELSE": {
+                  "block": {
+                    "type": "SetVariable",
+                    "id": "8MM.ZhLq5}FF9t7op$}P",
+                    "inputs": {
+                      "VALUE-0": {
+                        "block": {
+                          "type": "variableReferenceBlock",
+                          "id": "xOyMWDIrUofO{4h}NI7:",
+                          "extraState": {
+                            "isObjectVar": false
+                          },
+                          "fields": {
+                            "OBJECTTYPE": "Global",
+                            "VAR": {
+                              "id": "avhOM{5IU+T,cbtA-5?M"
+                            }
+                          }
+                        }
+                      },
+                      "VALUE-1": {
+                        "block": {
+                          "type": "EmptyArray",
+                          "id": "N{F#*I?(2LeV{7`iN.8("
+                        }
+                      }
+                    },
+                    "next": {
+                      "block": {
+                        "type": "subroutineInstanceBlock",
+                        "id": "Q}A,n,Fft[Q+@K?Wr-Y-",
+                        "extraState": {
+                          "subroutineName": "PlayArea",
+                          "parameters": [
+                            {
+                              "types": "Vector",
+                              "name": "Vector"
+                            }
+                          ]
+                        },
+                        "fields": {
+                          "SUBROUTINE_NAME": "PlayArea"
+                        },
+                        "inputs": {
+                          "PARAM-0": {
+                            "block": {
+                              "type": "CreateVector",
+                              "id": "?8|kE~gu+Uc|CBdG`8oJ",
+                              "inputs": {
+                                "VALUE-0": {
+                                  "block": {
+                                    "type": "Number",
+                                    "id": "VME`9`R{S#D,gD(Y}?8n",
+                                    "fields": {
+                                      "NUM": -431.5
+                                    }
+                                  }
+                                },
+                                "VALUE-1": {
+                                  "block": {
+                                    "type": "Number",
+                                    "id": "=2w.IQ52aXS`/kAJlIgP",
+                                    "fields": {
+                                      "NUM": 164.5
+                                    }
+                                  }
+                                },
+                                "VALUE-2": {
+                                  "block": {
+                                    "type": "Number",
+                                    "id": "Z?-4^=4_~9jeI[@Vf:Oz",
+                                    "fields": {
+                                      "NUM": 454.4
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "next": {
+                          "block": {
+                            "type": "subroutineInstanceBlock",
+                            "id": "UNaoQ;mAzr!.qt=smO,]",
+                            "extraState": {
+                              "subroutineName": "PlayArea",
+                              "parameters": [
+                                {
+                                  "types": "Vector",
+                                  "name": "Vector"
+                                }
+                              ]
+                            },
+                            "fields": {
+                              "SUBROUTINE_NAME": "PlayArea"
+                            },
+                            "inputs": {
+                              "PARAM-0": {
+                                "block": {
+                                  "type": "CreateVector",
+                                  "id": "},GNE`66e}TG*)Fb9lJ?",
+                                  "inputs": {
+                                    "VALUE-0": {
+                                      "block": {
+                                        "type": "Number",
+                                        "id": "Yp*x6#^?0x_lW,o)+tm%",
+                                        "fields": {
+                                          "NUM": -332.6
+                                        }
+                                      }
+                                    },
+                                    "VALUE-1": {
+                                      "block": {
+                                        "type": "Number",
+                                        "id": "#9W2uZR9o$DQhB9{}aK.",
+                                        "fields": {
+                                          "NUM": 164.9
+                                        }
+                                      }
+                                    },
+                                    "VALUE-2": {
+                                      "block": {
+                                        "type": "Number",
+                                        "id": "g1ISn:X(fp$1DeJJ/pyA",
+                                        "fields": {
+                                          "NUM": 420.5
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "next": {
+                              "block": {
+                                "type": "subroutineInstanceBlock",
+                                "id": "~9Q}Rvlhm+y7Pi$WkdxD",
+                                "extraState": {
+                                  "subroutineName": "PlayArea",
+                                  "parameters": [
+                                    {
+                                      "types": "Vector",
+                                      "name": "Vector"
+                                    }
+                                  ]
+                                },
+                                "fields": {
+                                  "SUBROUTINE_NAME": "PlayArea"
+                                },
+                                "inputs": {
+                                  "PARAM-0": {
+                                    "block": {
+                                      "type": "CreateVector",
+                                      "id": "ZH)YD:({n7bI(Om|OT?w",
+                                      "inputs": {
+                                        "VALUE-0": {
+                                          "block": {
+                                            "type": "Number",
+                                            "id": "Jsq~C-b^WwWck4Xq-R%K",
+                                            "fields": {
+                                              "NUM": -280
+                                            }
+                                          }
+                                        },
+                                        "VALUE-1": {
+                                          "block": {
+                                            "type": "Number",
+                                            "id": "i/,#uiG1C7_jB1,4iHP?",
+                                            "fields": {
+                                              "NUM": 150.7
+                                            }
+                                          }
+                                        },
+                                        "VALUE-2": {
+                                          "block": {
+                                            "type": "Number",
+                                            "id": "$/ok?Z^}2-E:L3%y@wqF",
+                                            "fields": {
+                                              "NUM": 374
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "next": {
+                                  "block": {
+                                    "type": "subroutineInstanceBlock",
+                                    "id": "8vZ3eh#/Ml9cz(6Eg+YH",
+                                    "extraState": {
+                                      "subroutineName": "PlayArea",
+                                      "parameters": [
+                                        {
+                                          "types": "Vector",
+                                          "name": "Vector"
+                                        }
+                                      ]
+                                    },
+                                    "fields": {
+                                      "SUBROUTINE_NAME": "PlayArea"
+                                    },
+                                    "inputs": {
+                                      "PARAM-0": {
+                                        "block": {
+                                          "type": "CreateVector",
+                                          "id": "Nxp*e5Q9fI4k8NV0~;+i",
+                                          "inputs": {
+                                            "VALUE-0": {
+                                              "block": {
+                                                "type": "Number",
+                                                "id": "ndSQj_g%Vhsu[Kod:vCQ",
+                                                "fields": {
+                                                  "NUM": -326
+                                                }
+                                              }
+                                            },
+                                            "VALUE-1": {
+                                              "block": {
+                                                "type": "Number",
+                                                "id": "8.A.;j@x*KN8~7boizNO",
+                                                "fields": {
+                                                  "NUM": 157
+                                                }
+                                              }
+                                            },
+                                            "VALUE-2": {
+                                              "block": {
+                                                "type": "Number",
+                                                "id": "=sixy`5bdvc43^+(;6PE",
+                                                "fields": {
+                                                  "NUM": 268.9
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "next": {
+                                      "block": {
+                                        "type": "subroutineInstanceBlock",
+                                        "id": "E%}#JxfoV*KqoyU%I;q/",
+                                        "extraState": {
+                                          "subroutineName": "PlayArea",
+                                          "parameters": [
+                                            {
+                                              "types": "Vector",
+                                              "name": "Vector"
+                                            }
+                                          ]
+                                        },
+                                        "fields": {
+                                          "SUBROUTINE_NAME": "PlayArea"
+                                        },
+                                        "inputs": {
+                                          "PARAM-0": {
+                                            "block": {
+                                              "type": "CreateVector",
+                                              "id": "pB90%}$Zz{u`YP*k1CTw",
+                                              "inputs": {
+                                                "VALUE-0": {
+                                                  "block": {
+                                                    "type": "Number",
+                                                    "id": "6nKv*R:k#6%-CF:SNXk3",
+                                                    "fields": {
+                                                      "NUM": -366.5
+                                                    }
+                                                  }
+                                                },
+                                                "VALUE-1": {
+                                                  "block": {
+                                                    "type": "Number",
+                                                    "id": "%!YX;YpM?/{t|yF14vYh",
+                                                    "fields": {
+                                                      "NUM": 165.7
+                                                    }
+                                                  }
+                                                },
+                                                "VALUE-2": {
+                                                  "block": {
+                                                    "type": "Number",
+                                                    "id": "nUNr`6NDv)$#j2E~*:#x",
+                                                    "fields": {
+                                                      "NUM": 226
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "next": {
+                                          "block": {
+                                            "type": "subroutineInstanceBlock",
+                                            "id": "g/VokI3h54*5a/ogty}%",
+                                            "extraState": {
+                                              "subroutineName": "PlayArea",
+                                              "parameters": [
+                                                {
+                                                  "types": "Vector",
+                                                  "name": "Vector"
+                                                }
+                                              ]
+                                            },
+                                            "fields": {
+                                              "SUBROUTINE_NAME": "PlayArea"
+                                            },
+                                            "inputs": {
+                                              "PARAM-0": {
+                                                "block": {
+                                                  "type": "CreateVector",
+                                                  "id": "U|JRW]p]S|NL_T=:8uHR",
+                                                  "inputs": {
+                                                    "VALUE-0": {
+                                                      "block": {
+                                                        "type": "Number",
+                                                        "id": "e]a;qfFR2LiB%aAo?RqV",
+                                                        "fields": {
+                                                          "NUM": -418.9
+                                                        }
+                                                      }
+                                                    },
+                                                    "VALUE-1": {
+                                                      "block": {
+                                                        "type": "Number",
+                                                        "id": "ZGZlH.cv=/V|vi,SV})$",
+                                                        "fields": {
+                                                          "NUM": 171.3
+                                                        }
+                                                      }
+                                                    },
+                                                    "VALUE-2": {
+                                                      "block": {
+                                                        "type": "Number",
+                                                        "id": ")fBu$vO$~3$-eNFu6W0!",
+                                                        "fields": {
+                                                          "NUM": 257.5
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "next": {
+                                              "block": {
+                                                "type": "subroutineInstanceBlock",
+                                                "id": "YPp`tA1LH:XzV#3u|uWr",
+                                                "extraState": {
+                                                  "subroutineName": "PlayArea",
+                                                  "parameters": [
+                                                    {
+                                                      "types": "Vector",
+                                                      "name": "Vector"
+                                                    }
+                                                  ]
+                                                },
+                                                "fields": {
+                                                  "SUBROUTINE_NAME": "PlayArea"
+                                                },
+                                                "inputs": {
+                                                  "PARAM-0": {
+                                                    "block": {
+                                                      "type": "CreateVector",
+                                                      "id": "pU%iwcDcN(9JF7E@yubc",
+                                                      "inputs": {
+                                                        "VALUE-0": {
+                                                          "block": {
+                                                            "type": "Number",
+                                                            "id": "oLo(53o4VFHsq8=3rh_2",
+                                                            "fields": {
+                                                              "NUM": -473.5
+                                                            }
+                                                          }
+                                                        },
+                                                        "VALUE-1": {
+                                                          "block": {
+                                                            "type": "Number",
+                                                            "id": "bSMER^@Xf^5|P1op#JLQ",
+                                                            "fields": {
+                                                              "NUM": 156.5
+                                                            }
+                                                          }
+                                                        },
+                                                        "VALUE-2": {
+                                                          "block": {
+                                                            "type": "Number",
+                                                            "id": "lDd0bD34)jHIIET-H~fl",
+                                                            "fields": {
+                                                              "NUM": 270
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "next": {
+                                                  "block": {
+                                                    "type": "subroutineInstanceBlock",
+                                                    "id": ",Dmkq#?)MlQ)%|*|ZSA?",
+                                                    "extraState": {
+                                                      "subroutineName": "PlayArea",
+                                                      "parameters": [
+                                                        {
+                                                          "types": "Vector",
+                                                          "name": "Vector"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "fields": {
+                                                      "SUBROUTINE_NAME": "PlayArea"
+                                                    },
+                                                    "inputs": {
+                                                      "PARAM-0": {
+                                                        "block": {
+                                                          "type": "CreateVector",
+                                                          "id": "s3[RexgF[,6Vg2T8+9FU",
+                                                          "inputs": {
+                                                            "VALUE-0": {
+                                                              "block": {
+                                                                "type": "Number",
+                                                                "id": "pr+S_U2)+RKly^_{LwIt",
+                                                                "fields": {
+                                                                  "NUM": -440
+                                                                }
+                                                              }
+                                                            },
+                                                            "VALUE-1": {
+                                                              "block": {
+                                                                "type": "Number",
+                                                                "id": "0gMVAlT.!{cmVt;I(r,0",
+                                                                "fields": {
+                                                                  "NUM": 149
+                                                                }
+                                                              }
+                                                            },
+                                                            "VALUE-2": {
+                                                              "block": {
+                                                                "type": "Number",
+                                                                "id": "d;hS^t-|7R4Bj9}+ExE]",
+                                                                "fields": {
+                                                                  "NUM": 330
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    },
+                                                    "next": {
+                                                      "block": {
+                                                        "type": "subroutineInstanceBlock",
+                                                        "id": "JKopq{1omd/fII-?qH0^",
+                                                        "extraState": {
+                                                          "subroutineName": "PlayArea",
+                                                          "parameters": [
+                                                            {
+                                                              "types": "Vector",
+                                                              "name": "Vector"
+                                                            }
+                                                          ]
+                                                        },
+                                                        "fields": {
+                                                          "SUBROUTINE_NAME": "PlayArea"
+                                                        },
+                                                        "inputs": {
+                                                          "PARAM-0": {
+                                                            "block": {
+                                                              "type": "CreateVector",
+                                                              "id": "d1tfM3`RJ3]p{A^|ZL[t",
+                                                              "inputs": {
+                                                                "VALUE-0": {
+                                                                  "block": {
+                                                                    "type": "Number",
+                                                                    "id": "cZIfH7kH($haG0(uN^z$",
+                                                                    "fields": {
+                                                                      "NUM": -460.8
+                                                                    }
+                                                                  }
+                                                                },
+                                                                "VALUE-1": {
+                                                                  "block": {
+                                                                    "type": "Number",
+                                                                    "id": "3{F;#H~q]BxZyLO;%3R_",
+                                                                    "fields": {
+                                                                      "NUM": 149.7
+                                                                    }
+                                                                  }
+                                                                },
+                                                                "VALUE-2": {
+                                                                  "block": {
+                                                                    "type": "Number",
+                                                                    "id": "WO(sZ|h^A@|G_9$?7]jQ",
+                                                                    "fields": {
+                                                                      "NUM": 415.2
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        },
+                                                        "next": {
+                                                          "block": {
+                                                            "type": "SetVariable",
+                                                            "id": "d~[XquE#Y.AoqDrIpq.F",
+                                                            "inputs": {
+                                                              "VALUE-0": {
+                                                                "block": {
+                                                                  "type": "variableReferenceBlock",
+                                                                  "id": "S^6[-BG/@k)8VT7Q_kkB",
+                                                                  "extraState": {
+                                                                    "isObjectVar": true
+                                                                  },
+                                                                  "fields": {
+                                                                    "OBJECTTYPE": "TeamId",
+                                                                    "VAR": {
+                                                                      "id": "~!s}ovrs?jb7Yd/X[z2!"
+                                                                    }
+                                                                  },
+                                                                  "inputs": {
+                                                                    "OBJECT": {
+                                                                      "block": {
+                                                                        "type": "GetTeamId",
+                                                                        "id": "y3k[mQ}swR}7(4pJH*`9",
+                                                                        "inputs": {
+                                                                          "VALUE-0": {
+                                                                            "block": {
+                                                                              "type": "Number",
+                                                                              "id": "FU5AtEDG}pqG[Jr}(5Hd",
+                                                                              "fields": {
+                                                                                "NUM": 1
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              },
+                                                              "VALUE-1": {
+                                                                "block": {
+                                                                  "type": "EmptyArray",
+                                                                  "id": "{-qLK`,#MUFKZ9,n[:Vf"
+                                                                }
+                                                              }
+                                                            },
+                                                            "next": {
+                                                              "block": {
+                                                                "type": "subroutineInstanceBlock",
+                                                                "id": "vKE#o+|7]=Q.hx/F+t!3",
+                                                                "extraState": {
+                                                                  "subroutineName": "Team1_HQ_Boundaries",
+                                                                  "parameters": [
+                                                                    {
+                                                                      "types": "Vector",
+                                                                      "name": "Vector"
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                "fields": {
+                                                                  "SUBROUTINE_NAME": "Team1_HQ_Boundaries"
+                                                                },
+                                                                "inputs": {
+                                                                  "PARAM-0": {
+                                                                    "block": {
+                                                                      "type": "CreateVector",
+                                                                      "id": "}rYJLs*bkip+cH.kdy60",
+                                                                      "inputs": {
+                                                                        "VALUE-0": {
+                                                                          "block": {
+                                                                            "type": "Number",
+                                                                            "id": "=r7.,pX#U=@^L|v/3@xb",
+                                                                            "fields": {
+                                                                              "NUM": -332.6
+                                                                            }
+                                                                          }
+                                                                        },
+                                                                        "VALUE-1": {
+                                                                          "block": {
+                                                                            "type": "Number",
+                                                                            "id": "xe=r(b#c58s{$)apqQKg",
+                                                                            "fields": {
+                                                                              "NUM": 164.9
+                                                                            }
+                                                                          }
+                                                                        },
+                                                                        "VALUE-2": {
+                                                                          "block": {
+                                                                            "type": "Number",
+                                                                            "id": "RbmFI:R4!P*^@(v/ZdQ?",
+                                                                            "fields": {
+                                                                              "NUM": 420.5
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                },
+                                                                "next": {
+                                                                  "block": {
+                                                                    "type": "subroutineInstanceBlock",
+                                                                    "id": "db*+05^Y4dz@Q76Jd?]A",
+                                                                    "extraState": {
+                                                                      "subroutineName": "Team1_HQ_Boundaries",
+                                                                      "parameters": [
+                                                                        {
+                                                                          "types": "Vector",
+                                                                          "name": "Vector"
+                                                                        }
+                                                                      ]
+                                                                    },
+                                                                    "fields": {
+                                                                      "SUBROUTINE_NAME": "Team1_HQ_Boundaries"
+                                                                    },
+                                                                    "inputs": {
+                                                                      "PARAM-0": {
+                                                                        "block": {
+                                                                          "type": "CreateVector",
+                                                                          "id": "_=/2HSnLJ|7(94Na{!E9",
+                                                                          "inputs": {
+                                                                            "VALUE-0": {
+                                                                              "block": {
+                                                                                "type": "Number",
+                                                                                "id": "$nlBASw?HZ%-9D~ri~;,",
+                                                                                "fields": {
+                                                                                  "NUM": -431.5
+                                                                                }
+                                                                              }
+                                                                            },
+                                                                            "VALUE-1": {
+                                                                              "block": {
+                                                                                "type": "Number",
+                                                                                "id": "m7u;1V{^$:7x5HdX{~h(",
+                                                                                "fields": {
+                                                                                  "NUM": 164.5
+                                                                                }
+                                                                              }
+                                                                            },
+                                                                            "VALUE-2": {
+                                                                              "block": {
+                                                                                "type": "Number",
+                                                                                "id": "SZ+,F(@+oqbaevR{r7AI",
+                                                                                "fields": {
+                                                                                  "NUM": 454.4
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    "next": {
+                                                                      "block": {
+                                                                        "type": "subroutineInstanceBlock",
+                                                                        "id": "%A{#@r38C6JF`*1c%8Fs",
+                                                                        "extraState": {
+                                                                          "subroutineName": "Team1_HQ_Boundaries",
+                                                                          "parameters": [
+                                                                            {
+                                                                              "types": "Vector",
+                                                                              "name": "Vector"
+                                                                            }
+                                                                          ]
+                                                                        },
+                                                                        "fields": {
+                                                                          "SUBROUTINE_NAME": "Team1_HQ_Boundaries"
+                                                                        },
+                                                                        "inputs": {
+                                                                          "PARAM-0": {
+                                                                            "block": {
+                                                                              "type": "CreateVector",
+                                                                              "id": "t4^+*1x]{]izgINMZ_|G",
+                                                                              "inputs": {
+                                                                                "VALUE-0": {
+                                                                                  "block": {
+                                                                                    "type": "Number",
+                                                                                    "id": "CG8/L|rt+6E:])`#.}qn",
+                                                                                    "fields": {
+                                                                                      "NUM": -408.6
+                                                                                    }
+                                                                                  }
+                                                                                },
+                                                                                "VALUE-1": {
+                                                                                  "block": {
+                                                                                    "type": "Number",
+                                                                                    "id": "gl!$~n;AasW!Vv@,Daw#",
+                                                                                    "fields": {
+                                                                                      "NUM": 161.5
+                                                                                    }
+                                                                                  }
+                                                                                },
+                                                                                "VALUE-2": {
+                                                                                  "block": {
+                                                                                    "type": "Number",
+                                                                                    "id": "Dvm,_):52S7=ZW[CzW=o",
+                                                                                    "fields": {
+                                                                                      "NUM": 519.9
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        },
+                                                                        "next": {
+                                                                          "block": {
+                                                                            "type": "subroutineInstanceBlock",
+                                                                            "id": "M)`9,+4:2:?AFWHW3T_/",
+                                                                            "extraState": {
+                                                                              "subroutineName": "Team1_HQ_Boundaries",
+                                                                              "parameters": [
+                                                                                {
+                                                                                  "types": "Vector",
+                                                                                  "name": "Vector"
+                                                                                }
+                                                                              ]
+                                                                            },
+                                                                            "fields": {
+                                                                              "SUBROUTINE_NAME": "Team1_HQ_Boundaries"
+                                                                            },
+                                                                            "inputs": {
+                                                                              "PARAM-0": {
+                                                                                "block": {
+                                                                                  "type": "CreateVector",
+                                                                                  "id": "|_%(|1Aq!x!j-EDg/0Mn",
+                                                                                  "inputs": {
+                                                                                    "VALUE-0": {
+                                                                                      "block": {
+                                                                                        "type": "Number",
+                                                                                        "id": "=^n6lQvafF0r=:lGuI03",
+                                                                                        "fields": {
+                                                                                          "NUM": -311.9
+                                                                                        }
+                                                                                      }
+                                                                                    },
+                                                                                    "VALUE-1": {
+                                                                                      "block": {
+                                                                                        "type": "Number",
+                                                                                        "id": "x3v8q?=LGy^ve8l^(_Gf",
+                                                                                        "fields": {
+                                                                                          "NUM": 167.7
+                                                                                        }
+                                                                                      }
+                                                                                    },
+                                                                                    "VALUE-2": {
+                                                                                      "block": {
+                                                                                        "type": "Number",
+                                                                                        "id": "?CX/+x@@`;CU.dUuOOyk",
+                                                                                        "fields": {
+                                                                                          "NUM": 486.7
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            },
+                                                                            "next": {
+                                                                              "block": {
+                                                                                "type": "SetVariable",
+                                                                                "id": "y-|:8[lgDniV3;EIkm~p",
+                                                                                "inputs": {
+                                                                                  "VALUE-0": {
+                                                                                    "block": {
+                                                                                      "type": "variableReferenceBlock",
+                                                                                      "id": "K4Xq=q6dPjjL@V1)~ku=",
+                                                                                      "extraState": {
+                                                                                        "isObjectVar": true
+                                                                                      },
+                                                                                      "fields": {
+                                                                                        "OBJECTTYPE": "TeamId",
+                                                                                        "VAR": {
+                                                                                          "id": "~!s}ovrs?jb7Yd/X[z2!"
+                                                                                        }
+                                                                                      },
+                                                                                      "inputs": {
+                                                                                        "OBJECT": {
+                                                                                          "block": {
+                                                                                            "type": "GetTeamId",
+                                                                                            "id": "1}::0zc.uv]v883Z|Qoc",
+                                                                                            "inputs": {
+                                                                                              "VALUE-0": {
+                                                                                                "block": {
+                                                                                                  "type": "Number",
+                                                                                                  "id": "2.*Hkx3gk[}Tz)KFymNH",
+                                                                                                  "fields": {
+                                                                                                    "NUM": 2
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  },
+                                                                                  "VALUE-1": {
+                                                                                    "block": {
+                                                                                      "type": "EmptyArray",
+                                                                                      "id": "3L2Mx/2:]^G#]5|aVHt."
+                                                                                    }
+                                                                                  }
+                                                                                },
+                                                                                "next": {
+                                                                                  "block": {
+                                                                                    "type": "subroutineInstanceBlock",
+                                                                                    "id": "[(@UXaFzkJfGX~q]8*o$",
+                                                                                    "extraState": {
+                                                                                      "subroutineName": "Team2_HQ_Boundaries",
+                                                                                      "parameters": [
+                                                                                        {
+                                                                                          "types": "Vector",
+                                                                                          "name": "Vector"
+                                                                                        }
+                                                                                      ]
+                                                                                    },
+                                                                                    "fields": {
+                                                                                      "SUBROUTINE_NAME": "Team2_HQ_Boundaries"
+                                                                                    },
+                                                                                    "inputs": {
+                                                                                      "PARAM-0": {
+                                                                                        "block": {
+                                                                                          "type": "CreateVector",
+                                                                                          "id": "hg}7@$HXWg=rZ#G@ePc_",
+                                                                                          "inputs": {
+                                                                                            "VALUE-0": {
+                                                                                              "block": {
+                                                                                                "type": "Number",
+                                                                                                "id": "cTTRO^bHk79!LRrZ*-Cd",
+                                                                                                "fields": {
+                                                                                                  "NUM": -366.5
+                                                                                                }
+                                                                                              }
+                                                                                            },
+                                                                                            "VALUE-1": {
+                                                                                              "block": {
+                                                                                                "type": "Number",
+                                                                                                "id": "GR(t`Fi(C[DF=@yCv+8u",
+                                                                                                "fields": {
+                                                                                                  "NUM": 165.7
+                                                                                                }
+                                                                                              }
+                                                                                            },
+                                                                                            "VALUE-2": {
+                                                                                              "block": {
+                                                                                                "type": "Number",
+                                                                                                "id": "O772X@19e}[D_ASbX;DM",
+                                                                                                "fields": {
+                                                                                                  "NUM": 226
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    },
+                                                                                    "next": {
+                                                                                      "block": {
+                                                                                        "type": "subroutineInstanceBlock",
+                                                                                        "id": "%3Vrq6vKUDvUOkQ,:_)[",
+                                                                                        "extraState": {
+                                                                                          "subroutineName": "Team2_HQ_Boundaries",
+                                                                                          "parameters": [
+                                                                                            {
+                                                                                              "types": "Vector",
+                                                                                              "name": "Vector"
+                                                                                            }
+                                                                                          ]
+                                                                                        },
+                                                                                        "fields": {
+                                                                                          "SUBROUTINE_NAME": "Team2_HQ_Boundaries"
+                                                                                        },
+                                                                                        "inputs": {
+                                                                                          "PARAM-0": {
+                                                                                            "block": {
+                                                                                              "type": "CreateVector",
+                                                                                              "id": "wd}g16p,?Z|oSOm*k:PN",
+                                                                                              "inputs": {
+                                                                                                "VALUE-0": {
+                                                                                                  "block": {
+                                                                                                    "type": "Number",
+                                                                                                    "id": "-.dHpjhxU{_esFX0G:7I",
+                                                                                                    "fields": {
+                                                                                                      "NUM": -418.9
+                                                                                                    }
+                                                                                                  }
+                                                                                                },
+                                                                                                "VALUE-1": {
+                                                                                                  "block": {
+                                                                                                    "type": "Number",
+                                                                                                    "id": "dy^W67%y6y%(]?[`YjPy",
+                                                                                                    "fields": {
+                                                                                                      "NUM": 171.3
+                                                                                                    }
+                                                                                                  }
+                                                                                                },
+                                                                                                "VALUE-2": {
+                                                                                                  "block": {
+                                                                                                    "type": "Number",
+                                                                                                    "id": "F8*E{7SuPs[M8#N?{B3}",
+                                                                                                    "fields": {
+                                                                                                      "NUM": 257.5
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        },
+                                                                                        "next": {
+                                                                                          "block": {
+                                                                                            "type": "subroutineInstanceBlock",
+                                                                                            "id": "pi,wedo!!Ko%1kNA,bxo",
+                                                                                            "extraState": {
+                                                                                              "subroutineName": "Team2_HQ_Boundaries",
+                                                                                              "parameters": [
+                                                                                                {
+                                                                                                  "types": "Vector",
+                                                                                                  "name": "Vector"
+                                                                                                }
+                                                                                              ]
+                                                                                            },
+                                                                                            "fields": {
+                                                                                              "SUBROUTINE_NAME": "Team2_HQ_Boundaries"
+                                                                                            },
+                                                                                            "inputs": {
+                                                                                              "PARAM-0": {
+                                                                                                "block": {
+                                                                                                  "type": "CreateVector",
+                                                                                                  "id": "W#BhW@jKG]D^#*Sc4Y-3",
+                                                                                                  "inputs": {
+                                                                                                    "VALUE-0": {
+                                                                                                      "block": {
+                                                                                                        "type": "Number",
+                                                                                                        "id": "L9??7UEZBZ-]/{+DnSxr",
+                                                                                                        "fields": {
+                                                                                                          "NUM": -473.5
+                                                                                                        }
+                                                                                                      }
+                                                                                                    },
+                                                                                                    "VALUE-1": {
+                                                                                                      "block": {
+                                                                                                        "type": "Number",
+                                                                                                        "id": "LH^},[8VQj5eZ#M}w=p(",
+                                                                                                        "fields": {
+                                                                                                          "NUM": 156.5
+                                                                                                        }
+                                                                                                      }
+                                                                                                    },
+                                                                                                    "VALUE-2": {
+                                                                                                      "block": {
+                                                                                                        "type": "Number",
+                                                                                                        "id": "#RC1$fZquklD9sq5zCWe",
+                                                                                                        "fields": {
+                                                                                                          "NUM": 270
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            },
+                                                                                            "next": {
+                                                                                              "block": {
+                                                                                                "type": "subroutineInstanceBlock",
+                                                                                                "id": "F}IwJz@D91*VMf0M[Mf+",
+                                                                                                "extraState": {
+                                                                                                  "subroutineName": "Team2_HQ_Boundaries",
+                                                                                                  "parameters": [
+                                                                                                    {
+                                                                                                      "types": "Vector",
+                                                                                                      "name": "Vector"
+                                                                                                    }
+                                                                                                  ]
+                                                                                                },
+                                                                                                "fields": {
+                                                                                                  "SUBROUTINE_NAME": "Team2_HQ_Boundaries"
+                                                                                                },
+                                                                                                "inputs": {
+                                                                                                  "PARAM-0": {
+                                                                                                    "block": {
+                                                                                                      "type": "CreateVector",
+                                                                                                      "id": "O*I9{@;h?=$.IwFYaUwi",
+                                                                                                      "inputs": {
+                                                                                                        "VALUE-0": {
+                                                                                                          "block": {
+                                                                                                            "type": "Number",
+                                                                                                            "id": "(C0L(K[-O0.e)Umj^9:f",
+                                                                                                            "fields": {
+                                                                                                              "NUM": -425
+                                                                                                            }
+                                                                                                          }
+                                                                                                        },
+                                                                                                        "VALUE-1": {
+                                                                                                          "block": {
+                                                                                                            "type": "Number",
+                                                                                                            "id": "r`$hw:OaLn:3bhttPkds",
+                                                                                                            "fields": {
+                                                                                                              "NUM": 172.7
+                                                                                                            }
+                                                                                                          }
+                                                                                                        },
+                                                                                                        "VALUE-2": {
+                                                                                                          "block": {
+                                                                                                            "type": "Number",
+                                                                                                            "id": "dS3pwV]u52b(*pnlBZ0z",
+                                                                                                            "fields": {
+                                                                                                              "NUM": 198
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                },
+                                                                                                "next": {
+                                                                                                  "block": {
+                                                                                                    "type": "subroutineInstanceBlock",
+                                                                                                    "id": "D7sGi94CDXJn,U1vuE]I",
+                                                                                                    "extraState": {
+                                                                                                      "subroutineName": "Team2_HQ_Boundaries",
+                                                                                                      "parameters": [
+                                                                                                        {
+                                                                                                          "types": "Vector",
+                                                                                                          "name": "Vector"
+                                                                                                        }
+                                                                                                      ]
+                                                                                                    },
+                                                                                                    "fields": {
+                                                                                                      "SUBROUTINE_NAME": "Team2_HQ_Boundaries"
+                                                                                                    },
+                                                                                                    "inputs": {
+                                                                                                      "PARAM-0": {
+                                                                                                        "block": {
+                                                                                                          "type": "CreateVector",
+                                                                                                          "id": "e{ji0%wKh.~~:/%bE64o",
+                                                                                                          "inputs": {
+                                                                                                            "VALUE-0": {
+                                                                                                              "block": {
+                                                                                                                "type": "Number",
+                                                                                                                "id": "RJ;#ZQ5$?RKv0R,{mAgs",
+                                                                                                                "fields": {
+                                                                                                                  "NUM": -385
+                                                                                                                }
+                                                                                                              }
+                                                                                                            },
+                                                                                                            "VALUE-1": {
+                                                                                                              "block": {
+                                                                                                                "type": "Number",
+                                                                                                                "id": "#{m2z3J~,Z#v~lH^`E-2",
+                                                                                                                "fields": {
+                                                                                                                  "NUM": 169
+                                                                                                                }
+                                                                                                              }
+                                                                                                            },
+                                                                                                            "VALUE-2": {
+                                                                                                              "block": {
+                                                                                                                "type": "Number",
+                                                                                                                "id": "-X3m5KtZ#C~I7_=EzAw|",
+                                                                                                                "fields": {
+                                                                                                                  "NUM": 207
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    },
+                                                                                                    "next": {
+                                                                                                      "block": {
+                                                                                                        "type": "SetVariable",
+                                                                                                        "id": ";~)4%[25KIf7#/g{L!-)",
+                                                                                                        "inputs": {
+                                                                                                          "VALUE-0": {
+                                                                                                            "block": {
+                                                                                                              "type": "variableReferenceBlock",
+                                                                                                              "id": "S*=W`P1b5_a#.Wf5?ff^",
+                                                                                                              "extraState": {
+                                                                                                                "isObjectVar": true
+                                                                                                              },
+                                                                                                              "fields": {
+                                                                                                                "OBJECTTYPE": "TeamId",
+                                                                                                                "VAR": {
+                                                                                                                  "id": ")85N/!w[yu2n1i{J:kG%"
+                                                                                                                }
+                                                                                                              },
+                                                                                                              "inputs": {
+                                                                                                                "OBJECT": {
+                                                                                                                  "block": {
+                                                                                                                    "type": "GetTeamId",
+                                                                                                                    "id": "rjdkj7u-y9~X=XD=Mu#!",
+                                                                                                                    "inputs": {
+                                                                                                                      "VALUE-0": {
+                                                                                                                        "block": {
+                                                                                                                          "type": "Number",
+                                                                                                                          "id": "j^=[AW`.G+pW;fEe[Y:u",
+                                                                                                                          "fields": {
+                                                                                                                            "NUM": 1
+                                                                                                                          }
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          },
+                                                                                                          "VALUE-1": {
+                                                                                                            "block": {
+                                                                                                              "type": "CreateVector",
+                                                                                                              "id": "8zy|7#bwr=c{f5zO|Kr`",
+                                                                                                              "inputs": {
+                                                                                                                "VALUE-0": {
+                                                                                                                  "block": {
+                                                                                                                    "type": "Number",
+                                                                                                                    "id": "vPb*Ccmc?to6f:+N*3B!",
+                                                                                                                    "fields": {
+                                                                                                                      "NUM": -348.5
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                },
+                                                                                                                "VALUE-1": {
+                                                                                                                  "block": {
+                                                                                                                    "type": "Number",
+                                                                                                                    "id": "wop?5oO~xrmyS.m|*7V!",
+                                                                                                                    "fields": {
+                                                                                                                      "NUM": 171.3
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                },
+                                                                                                                "VALUE-2": {
+                                                                                                                  "block": {
+                                                                                                                    "type": "Number",
+                                                                                                                    "id": "AxnjB_;adPVHV;PZ|hTC",
+                                                                                                                    "fields": {
+                                                                                                                      "NUM": 470
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        },
+                                                                                                        "next": {
+                                                                                                          "block": {
+                                                                                                            "type": "SetVariable",
+                                                                                                            "id": "Ljxzjml4iL86*CdTotnD",
+                                                                                                            "inputs": {
+                                                                                                              "VALUE-0": {
+                                                                                                                "block": {
+                                                                                                                  "type": "variableReferenceBlock",
+                                                                                                                  "id": "8QTFQ;E#p/u?aHNfGE+!",
+                                                                                                                  "extraState": {
+                                                                                                                    "isObjectVar": true
+                                                                                                                  },
+                                                                                                                  "fields": {
+                                                                                                                    "OBJECTTYPE": "TeamId",
+                                                                                                                    "VAR": {
+                                                                                                                      "id": ")85N/!w[yu2n1i{J:kG%"
+                                                                                                                    }
+                                                                                                                  },
+                                                                                                                  "inputs": {
+                                                                                                                    "OBJECT": {
+                                                                                                                      "block": {
+                                                                                                                        "type": "GetTeamId",
+                                                                                                                        "id": "LaS`.)thFlY,A+[Eb^jc",
+                                                                                                                        "inputs": {
+                                                                                                                          "VALUE-0": {
+                                                                                                                            "block": {
+                                                                                                                              "type": "Number",
+                                                                                                                              "id": "i1A=MBY%^Ux=4I##qu:/",
+                                                                                                                              "fields": {
+                                                                                                                                "NUM": 2
+                                                                                                                              }
+                                                                                                                            }
+                                                                                                                          }
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              },
+                                                                                                              "VALUE-1": {
+                                                                                                                "block": {
+                                                                                                                  "type": "CreateVector",
+                                                                                                                  "id": "-=FLRzIaOpUeY:6jTE(R",
+                                                                                                                  "inputs": {
+                                                                                                                    "VALUE-0": {
+                                                                                                                      "block": {
+                                                                                                                        "type": "Number",
+                                                                                                                        "id": "#N.bhMAd[p;M!YBVp]-z",
+                                                                                                                        "fields": {
+                                                                                                                          "NUM": -415.6
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    },
+                                                                                                                    "VALUE-1": {
+                                                                                                                      "block": {
+                                                                                                                        "type": "Number",
+                                                                                                                        "id": "![c7EJGlq:8RDnmc~qK)",
+                                                                                                                        "fields": {
+                                                                                                                          "NUM": 171.3
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    },
+                                                                                                                    "VALUE-2": {
+                                                                                                                      "block": {
+                                                                                                                        "type": "Number",
+                                                                                                                        "id": "MvWX~I7~vL%}e4n[Nb$/",
+                                                                                                                        "fields": {
+                                                                                                                          "NUM": 214
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            },
+                                                                                                            "next": {
+                                                                                                              "block": {
+                                                                                                                "type": "SetVariable",
+                                                                                                                "id": "}C7}E{X{eD1JWoViYiO]",
+                                                                                                                "inputs": {
+                                                                                                                  "VALUE-0": {
+                                                                                                                    "block": {
+                                                                                                                      "type": "variableReferenceBlock",
+                                                                                                                      "id": "[CGTs*P7jstf@ZD!bkNE",
+                                                                                                                      "extraState": {
+                                                                                                                        "isObjectVar": false
+                                                                                                                      },
+                                                                                                                      "fields": {
+                                                                                                                        "OBJECTTYPE": "Global",
+                                                                                                                        "VAR": {
+                                                                                                                          "id": "]dWwQ+kkD!f)85rwAEAQ"
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    }
+                                                                                                                  },
+                                                                                                                  "VALUE-1": {
+                                                                                                                    "block": {
+                                                                                                                      "type": "CreateVector",
+                                                                                                                      "id": "HLe*1EqSV@!B{MQwors:",
+                                                                                                                      "inputs": {
+                                                                                                                        "VALUE-0": {
+                                                                                                                          "block": {
+                                                                                                                            "type": "Number",
+                                                                                                                            "id": "-OaS^TW,KLbf~pG1CfdB",
+                                                                                                                            "fields": {
+                                                                                                                              "NUM": -368.26
+                                                                                                                            }
+                                                                                                                          }
+                                                                                                                        },
+                                                                                                                        "VALUE-1": {
+                                                                                                                          "block": {
+                                                                                                                            "type": "Number",
+                                                                                                                            "id": "vL`MxB.:}c1$0CbVQ2tH",
+                                                                                                                            "fields": {
+                                                                                                                              "NUM": 166.2
+                                                                                                                            }
+                                                                                                                          }
+                                                                                                                        },
+                                                                                                                        "VALUE-2": {
+                                                                                                                          "block": {
+                                                                                                                            "type": "Number",
+                                                                                                                            "id": "eez;QoW.AJ*{v,o@E!6b",
+                                                                                                                            "fields": {
+                                                                                                                              "NUM": 344.4
+                                                                                                                            }
+                                                                                                                          }
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                },
+                                                                                                                "next": {
+                                                                                                                  "block": {
+                                                                                                                    "type": "SetVariable",
+                                                                                                                    "id": "5F4UPcmPr+H`o*tcH7YV",
+                                                                                                                    "inputs": {
+                                                                                                                      "VALUE-0": {
+                                                                                                                        "block": {
+                                                                                                                          "type": "variableReferenceBlock",
+                                                                                                                          "id": "{z63Kk*NDS_Of^XNx0Gs",
+                                                                                                                          "extraState": {
+                                                                                                                            "isObjectVar": false
+                                                                                                                          },
+                                                                                                                          "fields": {
+                                                                                                                            "OBJECTTYPE": "Global",
+                                                                                                                            "VAR": {
+                                                                                                                              "id": "eF$rR9X[_su_hNxhGZ`R"
+                                                                                                                            }
+                                                                                                                          }
+                                                                                                                        }
+                                                                                                                      },
+                                                                                                                      "VALUE-1": {
+                                                                                                                        "block": {
+                                                                                                                          "type": "Number",
+                                                                                                                          "id": "z+=f,wi7p{zXbNA|R8VZ",
+                                                                                                                          "fields": {
+                                                                                                                            "NUM": 4.67
+                                                                                                                          }
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    },
+                                                                                                                    "next": {
+                                                                                                                      "block": {
+                                                                                                                        "type": "SetVariable",
+                                                                                                                        "id": "9%o/!8)b$1NV/+%bB;Q,",
+                                                                                                                        "inputs": {
+                                                                                                                          "VALUE-0": {
+                                                                                                                            "block": {
+                                                                                                                              "type": "variableReferenceBlock",
+                                                                                                                              "id": "`0;EHSQyS(}nC_IozG49",
+                                                                                                                              "extraState": {
+                                                                                                                                "isObjectVar": false
+                                                                                                                              },
+                                                                                                                              "fields": {
+                                                                                                                                "OBJECTTYPE": "Global",
+                                                                                                                                "VAR": {
+                                                                                                                                  "id": "s;)yD}A?@5f!E58$,z[c"
+                                                                                                                                }
+                                                                                                                              }
+                                                                                                                            }
+                                                                                                                          },
+                                                                                                                          "VALUE-1": {
+                                                                                                                            "block": {
+                                                                                                                              "type": "CreateVector",
+                                                                                                                              "id": "v`2fSLp%u,U)t)Kew8|c",
+                                                                                                                              "inputs": {
+                                                                                                                                "VALUE-0": {
+                                                                                                                                  "block": {
+                                                                                                                                    "type": "Number",
+                                                                                                                                    "id": "g_)?1GV8ppk=NHsJMNwC",
+                                                                                                                                    "fields": {
+                                                                                                                                      "NUM": -403.59
+                                                                                                                                    }
+                                                                                                                                  }
+                                                                                                                                },
+                                                                                                                                "VALUE-1": {
+                                                                                                                                  "block": {
+                                                                                                                                    "type": "Number",
+                                                                                                                                    "id": "P-=v)aYhn.Zj,yo9}w!s",
+                                                                                                                                    "fields": {
+                                                                                                                                      "NUM": 171.35
+                                                                                                                                    }
+                                                                                                                                  }
+                                                                                                                                },
+                                                                                                                                "VALUE-2": {
+                                                                                                                                  "block": {
+                                                                                                                                    "type": "Number",
+                                                                                                                                    "id": "C|U1Ro;+E2#f4kdmTh~R",
+                                                                                                                                    "fields": {
+                                                                                                                                      "NUM": 297.55
+                                                                                                                                    }
+                                                                                                                                  }
+                                                                                                                                }
+                                                                                                                              }
+                                                                                                                            }
+                                                                                                                          }
+                                                                                                                        },
+                                                                                                                        "next": {
+                                                                                                                          "block": {
+                                                                                                                            "type": "SetVariable",
+                                                                                                                            "id": "Ul~10]e)]a^uEerd,6V)",
+                                                                                                                            "inputs": {
+                                                                                                                              "VALUE-0": {
+                                                                                                                                "block": {
+                                                                                                                                  "type": "variableReferenceBlock",
+                                                                                                                                  "id": "8:Wx4cFznef5|)1$FRZQ",
+                                                                                                                                  "extraState": {
+                                                                                                                                    "isObjectVar": false
+                                                                                                                                  },
+                                                                                                                                  "fields": {
+                                                                                                                                    "OBJECTTYPE": "Global",
+                                                                                                                                    "VAR": {
+                                                                                                                                      "id": "x8Nn45#O(#5EaIGY=`@u"
+                                                                                                                                    }
+                                                                                                                                  }
+                                                                                                                                }
+                                                                                                                              },
+                                                                                                                              "VALUE-1": {
+                                                                                                                                "block": {
+                                                                                                                                  "type": "Number",
+                                                                                                                                  "id": "lZs8;d[xr{q%b`GCF26p",
+                                                                                                                                  "fields": {
+                                                                                                                                    "NUM": 3.78
+                                                                                                                                  }
+                                                                                                                                }
+                                                                                                                              }
+                                                                                                                            }
+                                                                                                                          }
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
         }
       },
       {
         "type": "subroutineBlock",
         "id": "%%%F_nRKxl0V]hbt^]y+",
-        "x": 2574,
-        "y": 2211,
+        "x": 3921,
+        "y": 4465,
         "extraState": {
           "subroutineName": "CheckBoundaries",
           "parameters": [
@@ -2068,63 +8002,63 @@
       },
       {
         "type": "subroutineBlock",
-        "id": "NVLX/Atir8Z$S,4!~tmA",
-        "x": 2588,
-        "y": 344,
+        "id": "aTm+^+K[SMP{dAg53{8B",
+        "x": 3921,
+        "y": 5953,
         "extraState": {
-          "subroutineName": "Renewal",
+          "subroutineName": "yaw",
           "parameters": []
         },
         "fields": {
-          "SUBROUTINE_NAME": "Renewal"
+          "SUBROUTINE_NAME": "yaw"
         },
         "inputs": {
           "ACTIONS": {
             "block": {
-              "type": "subroutineInstanceBlock",
-              "id": "-jaWT_.yt=,f5%MiCdZU",
-              "extraState": {
-                "subroutineName": "Append",
-                "parameters": [
-                  {
-                    "types": "Vector",
-                    "name": "Vector"
-                  }
-                ]
-              },
-              "fields": {
-                "SUBROUTINE_NAME": "Append"
-              },
+              "type": "SetVariable",
+              "id": "zfWnUWJ@QnlYqEhs/9fn",
               "inputs": {
-                "PARAM-0": {
+                "VALUE-0": {
                   "block": {
-                    "type": "CreateVector",
-                    "id": "GJl?zz#~}Lh_~*!qd.:c",
+                    "type": "variableReferenceBlock",
+                    "id": "#0y*rHB2._$yrpyB$MPI",
+                    "extraState": {
+                      "isObjectVar": true
+                    },
+                    "fields": {
+                      "OBJECTTYPE": "Player",
+                      "VAR": {
+                        "id": "Q5Zu0keSSA7tlAfVDnKZ"
+                      }
+                    },
+                    "inputs": {
+                      "OBJECT": {
+                        "block": {
+                          "type": "EventPlayer",
+                          "id": "I6V~8PEa%_9e3OicI6;O"
+                        }
+                      }
+                    }
+                  }
+                },
+                "VALUE-1": {
+                  "block": {
+                    "type": "GetSoldierState",
+                    "id": "3vM6_nJ2,mB8+tC*@l[a",
                     "inputs": {
                       "VALUE-0": {
                         "block": {
-                          "type": "Number",
-                          "id": "E]1:z5j2I(?RY0a%Jh}u",
-                          "fields": {
-                            "NUM": -62
-                          }
+                          "type": "EventPlayer",
+                          "id": "N?$Ay+;d3?ymL*zM~=DD"
                         }
                       },
                       "VALUE-1": {
                         "block": {
-                          "type": "Number",
-                          "id": "5lz}KOweUzJ#fHkTgv`m",
+                          "type": "SoldierStateVectorItem",
+                          "id": "86@XD=yjs^v!U[@Waymk",
                           "fields": {
-                            "NUM": 57.1
-                          }
-                        }
-                      },
-                      "VALUE-2": {
-                        "block": {
-                          "type": "Number",
-                          "id": "#Q9Kw4]Oh%BOq8[fn;fV",
-                          "fields": {
-                            "NUM": -72.6
+                            "VALUE-0": "SoldierStateVector",
+                            "VALUE-1": "GetFacingDirection"
                           }
                         }
                       }
@@ -2134,103 +8068,614 @@
               },
               "next": {
                 "block": {
-                  "type": "subroutineInstanceBlock",
-                  "id": "g@/W2KQnKZ(@*RoBCC*e",
+                  "type": "If",
+                  "id": "HR9SA$:G?{w6TE1W=VCP",
                   "extraState": {
-                    "subroutineName": "Append",
-                    "parameters": [
-                      {
-                        "types": "Vector",
-                        "name": "Vector"
-                      }
-                    ]
-                  },
-                  "fields": {
-                    "SUBROUTINE_NAME": "Append"
+                    "elseif": 0,
+                    "else": 1
                   },
                   "inputs": {
-                    "PARAM-0": {
+                    "VALUE-0": {
                       "block": {
-                        "type": "CreateVector",
-                        "id": "krlYnL1cN/Z)0weS}0I-",
+                        "type": "GreaterThanEqualTo",
+                        "id": "j]JC50R8^n^FFiV{EI-a",
                         "inputs": {
                           "VALUE-0": {
                             "block": {
-                              "type": "Number",
-                              "id": "n(PJl!8.[.K0sPgrqC0@",
-                              "fields": {
-                                "NUM": -4.8
+                              "type": "XComponentOf",
+                              "id": "|,A{toA7tglb{O$0WzA$",
+                              "inputs": {
+                                "VALUE-0": {
+                                  "block": {
+                                    "type": "GetVariable",
+                                    "id": "$PX,=S-4:Ggf1-bU+O_Z",
+                                    "inputs": {
+                                      "VALUE-0": {
+                                        "block": {
+                                          "type": "variableReferenceBlock",
+                                          "id": "t.]|ooQr}+5a*W%FW:[$",
+                                          "extraState": {
+                                            "isObjectVar": true
+                                          },
+                                          "fields": {
+                                            "OBJECTTYPE": "Player",
+                                            "VAR": {
+                                              "id": "Q5Zu0keSSA7tlAfVDnKZ"
+                                            }
+                                          },
+                                          "inputs": {
+                                            "OBJECT": {
+                                              "block": {
+                                                "type": "EventPlayer",
+                                                "id": "Mv!il%WL.Gpd;H0Ab$ES"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
                               }
                             }
                           },
                           "VALUE-1": {
                             "block": {
                               "type": "Number",
-                              "id": "+9RE`@G+]~}i^q5Cpr@K",
+                              "id": "by@62wiY{3lUBq0b{fAc",
                               "fields": {
-                                "NUM": 57.1
+                                "NUM": 0
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "DO": {
+                      "block": {
+                        "type": "SetVariable",
+                        "id": ",bI@Z~qWiM7RY_$9]Qk7",
+                        "inputs": {
+                          "VALUE-0": {
+                            "block": {
+                              "type": "variableReferenceBlock",
+                              "id": "8^kd|c#`Yb]e5DRyoQ%|",
+                              "extraState": {
+                                "isObjectVar": true
+                              },
+                              "fields": {
+                                "OBJECTTYPE": "Player",
+                                "VAR": {
+                                  "id": "Q5Zu0keSSA7tlAfVDnKZ"
+                                }
+                              },
+                              "inputs": {
+                                "OBJECT": {
+                                  "block": {
+                                    "type": "EventPlayer",
+                                    "id": "oz([50]sN9~`nEWC-S.$"
+                                  }
+                                }
                               }
                             }
                           },
-                          "VALUE-2": {
+                          "VALUE-1": {
                             "block": {
-                              "type": "Number",
-                              "id": "4$h;tY(=3L3U|gDyi/jL",
+                              "type": "Multiply",
+                              "id": "r9tU/BpgmbUPid8*$N:T",
+                              "inputs": {
+                                "VALUE-0": {
+                                  "block": {
+                                    "type": "AngleBetweenVectors",
+                                    "id": "~1pm;7Y5!Ce5=fNLKs4e",
+                                    "inline": false,
+                                    "inputs": {
+                                      "VALUE-0": {
+                                        "block": {
+                                          "type": "BackwardVector",
+                                          "id": "QhWYXT:!5|g,!YL2igsp"
+                                        }
+                                      },
+                                      "VALUE-1": {
+                                        "block": {
+                                          "type": "Normalize",
+                                          "id": "RC=Tv|p(_~pY^3;Nc]EC",
+                                          "inputs": {
+                                            "VALUE-0": {
+                                              "block": {
+                                                "type": "CreateVector",
+                                                "id": "#GWXjI;eDTZc}+QWjLfm",
+                                                "inline": false,
+                                                "inputs": {
+                                                  "VALUE-0": {
+                                                    "block": {
+                                                      "type": "XComponentOf",
+                                                      "id": "blmx0Ue:0gkyZ^X|H}9O",
+                                                      "inputs": {
+                                                        "VALUE-0": {
+                                                          "block": {
+                                                            "type": "GetVariable",
+                                                            "id": "2eI[:tdKy8BSBUvR2cFH",
+                                                            "inputs": {
+                                                              "VALUE-0": {
+                                                                "block": {
+                                                                  "type": "variableReferenceBlock",
+                                                                  "id": ".AFk2R.y+gg*pMAOH/G]",
+                                                                  "extraState": {
+                                                                    "isObjectVar": true
+                                                                  },
+                                                                  "fields": {
+                                                                    "OBJECTTYPE": "Player",
+                                                                    "VAR": {
+                                                                      "id": "Q5Zu0keSSA7tlAfVDnKZ"
+                                                                    }
+                                                                  },
+                                                                  "inputs": {
+                                                                    "OBJECT": {
+                                                                      "block": {
+                                                                        "type": "EventPlayer",
+                                                                        "id": "LL`9s|?m,9D!_UpPrSmw"
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  },
+                                                  "VALUE-1": {
+                                                    "block": {
+                                                      "type": "Number",
+                                                      "id": "f^]QXJ3BrW,yJq_5?dkn",
+                                                      "fields": {
+                                                        "NUM": 0
+                                                      }
+                                                    }
+                                                  },
+                                                  "VALUE-2": {
+                                                    "block": {
+                                                      "type": "ZComponentOf",
+                                                      "id": "btb9:{^#qkK{QO/)LL!W",
+                                                      "inputs": {
+                                                        "VALUE-0": {
+                                                          "block": {
+                                                            "type": "GetVariable",
+                                                            "id": "~g.A+/zaK#TKJ;WmAt5c",
+                                                            "inputs": {
+                                                              "VALUE-0": {
+                                                                "block": {
+                                                                  "type": "variableReferenceBlock",
+                                                                  "id": "ut9np5tdnb,@]/mQ{6Y)",
+                                                                  "extraState": {
+                                                                    "isObjectVar": true
+                                                                  },
+                                                                  "fields": {
+                                                                    "OBJECTTYPE": "Player",
+                                                                    "VAR": {
+                                                                      "id": "Q5Zu0keSSA7tlAfVDnKZ"
+                                                                    }
+                                                                  },
+                                                                  "inputs": {
+                                                                    "OBJECT": {
+                                                                      "block": {
+                                                                        "type": "EventPlayer",
+                                                                        "id": "USor}YgJ?f:4]?;8suD~"
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "VALUE-1": {
+                                  "block": {
+                                    "type": "Divide",
+                                    "id": "Uiwu]~xPdh8=H#G=2,#)",
+                                    "inline": false,
+                                    "inputs": {
+                                      "VALUE-0": {
+                                        "block": {
+                                          "type": "ArctangentInRadians",
+                                          "id": "/T{OSzjS-U9,]H/Y@Z:e",
+                                          "inputs": {
+                                            "VALUE-0": {
+                                              "block": {
+                                                "type": "Number",
+                                                "id": ";Q2S#XA0OSQoe5AGZ^Br",
+                                                "fields": {
+                                                  "NUM": 1
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "VALUE-1": {
+                                        "block": {
+                                          "type": "Number",
+                                          "id": "M]C4(2p7~$}!}RR5wGb=",
+                                          "fields": {
+                                            "NUM": 45
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ELSE": {
+                      "block": {
+                        "type": "SetVariable",
+                        "id": "$@1NqFs1g5@;M%ogZGH!",
+                        "inputs": {
+                          "VALUE-0": {
+                            "block": {
+                              "type": "variableReferenceBlock",
+                              "id": "UhKVh.,(jH#7_eQj03/Q",
+                              "extraState": {
+                                "isObjectVar": true
+                              },
                               "fields": {
-                                "NUM": -112.78
+                                "OBJECTTYPE": "Player",
+                                "VAR": {
+                                  "id": "Q5Zu0keSSA7tlAfVDnKZ"
+                                }
+                              },
+                              "inputs": {
+                                "OBJECT": {
+                                  "block": {
+                                    "type": "EventPlayer",
+                                    "id": ";WVKFoe_hR*`FMCBZNoj"
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "VALUE-1": {
+                            "block": {
+                              "type": "Multiply",
+                              "id": "8D@z_JNtozO])WT{V0FM",
+                              "inputs": {
+                                "VALUE-0": {
+                                  "block": {
+                                    "type": "Subtract",
+                                    "id": "8f[5MbN6#Q!!]XVj{6TM",
+                                    "inline": false,
+                                    "inputs": {
+                                      "VALUE-0": {
+                                        "block": {
+                                          "type": "Number",
+                                          "id": "$?ou%rHE^0=522nKKk}i",
+                                          "fields": {
+                                            "NUM": 360
+                                          }
+                                        }
+                                      },
+                                      "VALUE-1": {
+                                        "block": {
+                                          "type": "AngleBetweenVectors",
+                                          "id": "D[6k(s3s~+X_Op4eYDl(",
+                                          "inline": false,
+                                          "inputs": {
+                                            "VALUE-0": {
+                                              "block": {
+                                                "type": "BackwardVector",
+                                                "id": "v,/hLm88TEBH9/WV!g|C"
+                                              }
+                                            },
+                                            "VALUE-1": {
+                                              "block": {
+                                                "type": "Normalize",
+                                                "id": "Y,ndH=t-b.,g-I|EhC=K",
+                                                "inputs": {
+                                                  "VALUE-0": {
+                                                    "block": {
+                                                      "type": "CreateVector",
+                                                      "id": "d9)KV0|Jz2BP[npE`p60",
+                                                      "inline": false,
+                                                      "inputs": {
+                                                        "VALUE-0": {
+                                                          "block": {
+                                                            "type": "XComponentOf",
+                                                            "id": "i*`~|Ed|1j,u+Nqp2Vr[",
+                                                            "inputs": {
+                                                              "VALUE-0": {
+                                                                "block": {
+                                                                  "type": "GetVariable",
+                                                                  "id": "MArA@fWNY~bU^KCWl?oM",
+                                                                  "inputs": {
+                                                                    "VALUE-0": {
+                                                                      "block": {
+                                                                        "type": "variableReferenceBlock",
+                                                                        "id": "f$DxaACce]T@lLR^x4hj",
+                                                                        "extraState": {
+                                                                          "isObjectVar": true
+                                                                        },
+                                                                        "fields": {
+                                                                          "OBJECTTYPE": "Player",
+                                                                          "VAR": {
+                                                                            "id": "Q5Zu0keSSA7tlAfVDnKZ"
+                                                                          }
+                                                                        },
+                                                                        "inputs": {
+                                                                          "OBJECT": {
+                                                                            "block": {
+                                                                              "type": "EventPlayer",
+                                                                              "id": "Cqm.D-ggOgMK!$00G6vL"
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        },
+                                                        "VALUE-1": {
+                                                          "block": {
+                                                            "type": "Number",
+                                                            "id": "Bj!u4a4Iz7vokK(ZubJn",
+                                                            "fields": {
+                                                              "NUM": 0
+                                                            }
+                                                          }
+                                                        },
+                                                        "VALUE-2": {
+                                                          "block": {
+                                                            "type": "ZComponentOf",
+                                                            "id": "(yJc!=LiGQ6E?dRm_2bE",
+                                                            "inputs": {
+                                                              "VALUE-0": {
+                                                                "block": {
+                                                                  "type": "GetVariable",
+                                                                  "id": "a:0ghRF|nb$zv[}LkY@2",
+                                                                  "inputs": {
+                                                                    "VALUE-0": {
+                                                                      "block": {
+                                                                        "type": "variableReferenceBlock",
+                                                                        "id": "_iFES)kF^,`@Q/H?@B!^",
+                                                                        "extraState": {
+                                                                          "isObjectVar": true
+                                                                        },
+                                                                        "fields": {
+                                                                          "OBJECTTYPE": "Player",
+                                                                          "VAR": {
+                                                                            "id": "Q5Zu0keSSA7tlAfVDnKZ"
+                                                                          }
+                                                                        },
+                                                                        "inputs": {
+                                                                          "OBJECT": {
+                                                                            "block": {
+                                                                              "type": "EventPlayer",
+                                                                              "id": "hX5-=hqb+9?tw|8p;),7"
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "VALUE-1": {
+                                  "block": {
+                                    "type": "Divide",
+                                    "id": "SQ;q}4T7NgZj?P#c[URw",
+                                    "inline": false,
+                                    "inputs": {
+                                      "VALUE-0": {
+                                        "block": {
+                                          "type": "ArctangentInRadians",
+                                          "id": "j^%5T|6IL.wFLC2VPt*h",
+                                          "inputs": {
+                                            "VALUE-0": {
+                                              "block": {
+                                                "type": "Number",
+                                                "id": "I22e00C?rdSL@|`,w|Yp",
+                                                "fields": {
+                                                  "NUM": 1
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "VALUE-1": {
+                                        "block": {
+                                          "type": "Number",
+                                          "id": "_kN?t-4i?cBfz~GU?5x.",
+                                          "fields": {
+                                            "NUM": 45
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
                               }
                             }
                           }
                         }
                       }
                     }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "subroutineBlock",
+        "id": "HqoKtBI,Z-g5p`5)-v*a",
+        "x": 3921,
+        "y": 7214,
+        "extraState": {
+          "subroutineName": "MCOM_Setup",
+          "parameters": []
+        },
+        "fields": {
+          "SUBROUTINE_NAME": "MCOM_Setup"
+        },
+        "inputs": {
+          "ACTIONS": {
+            "block": {
+              "type": "EnableObjective",
+              "id": "QH|xeccx6MOiz!({81Y#",
+              "inputs": {
+                "VALUE-0": {
+                  "block": {
+                    "type": "GetVariable",
+                    "id": "W*:yn2cbR(6!y)%Nl,SY",
+                    "inputs": {
+                      "VALUE-0": {
+                        "block": {
+                          "type": "variableReferenceBlock",
+                          "id": "JE4*C83fWr-qi}zvz+rF",
+                          "extraState": {
+                            "isObjectVar": false
+                          },
+                          "fields": {
+                            "OBJECTTYPE": "Global",
+                            "VAR": {
+                              "id": "W?M=066mWT~Tf=[ON!`$"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "VALUE-1": {
+                  "block": {
+                    "type": "Boolean",
+                    "id": "#b#ZXsbV#m_L5^jima1]",
+                    "fields": {
+                      "BOOL": "TRUE"
+                    }
+                  }
+                }
+              },
+              "next": {
+                "block": {
+                  "type": "EnableObjective",
+                  "id": "-vAfxH},^~Z8EFKdGybx",
+                  "inputs": {
+                    "VALUE-0": {
+                      "block": {
+                        "type": "GetVariable",
+                        "id": "bTK*K#zKeq,|oXmJaG{a",
+                        "inputs": {
+                          "VALUE-0": {
+                            "block": {
+                              "type": "variableReferenceBlock",
+                              "id": "O7aD$mYuIr5WuU)XAf4S",
+                              "extraState": {
+                                "isObjectVar": false
+                              },
+                              "fields": {
+                                "OBJECTTYPE": "Global",
+                                "VAR": {
+                                  "id": "ZCBg+S5Y0?xD[@GpnRJ."
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "VALUE-1": {
+                      "block": {
+                        "type": "Boolean",
+                        "id": "-;RFf#Se/ib,E/Rpm-=D",
+                        "fields": {
+                          "BOOL": "TRUE"
+                        }
+                      }
+                    }
                   },
                   "next": {
                     "block": {
-                      "type": "subroutineInstanceBlock",
-                      "id": "QgA!k4PGIE*`*G:K,HWN",
-                      "extraState": {
-                        "subroutineName": "Append",
-                        "parameters": [
-                          {
-                            "types": "Vector",
-                            "name": "Vector"
-                          }
-                        ]
-                      },
-                      "fields": {
-                        "SUBROUTINE_NAME": "Append"
-                      },
+                      "type": "SetMCOMFuseTime",
+                      "id": "z$Y5UZ;O(~V:wiQA[wSK",
                       "inputs": {
-                        "PARAM-0": {
+                        "VALUE-0": {
                           "block": {
-                            "type": "CreateVector",
-                            "id": "!cU]vuf:TE]0PtxSY3l.",
+                            "type": "GetVariable",
+                            "id": "YdSVykh_bBLW39;0SxTa",
                             "inputs": {
                               "VALUE-0": {
                                 "block": {
-                                  "type": "Number",
-                                  "id": "bYyuw_,9w?P!9+Bu$E%L",
+                                  "type": "variableReferenceBlock",
+                                  "id": "?pF^W:bo*97h9aUx{CTh",
+                                  "extraState": {
+                                    "isObjectVar": false
+                                  },
                                   "fields": {
-                                    "NUM": -14.9
+                                    "OBJECTTYPE": "Global",
+                                    "VAR": {
+                                      "id": "W?M=066mWT~Tf=[ON!`$"
+                                    }
                                   }
                                 }
-                              },
-                              "VALUE-1": {
+                              }
+                            }
+                          }
+                        },
+                        "VALUE-1": {
+                          "block": {
+                            "type": "GetVariable",
+                            "id": "U^(M#:pWp6?C62:nA;~#",
+                            "inputs": {
+                              "VALUE-0": {
                                 "block": {
-                                  "type": "Number",
-                                  "id": ";[k,:hNT35[%:;aw;F+Z",
+                                  "type": "variableReferenceBlock",
+                                  "id": "Y8m{~Kp,jS;TN}!F$Fk,",
+                                  "extraState": {
+                                    "isObjectVar": false
+                                  },
                                   "fields": {
-                                    "NUM": 57.2
-                                  }
-                                }
-                              },
-                              "VALUE-2": {
-                                "block": {
-                                  "type": "Number",
-                                  "id": "d*tx?Q6PNZJ3vBkGiA9M",
-                                  "fields": {
-                                    "NUM": -137.1
+                                    "OBJECTTYPE": "Global",
+                                    "VAR": {
+                                      "id": "G8`8D):j~iWsK^BLzR?n"
+                                    }
                                   }
                                 }
                               }
@@ -2240,50 +8685,49 @@
                       },
                       "next": {
                         "block": {
-                          "type": "subroutineInstanceBlock",
-                          "id": "~:rJA3w(?O5q*|hy2QpJ",
-                          "extraState": {
-                            "subroutineName": "Append",
-                            "parameters": [
-                              {
-                                "types": "Vector",
-                                "name": "Vector"
-                              }
-                            ]
-                          },
-                          "fields": {
-                            "SUBROUTINE_NAME": "Append"
-                          },
+                          "type": "SetMCOMFuseTime",
+                          "id": "U:M3.6|(_#|uD;^XSck;",
                           "inputs": {
-                            "PARAM-0": {
+                            "VALUE-0": {
                               "block": {
-                                "type": "CreateVector",
-                                "id": "{T:VUqpt*Qj*~CK1H(y_",
+                                "type": "GetVariable",
+                                "id": "0fK7ju)A%^7y_l+sGbHJ",
                                 "inputs": {
                                   "VALUE-0": {
                                     "block": {
-                                      "type": "Number",
-                                      "id": "(R[LcaVqK#=#GvFDqj|G",
+                                      "type": "variableReferenceBlock",
+                                      "id": "f%X-vDZ7^+uPjP!~{Ceb",
+                                      "extraState": {
+                                        "isObjectVar": false
+                                      },
                                       "fields": {
-                                        "NUM": -36.7
+                                        "OBJECTTYPE": "Global",
+                                        "VAR": {
+                                          "id": "ZCBg+S5Y0?xD[@GpnRJ."
+                                        }
                                       }
                                     }
-                                  },
-                                  "VALUE-1": {
+                                  }
+                                }
+                              }
+                            },
+                            "VALUE-1": {
+                              "block": {
+                                "type": "GetVariable",
+                                "id": ",UBM/.)ybsmeL_glu*pi",
+                                "inputs": {
+                                  "VALUE-0": {
                                     "block": {
-                                      "type": "Number",
-                                      "id": "]XaO#JVFe^(q?(|U)=pZ",
+                                      "type": "variableReferenceBlock",
+                                      "id": "Omo^h%{0kd?ps`vTsb{t",
+                                      "extraState": {
+                                        "isObjectVar": false
+                                      },
                                       "fields": {
-                                        "NUM": 57.1
-                                      }
-                                    }
-                                  },
-                                  "VALUE-2": {
-                                    "block": {
-                                      "type": "Number",
-                                      "id": ".[?Zk+xj@Tp(9VYskB--",
-                                      "fields": {
-                                        "NUM": -134.3
+                                        "OBJECTTYPE": "Global",
+                                        "VAR": {
+                                          "id": "G8`8D):j~iWsK^BLzR?n"
+                                        }
                                       }
                                     }
                                   }
@@ -2293,50 +8737,72 @@
                           },
                           "next": {
                             "block": {
-                              "type": "subroutineInstanceBlock",
-                              "id": "cS@~PS]Sqr!sQxTWZ42/",
-                              "extraState": {
-                                "subroutineName": "Append",
-                                "parameters": [
-                                  {
-                                    "types": "Vector",
-                                    "name": "Vector"
-                                  }
-                                ]
-                              },
-                              "fields": {
-                                "SUBROUTINE_NAME": "Append"
-                              },
+                              "type": "Teleport",
+                              "id": "5Ve#=s8aKQSSq~yIZpaI",
                               "inputs": {
-                                "PARAM-0": {
+                                "VALUE-0": {
                                   "block": {
-                                    "type": "CreateVector",
-                                    "id": "CSh%e/(=eQKY)7gd565S",
+                                    "type": "GetVariable",
+                                    "id": "#~M{EQ{+HB%=/=Jn,It0",
                                     "inputs": {
                                       "VALUE-0": {
                                         "block": {
-                                          "type": "Number",
-                                          "id": "z:|EmYy;KTUp[xzo$5E1",
+                                          "type": "variableReferenceBlock",
+                                          "id": "p)xUf*dqCtJjs8V-69y;",
+                                          "extraState": {
+                                            "isObjectVar": false
+                                          },
                                           "fields": {
-                                            "NUM": -78.9
+                                            "OBJECTTYPE": "Global",
+                                            "VAR": {
+                                              "id": "W?M=066mWT~Tf=[ON!`$"
+                                            }
                                           }
                                         }
-                                      },
-                                      "VALUE-1": {
+                                      }
+                                    }
+                                  }
+                                },
+                                "VALUE-1": {
+                                  "block": {
+                                    "type": "GetVariable",
+                                    "id": "aitBqw|_B6Rf`2+?,l`|",
+                                    "inputs": {
+                                      "VALUE-0": {
                                         "block": {
-                                          "type": "Number",
-                                          "id": "{5bdOx!Cqn/60smYi+PT",
+                                          "type": "variableReferenceBlock",
+                                          "id": "}l5%3{i0,ruW;10$+`6b",
+                                          "extraState": {
+                                            "isObjectVar": false
+                                          },
                                           "fields": {
-                                            "NUM": 57.1
+                                            "OBJECTTYPE": "Global",
+                                            "VAR": {
+                                              "id": "]dWwQ+kkD!f)85rwAEAQ"
+                                            }
                                           }
                                         }
-                                      },
-                                      "VALUE-2": {
+                                      }
+                                    }
+                                  }
+                                },
+                                "VALUE-2": {
+                                  "block": {
+                                    "type": "GetVariable",
+                                    "id": "We_jC4#7$MC5fxcvBiu:",
+                                    "inputs": {
+                                      "VALUE-0": {
                                         "block": {
-                                          "type": "Number",
-                                          "id": "A.L-szF4cB*Kc).mr$uJ",
+                                          "type": "variableReferenceBlock",
+                                          "id": "/yTjyaR!]^qKxiNyi^LA",
+                                          "extraState": {
+                                            "isObjectVar": false
+                                          },
                                           "fields": {
-                                            "NUM": -108.32
+                                            "OBJECTTYPE": "Global",
+                                            "VAR": {
+                                              "id": "eF$rR9X[_su_hNxhGZ`R"
+                                            }
                                           }
                                         }
                                       }
@@ -2346,20 +8812,28 @@
                               },
                               "next": {
                                 "block": {
-                                  "type": "SetVariable",
-                                  "id": "~j+.x/]0{}#s4h~2Ec8.",
+                                  "type": "Teleport",
+                                  "id": "^-HX$rLUI-6L(~-orqF5",
                                   "inputs": {
                                     "VALUE-0": {
                                       "block": {
-                                        "type": "variableReferenceBlock",
-                                        "id": ",8d`td{vLvs}]Hb/~a]5",
-                                        "extraState": {
-                                          "isObjectVar": false
-                                        },
-                                        "fields": {
-                                          "OBJECTTYPE": "Global",
-                                          "VAR": {
-                                            "id": "avhOM{5IU+T,cbtA-5?M"
+                                        "type": "GetVariable",
+                                        "id": "Cyc:U:.2XO^bN#$lUhhs",
+                                        "inputs": {
+                                          "VALUE-0": {
+                                            "block": {
+                                              "type": "variableReferenceBlock",
+                                              "id": "hZk~F].x1uVD$|BRzk5e",
+                                              "extraState": {
+                                                "isObjectVar": false
+                                              },
+                                              "fields": {
+                                                "OBJECTTYPE": "Global",
+                                                "VAR": {
+                                                  "id": "ZCBg+S5Y0?xD[@GpnRJ."
+                                                }
+                                              }
+                                            }
                                           }
                                         }
                                       }
@@ -2367,19 +8841,42 @@
                                     "VALUE-1": {
                                       "block": {
                                         "type": "GetVariable",
-                                        "id": "x=+q1wd_GY^Y+1y@%YdS",
+                                        "id": "blTY#~b-mZwBw+nkRvvF",
                                         "inputs": {
                                           "VALUE-0": {
                                             "block": {
                                               "type": "variableReferenceBlock",
-                                              "id": "e[J:/T_XCXO[Nd#7hvH6",
+                                              "id": "f3uA|Ardzy,^9]6,Z;3-",
                                               "extraState": {
                                                 "isObjectVar": false
                                               },
                                               "fields": {
                                                 "OBJECTTYPE": "Global",
                                                 "VAR": {
-                                                  "id": "(ZHqM}3*6qf%Gv}2bOzk"
+                                                  "id": "s;)yD}A?@5f!E58$,z[c"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "VALUE-2": {
+                                      "block": {
+                                        "type": "GetVariable",
+                                        "id": "~{a#gN)m0JbByuDNkQ%V",
+                                        "inputs": {
+                                          "VALUE-0": {
+                                            "block": {
+                                              "type": "variableReferenceBlock",
+                                              "id": "C=%a9F6XD[I3}NN*ls2Y",
+                                              "extraState": {
+                                                "isObjectVar": false
+                                              },
+                                              "fields": {
+                                                "OBJECTTYPE": "Global",
+                                                "VAR": {
+                                                  "id": "x8Nn45#O(#5EaIGY=`@u"
                                                 }
                                               }
                                             }
@@ -2391,76 +8888,84 @@
                                   "next": {
                                     "block": {
                                       "type": "SetVariable",
-                                      "id": "-z`kZ.f`.Av{_,4OG/sD",
+                                      "id": "bTp[oWuD:YnYw0tm+Zqr",
                                       "inputs": {
                                         "VALUE-0": {
                                           "block": {
                                             "type": "variableReferenceBlock",
-                                            "id": "Foqw7O?gzi3t1,79Rhyg",
+                                            "id": "fK+~=a}I/5oe~xkFXv|p",
                                             "extraState": {
                                               "isObjectVar": false
                                             },
                                             "fields": {
                                               "OBJECTTYPE": "Global",
                                               "VAR": {
-                                                "id": "(ZHqM}3*6qf%Gv}2bOzk"
+                                                "id": "WmLAWml]VVTbibIk]jA/"
                                               }
                                             }
                                           }
                                         },
                                         "VALUE-1": {
                                           "block": {
-                                            "type": "EmptyArray",
-                                            "id": "h%D#qE45,aRomvH?q~1s"
+                                            "type": "GetVariable",
+                                            "id": ",vG7tA7CIPiF_+fID19v",
+                                            "inputs": {
+                                              "VALUE-0": {
+                                                "block": {
+                                                  "type": "variableReferenceBlock",
+                                                  "id": "S)bb24v74J(Hgm7w]@UU",
+                                                  "extraState": {
+                                                    "isObjectVar": false
+                                                  },
+                                                  "fields": {
+                                                    "OBJECTTYPE": "Global",
+                                                    "VAR": {
+                                                      "id": "G8`8D):j~iWsK^BLzR?n"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
                                           }
                                         }
                                       },
                                       "next": {
                                         "block": {
-                                          "type": "subroutineInstanceBlock",
-                                          "id": "~p+cQ1on1I=a!%n*9cPv",
-                                          "extraState": {
-                                            "subroutineName": "Append",
-                                            "parameters": [
-                                              {
-                                                "types": "Vector",
-                                                "name": "Vector"
-                                              }
-                                            ]
-                                          },
-                                          "fields": {
-                                            "SUBROUTINE_NAME": "Append"
-                                          },
+                                          "type": "SetVariable",
+                                          "id": "aX8xfM4P8@i7i1}f6Dfr",
                                           "inputs": {
-                                            "PARAM-0": {
+                                            "VALUE-0": {
                                               "block": {
-                                                "type": "CreateVector",
-                                                "id": "U`1;1ML*UH1Ta?lKXI$t",
+                                                "type": "variableReferenceBlock",
+                                                "id": "|laxQSPAYh3%lE^I+49}",
+                                                "extraState": {
+                                                  "isObjectVar": false
+                                                },
+                                                "fields": {
+                                                  "OBJECTTYPE": "Global",
+                                                  "VAR": {
+                                                    "id": "c[z#A9bNIqE/7|%xj;-G"
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "VALUE-1": {
+                                              "block": {
+                                                "type": "GetVariable",
+                                                "id": "4rV$Q:tTPS7;PDrA6_gg",
                                                 "inputs": {
                                                   "VALUE-0": {
                                                     "block": {
-                                                      "type": "Number",
-                                                      "id": "|_zC5bx=.VV~bo}r^d1O",
+                                                      "type": "variableReferenceBlock",
+                                                      "id": "Aoz{i~.)Zt/(/9Y{pUhS",
+                                                      "extraState": {
+                                                        "isObjectVar": false
+                                                      },
                                                       "fields": {
-                                                        "NUM": -116.2
-                                                      }
-                                                    }
-                                                  },
-                                                  "VALUE-1": {
-                                                    "block": {
-                                                      "type": "Number",
-                                                      "id": "W!HLbGF_E=-rYwS-$qs(",
-                                                      "fields": {
-                                                        "NUM": 57
-                                                      }
-                                                    }
-                                                  },
-                                                  "VALUE-2": {
-                                                    "block": {
-                                                      "type": "Number",
-                                                      "id": "pn57UGi[`:[1]B)k5)s3",
-                                                      "fields": {
-                                                        "NUM": -148.16
+                                                        "OBJECTTYPE": "Global",
+                                                        "VAR": {
+                                                          "id": "G8`8D):j~iWsK^BLzR?n"
+                                                        }
                                                       }
                                                     }
                                                   }
@@ -2470,250 +8975,385 @@
                                           },
                                           "next": {
                                             "block": {
-                                              "type": "subroutineInstanceBlock",
-                                              "id": "zj~)nI0~`]v];]p2ZjP!",
-                                              "extraState": {
-                                                "subroutineName": "Append",
-                                                "parameters": [
-                                                  {
-                                                    "types": "Vector",
-                                                    "name": "Vector"
-                                                  }
-                                                ]
-                                              },
-                                              "fields": {
-                                                "SUBROUTINE_NAME": "Append"
-                                              },
+                                              "type": "If",
+                                              "id": "Hf?Kn8M94eiZK_viXOR+",
+                                              "extraState": {},
                                               "inputs": {
-                                                "PARAM-0": {
+                                                "VALUE-0": {
                                                   "block": {
-                                                    "type": "CreateVector",
-                                                    "id": "DuK[h482qwpLN./e=Ozn",
+                                                    "type": "GetVariable",
+                                                    "id": "w6Z=H~SL$V@~?ns+Oez^",
                                                     "inputs": {
                                                       "VALUE-0": {
                                                         "block": {
-                                                          "type": "Number",
-                                                          "id": "y!{K:(tY!U;-agkl#/0s",
+                                                          "type": "variableReferenceBlock",
+                                                          "id": "5}Dn2Vm2dyQ*JVd0jexE",
+                                                          "extraState": {
+                                                            "isObjectVar": false
+                                                          },
                                                           "fields": {
-                                                            "NUM": -49.5
+                                                            "OBJECTTYPE": "Global",
+                                                            "VAR": {
+                                                              "id": "{EF$oQ94sNRA2*og65H/"
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "DO": {
+                                                  "block": {
+                                                    "type": "SetCapturePointOwner",
+                                                    "id": "hb#8A#qt6d/Tt$Jx/y4]",
+                                                    "inputs": {
+                                                      "VALUE-0": {
+                                                        "block": {
+                                                          "type": "GetCapturePoint",
+                                                          "id": "lY7=RzM]6E~?-uE7)[;~",
+                                                          "inputs": {
+                                                            "VALUE-0": {
+                                                              "block": {
+                                                                "type": "MCOMsItem",
+                                                                "id": ",u]hj*qi[Y#rx[rh;K0+",
+                                                                "fields": {
+                                                                  "VALUE-0": "MCOMs",
+                                                                  "VALUE-1": "E"
+                                                                }
+                                                              }
+                                                            }
                                                           }
                                                         }
                                                       },
                                                       "VALUE-1": {
                                                         "block": {
-                                                          "type": "Number",
-                                                          "id": "R$PsN?C:N4l((t.hifQO",
-                                                          "fields": {
-                                                            "NUM": 57
-                                                          }
-                                                        }
-                                                      },
-                                                      "VALUE-2": {
-                                                        "block": {
-                                                          "type": "Number",
-                                                          "id": "$YTTITLP1usIvhq8faw;",
-                                                          "fields": {
-                                                            "NUM": -187.8
+                                                          "type": "GetTeamId",
+                                                          "id": "!Fe:`DSb!Zfh0]Ae0q*q",
+                                                          "inputs": {
+                                                            "VALUE-0": {
+                                                              "block": {
+                                                                "type": "Number",
+                                                                "id": "CD5)Y1,(RuYdcFO_uj#K",
+                                                                "fields": {
+                                                                  "NUM": 1
+                                                                }
+                                                              }
+                                                            }
                                                           }
                                                         }
                                                       }
-                                                    }
-                                                  }
-                                                }
-                                              },
-                                              "next": {
-                                                "block": {
-                                                  "type": "subroutineInstanceBlock",
-                                                  "id": "PVzM?aQ{D5:@0`rhhkF!",
-                                                  "extraState": {
-                                                    "subroutineName": "Append",
-                                                    "parameters": [
-                                                      {
-                                                        "types": "Vector",
-                                                        "name": "Vector"
-                                                      }
-                                                    ]
-                                                  },
-                                                  "fields": {
-                                                    "SUBROUTINE_NAME": "Append"
-                                                  },
-                                                  "inputs": {
-                                                    "PARAM-0": {
+                                                    },
+                                                    "next": {
                                                       "block": {
-                                                        "type": "CreateVector",
-                                                        "id": "vKUEZO9h3zxX[EBCRCJO",
+                                                        "type": "SetCapturePointOwner",
+                                                        "id": "I4lLiP+O,^aUHjHmn#jA",
                                                         "inputs": {
                                                           "VALUE-0": {
                                                             "block": {
-                                                              "type": "Number",
-                                                              "id": "X`B;4jD6?M?E^|fA3W]v",
-                                                              "fields": {
-                                                                "NUM": -66.4
+                                                              "type": "GetCapturePoint",
+                                                              "id": "wQ{M%r:/$(2WnbI+3O4f",
+                                                              "inputs": {
+                                                                "VALUE-0": {
+                                                                  "block": {
+                                                                    "type": "MCOMsItem",
+                                                                    "id": ")~JS0KS2Sp0Ft4mtg1Lk",
+                                                                    "fields": {
+                                                                      "VALUE-0": "MCOMs",
+                                                                      "VALUE-1": "F"
+                                                                    }
+                                                                  }
+                                                                }
                                                               }
                                                             }
                                                           },
                                                           "VALUE-1": {
                                                             "block": {
-                                                              "type": "Number",
-                                                              "id": "Nm@FZaWwt?1rpgt8=3tD",
-                                                              "fields": {
-                                                                "NUM": 57.1
-                                                              }
-                                                            }
-                                                          },
-                                                          "VALUE-2": {
-                                                            "block": {
-                                                              "type": "Number",
-                                                              "id": "](~hBa$n%A6]?]3|N90O",
-                                                              "fields": {
-                                                                "NUM": -210.34
+                                                              "type": "GetTeamId",
+                                                              "id": "^EWi0Y_?E3Z}]/8q]SN0",
+                                                              "inputs": {
+                                                                "VALUE-0": {
+                                                                  "block": {
+                                                                    "type": "Number",
+                                                                    "id": "p0i^ME#+BWKhof6DX?@E",
+                                                                    "fields": {
+                                                                      "NUM": 1
+                                                                    }
+                                                                  }
+                                                                }
                                                               }
                                                             }
                                                           }
-                                                        }
-                                                      }
-                                                    }
-                                                  },
-                                                  "next": {
-                                                    "block": {
-                                                      "type": "subroutineInstanceBlock",
-                                                      "id": "h50g=rgvZ$IM*@`K$3cW",
-                                                      "extraState": {
-                                                        "subroutineName": "Append",
-                                                        "parameters": [
-                                                          {
-                                                            "types": "Vector",
-                                                            "name": "Vector"
-                                                          }
-                                                        ]
-                                                      },
-                                                      "fields": {
-                                                        "SUBROUTINE_NAME": "Append"
-                                                      },
-                                                      "inputs": {
-                                                        "PARAM-0": {
+                                                        },
+                                                        "next": {
                                                           "block": {
-                                                            "type": "CreateVector",
-                                                            "id": "qL1VylBc`HFP%MA]#(@P",
+                                                            "type": "EnableObjective",
+                                                            "id": "~4}-!m0Z.qA0p)OWj9SR",
                                                             "inputs": {
                                                               "VALUE-0": {
                                                                 "block": {
-                                                                  "type": "Number",
-                                                                  "id": "V@=O,TW/YW]q1?WAe0F5",
-                                                                  "fields": {
-                                                                    "NUM": -136.5
+                                                                  "type": "GetCapturePoint",
+                                                                  "id": "~gKx_lg$~CX5RN`=(%4+",
+                                                                  "inputs": {
+                                                                    "VALUE-0": {
+                                                                      "block": {
+                                                                        "type": "MCOMsItem",
+                                                                        "id": ";.jnRB/dma_@-FezS]iY",
+                                                                        "fields": {
+                                                                          "VALUE-0": "MCOMs",
+                                                                          "VALUE-1": "E"
+                                                                        }
+                                                                      }
+                                                                    }
                                                                   }
                                                                 }
                                                               },
                                                               "VALUE-1": {
                                                                 "block": {
-                                                                  "type": "Number",
-                                                                  "id": "^jKdN!y8miR0eZ$G5pXv",
+                                                                  "type": "Boolean",
+                                                                  "id": "MXjo1]g^:GSKqfis;9Eh",
                                                                   "fields": {
-                                                                    "NUM": 57.1
-                                                                  }
-                                                                }
-                                                              },
-                                                              "VALUE-2": {
-                                                                "block": {
-                                                                  "type": "Number",
-                                                                  "id": "4VGMR)nZMqD@uCU#vPvS",
-                                                                  "fields": {
-                                                                    "NUM": -164.37
+                                                                    "BOOL": "TRUE"
                                                                   }
                                                                 }
                                                               }
-                                                            }
-                                                          }
-                                                        }
-                                                      },
-                                                      "next": {
-                                                        "block": {
-                                                          "type": "SetVariable",
-                                                          "id": "J3O-jwut/_H4M.!Y!MKM",
-                                                          "inputs": {
-                                                            "VALUE-0": {
+                                                            },
+                                                            "next": {
                                                               "block": {
-                                                                "type": "variableReferenceBlock",
-                                                                "id": "TWrZ_ag5F/+7Fs5SzmV`",
-                                                                "extraState": {
-                                                                  "isObjectVar": true
-                                                                },
-                                                                "fields": {
-                                                                  "OBJECTTYPE": "TeamId",
-                                                                  "VAR": {
-                                                                    "id": "~!s}ovrs?jb7Yd/X[z2!"
-                                                                  }
-                                                                },
+                                                                "type": "EnableObjective",
+                                                                "id": "`$.AYb+M5B_0w29?-@n#",
                                                                 "inputs": {
-                                                                  "OBJECT": {
+                                                                  "VALUE-0": {
                                                                     "block": {
-                                                                      "type": "GetTeamId",
-                                                                      "id": "aS,7zvfx]L~zhrY0=4OV",
+                                                                      "type": "GetCapturePoint",
+                                                                      "id": "%%?aS`5IG)}ox!8.`o~5",
                                                                       "inputs": {
                                                                         "VALUE-0": {
                                                                           "block": {
-                                                                            "type": "Number",
-                                                                            "id": "pRWrn)-[[^gBSggtN9Hs",
+                                                                            "type": "MCOMsItem",
+                                                                            "id": "}rNVw%$P1?[?2YQiGuGh",
                                                                             "fields": {
-                                                                              "NUM": 1
+                                                                              "VALUE-0": "MCOMs",
+                                                                              "VALUE-1": "F"
                                                                             }
                                                                           }
                                                                         }
                                                                       }
                                                                     }
-                                                                  }
-                                                                }
-                                                              }
-                                                            },
-                                                            "VALUE-1": {
-                                                              "block": {
-                                                                "type": "GetVariable",
-                                                                "id": ",+?U@2FKy4*Tm3oN,YO2",
-                                                                "inputs": {
-                                                                  "VALUE-0": {
+                                                                  },
+                                                                  "VALUE-1": {
                                                                     "block": {
-                                                                      "type": "variableReferenceBlock",
-                                                                      "id": "oIJurVn*we5l!GA[qY;M",
-                                                                      "extraState": {
-                                                                        "isObjectVar": false
-                                                                      },
+                                                                      "type": "Boolean",
+                                                                      "id": "Pv-2K7$LKE6s!Sb!$~PE",
                                                                       "fields": {
-                                                                        "OBJECTTYPE": "Global",
-                                                                        "VAR": {
-                                                                          "id": "(ZHqM}3*6qf%Gv}2bOzk"
-                                                                        }
-                                                                      }
-                                                                    }
-                                                                  }
-                                                                }
-                                                              }
-                                                            }
-                                                          },
-                                                          "next": {
-                                                            "block": {
-                                                              "type": "SetVariable",
-                                                              "id": "dbQo1=wIF[Kuiy%a2mW1",
-                                                              "inputs": {
-                                                                "VALUE-0": {
-                                                                  "block": {
-                                                                    "type": "variableReferenceBlock",
-                                                                    "id": "kGHvT|lb=Jt,s;~C9o=5",
-                                                                    "extraState": {
-                                                                      "isObjectVar": false
-                                                                    },
-                                                                    "fields": {
-                                                                      "OBJECTTYPE": "Global",
-                                                                      "VAR": {
-                                                                        "id": "(ZHqM}3*6qf%Gv}2bOzk"
+                                                                        "BOOL": "TRUE"
                                                                       }
                                                                     }
                                                                   }
                                                                 },
-                                                                "VALUE-1": {
+                                                                "next": {
                                                                   "block": {
-                                                                    "type": "EmptyArray",
-                                                                    "id": "W//6UG6Y9$ExtFD^5;,Q"
+                                                                    "type": "Teleport",
+                                                                    "id": "w`N*Nlp*zKAIfb4`pqP^",
+                                                                    "inputs": {
+                                                                      "VALUE-0": {
+                                                                        "block": {
+                                                                          "type": "GetCapturePoint",
+                                                                          "id": "Nn^=-E:%?-DpXw0~lOz9",
+                                                                          "inputs": {
+                                                                            "VALUE-0": {
+                                                                              "block": {
+                                                                                "type": "MCOMsItem",
+                                                                                "id": "d7L6Gjj79$Mrr14kC*RW",
+                                                                                "fields": {
+                                                                                  "VALUE-0": "MCOMs",
+                                                                                  "VALUE-1": "E"
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      },
+                                                                      "VALUE-1": {
+                                                                        "block": {
+                                                                          "type": "Add",
+                                                                          "id": "f2|=^z#86~*(6@1VIPwH",
+                                                                          "inputs": {
+                                                                            "VALUE-0": {
+                                                                              "block": {
+                                                                                "type": "GetVariable",
+                                                                                "id": "i^Neg,ds~eo5:xX*iw1.",
+                                                                                "inputs": {
+                                                                                  "VALUE-0": {
+                                                                                    "block": {
+                                                                                      "type": "variableReferenceBlock",
+                                                                                      "id": "kalAIzkrqi)PT$/Dk_f~",
+                                                                                      "extraState": {
+                                                                                        "isObjectVar": false
+                                                                                      },
+                                                                                      "fields": {
+                                                                                        "OBJECTTYPE": "Global",
+                                                                                        "VAR": {
+                                                                                          "id": "]dWwQ+kkD!f)85rwAEAQ"
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            },
+                                                                            "VALUE-1": {
+                                                                              "block": {
+                                                                                "type": "Multiply",
+                                                                                "id": "1sPwW?NLaC+,u+23MEbP",
+                                                                                "inputs": {
+                                                                                  "VALUE-0": {
+                                                                                    "block": {
+                                                                                      "type": "UpVector",
+                                                                                      "id": "I=sGiB)LHySc!jrfR!5q"
+                                                                                    }
+                                                                                  },
+                                                                                  "VALUE-1": {
+                                                                                    "block": {
+                                                                                      "type": "Number",
+                                                                                      "id": "b#!qiykG8%Qa2H0gC^7{",
+                                                                                      "fields": {
+                                                                                        "NUM": 500
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      },
+                                                                      "VALUE-2": {
+                                                                        "block": {
+                                                                          "type": "GetVariable",
+                                                                          "id": "t!w)ecGIy-/Du-d;O|z9",
+                                                                          "inputs": {
+                                                                            "VALUE-0": {
+                                                                              "block": {
+                                                                                "type": "variableReferenceBlock",
+                                                                                "id": "WPb=|;YH(vYMzAeE8`j_",
+                                                                                "extraState": {
+                                                                                  "isObjectVar": false
+                                                                                },
+                                                                                "fields": {
+                                                                                  "OBJECTTYPE": "Global",
+                                                                                  "VAR": {
+                                                                                    "id": "eF$rR9X[_su_hNxhGZ`R"
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    "next": {
+                                                                      "block": {
+                                                                        "type": "Teleport",
+                                                                        "id": "vQOqO:-cQ`$~6oJoW@dm",
+                                                                        "inputs": {
+                                                                          "VALUE-0": {
+                                                                            "block": {
+                                                                              "type": "GetCapturePoint",
+                                                                              "id": "trn]S|MLV]8c{Ihq5%wZ",
+                                                                              "inputs": {
+                                                                                "VALUE-0": {
+                                                                                  "block": {
+                                                                                    "type": "MCOMsItem",
+                                                                                    "id": "1_68dLtuV,:#Z:6f|i,e",
+                                                                                    "fields": {
+                                                                                      "VALUE-0": "MCOMs",
+                                                                                      "VALUE-1": "F"
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          "VALUE-1": {
+                                                                            "block": {
+                                                                              "type": "Add",
+                                                                              "id": "S0W%hE,SMZp^%f`kSxDB",
+                                                                              "inputs": {
+                                                                                "VALUE-0": {
+                                                                                  "block": {
+                                                                                    "type": "GetVariable",
+                                                                                    "id": "9b0!n@}knP3M)UOov|7{",
+                                                                                    "inputs": {
+                                                                                      "VALUE-0": {
+                                                                                        "block": {
+                                                                                          "type": "variableReferenceBlock",
+                                                                                          "id": "/]`i(-I6%jUK@aw5s^t)",
+                                                                                          "extraState": {
+                                                                                            "isObjectVar": false
+                                                                                          },
+                                                                                          "fields": {
+                                                                                            "OBJECTTYPE": "Global",
+                                                                                            "VAR": {
+                                                                                              "id": "s;)yD}A?@5f!E58$,z[c"
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                },
+                                                                                "VALUE-1": {
+                                                                                  "block": {
+                                                                                    "type": "Multiply",
+                                                                                    "id": "+rtG38oxqQn5fC:3^vIX",
+                                                                                    "inputs": {
+                                                                                      "VALUE-0": {
+                                                                                        "block": {
+                                                                                          "type": "UpVector",
+                                                                                          "id": "F,ZbwQ7l[Rv8;rEd5-yu"
+                                                                                        }
+                                                                                      },
+                                                                                      "VALUE-1": {
+                                                                                        "block": {
+                                                                                          "type": "Number",
+                                                                                          "id": "p{%SKz%KS#cvC?ou?7I*",
+                                                                                          "fields": {
+                                                                                            "NUM": 500
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          "VALUE-2": {
+                                                                            "block": {
+                                                                              "type": "GetVariable",
+                                                                              "id": "QRoc1`0Cmc9d,iGRp-PF",
+                                                                              "inputs": {
+                                                                                "VALUE-0": {
+                                                                                  "block": {
+                                                                                    "type": "variableReferenceBlock",
+                                                                                    "id": "*d{ujOEHfLwKGunvJGt1",
+                                                                                    "extraState": {
+                                                                                      "isObjectVar": false
+                                                                                    },
+                                                                                    "fields": {
+                                                                                      "OBJECTTYPE": "Global",
+                                                                                      "VAR": {
+                                                                                        "id": "x8Nn45#O(#5EaIGY=`@u"
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
                                                                   }
                                                                 }
                                                               }
@@ -2744,14 +9384,1634 @@
             }
           }
         }
+      },
+      {
+        "type": "subroutineBlock",
+        "id": "Be7w)-;ly?4`6/eX]*_i",
+        "x": 3917,
+        "y": 3611,
+        "extraState": {
+          "subroutineName": "PlayArea",
+          "parameters": [
+            {
+              "types": "Vector",
+              "name": "Vector"
+            }
+          ]
+        },
+        "fields": {
+          "SUBROUTINE_NAME": "PlayArea"
+        },
+        "inputs": {
+          "ACTIONS": {
+            "block": {
+              "type": "SetVariable",
+              "id": "!mD,EnT13XXaNkxQ^E]Y",
+              "inputs": {
+                "VALUE-0": {
+                  "block": {
+                    "type": "variableReferenceBlock",
+                    "id": "(|F`Hpuk]tmo=wP1R|zg",
+                    "extraState": {
+                      "isObjectVar": false
+                    },
+                    "fields": {
+                      "OBJECTTYPE": "Global",
+                      "VAR": {
+                        "id": "avhOM{5IU+T,cbtA-5?M"
+                      }
+                    }
+                  }
+                },
+                "VALUE-1": {
+                  "block": {
+                    "type": "AppendToArray",
+                    "id": "LqB{*)U-/{i#vaDVzK]l",
+                    "inputs": {
+                      "VALUE-0": {
+                        "block": {
+                          "type": "GetVariable",
+                          "id": "ti}EBmM==nPWVbb#t2o{",
+                          "inputs": {
+                            "VALUE-0": {
+                              "block": {
+                                "type": "variableReferenceBlock",
+                                "id": "8|=Ws,8AlY:XJH%wL)Rd",
+                                "extraState": {
+                                  "isObjectVar": false
+                                },
+                                "fields": {
+                                  "OBJECTTYPE": "Global",
+                                  "VAR": {
+                                    "id": "avhOM{5IU+T,cbtA-5?M"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "VALUE-1": {
+                        "block": {
+                          "type": "subroutineArgumentBlock",
+                          "id": "[LD8ey5Y.i;!PpNDFq%$",
+                          "fields": {
+                            "ARGUMENT_INDEX": "0"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "subroutineBlock",
+        "id": "-mR6uLX297xW`GVix4oB",
+        "x": 3915,
+        "y": 3882,
+        "extraState": {
+          "subroutineName": "Team1_HQ_Boundaries",
+          "parameters": [
+            {
+              "types": "Vector",
+              "name": "Vector"
+            }
+          ]
+        },
+        "fields": {
+          "SUBROUTINE_NAME": "Team1_HQ_Boundaries"
+        },
+        "inputs": {
+          "ACTIONS": {
+            "block": {
+              "type": "SetVariable",
+              "id": "`#lH!lF5Vh+|XG5XW_he",
+              "inputs": {
+                "VALUE-0": {
+                  "block": {
+                    "type": "variableReferenceBlock",
+                    "id": "mo?g%Il;uo!yyQ=~rY-h",
+                    "extraState": {
+                      "isObjectVar": true
+                    },
+                    "fields": {
+                      "OBJECTTYPE": "TeamId",
+                      "VAR": {
+                        "id": "~!s}ovrs?jb7Yd/X[z2!"
+                      }
+                    },
+                    "inputs": {
+                      "OBJECT": {
+                        "block": {
+                          "type": "GetTeamId",
+                          "id": "1T_X[`{Xe[CGQ1wqRc-8",
+                          "inputs": {
+                            "VALUE-0": {
+                              "block": {
+                                "type": "Number",
+                                "id": "c=,Yy~B3ov_`VJc:zf7x",
+                                "fields": {
+                                  "NUM": 1
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "VALUE-1": {
+                  "block": {
+                    "type": "AppendToArray",
+                    "id": "C4O[s_-L4jxVJ0Z@OyBD",
+                    "inputs": {
+                      "VALUE-0": {
+                        "block": {
+                          "type": "GetVariable",
+                          "id": "trMTVTT?P4F@3;lRm!.F",
+                          "inputs": {
+                            "VALUE-0": {
+                              "block": {
+                                "type": "variableReferenceBlock",
+                                "id": "wx;.7Ao+oqV)I3JOBoO?",
+                                "extraState": {
+                                  "isObjectVar": true
+                                },
+                                "fields": {
+                                  "OBJECTTYPE": "TeamId",
+                                  "VAR": {
+                                    "id": "~!s}ovrs?jb7Yd/X[z2!"
+                                  }
+                                },
+                                "inputs": {
+                                  "OBJECT": {
+                                    "block": {
+                                      "type": "GetTeamId",
+                                      "id": "@wa!fI-V|oXwh;s?O?_5",
+                                      "inputs": {
+                                        "VALUE-0": {
+                                          "block": {
+                                            "type": "Number",
+                                            "id": "5)[1Wa`,9jri7*Q./@E{",
+                                            "fields": {
+                                              "NUM": 1
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "VALUE-1": {
+                        "block": {
+                          "type": "subroutineArgumentBlock",
+                          "id": "GRT$(O=7fZi`5L5uGPW#",
+                          "fields": {
+                            "ARGUMENT_INDEX": "0"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "subroutineBlock",
+        "id": "T%w/wk0?n^b^tqu{Sz0N",
+        "x": 3918,
+        "y": 10705,
+        "extraState": {
+          "subroutineName": "MCOMTracker",
+          "parameters": []
+        },
+        "fields": {
+          "SUBROUTINE_NAME": "MCOMTracker"
+        },
+        "inputs": {
+          "ACTIONS": {
+            "block": {
+              "type": "If",
+              "id": "(4WTQoI#_@qoNf!S}^{}",
+              "extraState": {},
+              "inputs": {
+                "VALUE-0": {
+                  "block": {
+                    "type": "And",
+                    "id": "Q7tUk|.`6NV;y}/lInlW",
+                    "inputs": {
+                      "VALUE-0": {
+                        "block": {
+                          "type": "GetMCOMState",
+                          "id": "^d|-RUDLB1g1sB_DB.Rv",
+                          "inputs": {
+                            "VALUE-0": {
+                              "block": {
+                                "type": "GetVariable",
+                                "id": "ZaV[v-{f-{|G2{E,#]kq",
+                                "inputs": {
+                                  "VALUE-0": {
+                                    "block": {
+                                      "type": "variableReferenceBlock",
+                                      "id": "gP|:GpA76;%Ar|[Rol]T",
+                                      "extraState": {
+                                        "isObjectVar": false
+                                      },
+                                      "fields": {
+                                        "OBJECTTYPE": "Global",
+                                        "VAR": {
+                                          "id": "W?M=066mWT~Tf=[ON!`$"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "VALUE-1": {
+                              "block": {
+                                "type": "MCOMStateBoolItem",
+                                "id": "?|ngOo4%/_z`bvsV^60l",
+                                "fields": {
+                                  "VALUE-0": "MCOMStateBool",
+                                  "VALUE-1": "IsArmed"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "VALUE-1": {
+                        "block": {
+                          "type": "Not",
+                          "id": "pyrm5c.k)[mz{Hq-SI|t",
+                          "inputs": {
+                            "VALUE-0": {
+                              "block": {
+                                "type": "GetMCOMState",
+                                "id": "!wxtO{ZKaHK/xJW_J1;k",
+                                "inputs": {
+                                  "VALUE-0": {
+                                    "block": {
+                                      "type": "GetVariable",
+                                      "id": "c=Pff_GEVu[7Y$(8T2Y_",
+                                      "inputs": {
+                                        "VALUE-0": {
+                                          "block": {
+                                            "type": "variableReferenceBlock",
+                                            "id": "R}/7K!CnH/q5cHf[d6,3",
+                                            "extraState": {
+                                              "isObjectVar": false
+                                            },
+                                            "fields": {
+                                              "OBJECTTYPE": "Global",
+                                              "VAR": {
+                                                "id": "W?M=066mWT~Tf=[ON!`$"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "VALUE-1": {
+                                    "block": {
+                                      "type": "MCOMStateBoolItem",
+                                      "id": "6OE-o:@8%)7^|^xM3LIp",
+                                      "fields": {
+                                        "VALUE-0": "MCOMStateBool",
+                                        "VALUE-1": "IsDefusing"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "DO": {
+                  "block": {
+                    "type": "SetVariable",
+                    "id": "J}{jdXF|k+x(9sgn^$m*",
+                    "inputs": {
+                      "VALUE-0": {
+                        "block": {
+                          "type": "variableReferenceBlock",
+                          "id": "4Gs0MJmgO$!I38]Y5uUP",
+                          "extraState": {
+                            "isObjectVar": false
+                          },
+                          "fields": {
+                            "OBJECTTYPE": "Global",
+                            "VAR": {
+                              "id": "WmLAWml]VVTbibIk]jA/"
+                            }
+                          }
+                        }
+                      },
+                      "VALUE-1": {
+                        "block": {
+                          "type": "GetRemainingFuseTime",
+                          "id": "M2=%s5ykk1rvmbJSm`u=",
+                          "inputs": {
+                            "VALUE-0": {
+                              "block": {
+                                "type": "GetVariable",
+                                "id": "vQ~jtzBFp46*@7GO1_6a",
+                                "inputs": {
+                                  "VALUE-0": {
+                                    "block": {
+                                      "type": "variableReferenceBlock",
+                                      "id": "#{}v+npbZhz[)d9AI)U`",
+                                      "extraState": {
+                                        "isObjectVar": false
+                                      },
+                                      "fields": {
+                                        "OBJECTTYPE": "Global",
+                                        "VAR": {
+                                          "id": "W?M=066mWT~Tf=[ON!`$"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "next": {
+                "block": {
+                  "type": "If",
+                  "id": "*Qre1Q_#/G)E}J(xwPH5",
+                  "extraState": {},
+                  "inputs": {
+                    "VALUE-0": {
+                      "block": {
+                        "type": "And",
+                        "id": "}6=diC:s3w}s6una]2Zv",
+                        "inputs": {
+                          "VALUE-0": {
+                            "block": {
+                              "type": "GetMCOMState",
+                              "id": "}OV/)z]}Bi4xcXg#.iN4",
+                              "inputs": {
+                                "VALUE-0": {
+                                  "block": {
+                                    "type": "GetVariable",
+                                    "id": "[/HF`1p]G^3GYj5}mqA/",
+                                    "inputs": {
+                                      "VALUE-0": {
+                                        "block": {
+                                          "type": "variableReferenceBlock",
+                                          "id": "LH*ysP8[*RQ`V^d8s6aF",
+                                          "extraState": {
+                                            "isObjectVar": false
+                                          },
+                                          "fields": {
+                                            "OBJECTTYPE": "Global",
+                                            "VAR": {
+                                              "id": "ZCBg+S5Y0?xD[@GpnRJ."
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "VALUE-1": {
+                                  "block": {
+                                    "type": "MCOMStateBoolItem",
+                                    "id": "h)}{y%nK%-%.h3DG@`75",
+                                    "fields": {
+                                      "VALUE-0": "MCOMStateBool",
+                                      "VALUE-1": "IsArmed"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "VALUE-1": {
+                            "block": {
+                              "type": "Not",
+                              "id": "vqU%zu*95[ImnMq=o*DA",
+                              "inputs": {
+                                "VALUE-0": {
+                                  "block": {
+                                    "type": "GetMCOMState",
+                                    "id": "OXky)4_WbQ4H^DI6L_j3",
+                                    "inputs": {
+                                      "VALUE-0": {
+                                        "block": {
+                                          "type": "GetVariable",
+                                          "id": "3!PU~^nqq:#saGw$%(ZO",
+                                          "inputs": {
+                                            "VALUE-0": {
+                                              "block": {
+                                                "type": "variableReferenceBlock",
+                                                "id": ":e`9b^GWC[pSgaXEfe:c",
+                                                "extraState": {
+                                                  "isObjectVar": false
+                                                },
+                                                "fields": {
+                                                  "OBJECTTYPE": "Global",
+                                                  "VAR": {
+                                                    "id": "ZCBg+S5Y0?xD[@GpnRJ."
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "VALUE-1": {
+                                        "block": {
+                                          "type": "MCOMStateBoolItem",
+                                          "id": "2phRR|Xt/brl0=U_}((a",
+                                          "fields": {
+                                            "VALUE-0": "MCOMStateBool",
+                                            "VALUE-1": "IsDefusing"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "DO": {
+                      "block": {
+                        "type": "SetVariable",
+                        "id": "jv_ks)Llwh[8idF,4f)1",
+                        "inputs": {
+                          "VALUE-0": {
+                            "block": {
+                              "type": "variableReferenceBlock",
+                              "id": "hOOGC*+a(!@,E2uk^l%v",
+                              "extraState": {
+                                "isObjectVar": false
+                              },
+                              "fields": {
+                                "OBJECTTYPE": "Global",
+                                "VAR": {
+                                  "id": "c[z#A9bNIqE/7|%xj;-G"
+                                }
+                              }
+                            }
+                          },
+                          "VALUE-1": {
+                            "block": {
+                              "type": "GetRemainingFuseTime",
+                              "id": "5w3N=lIU_X1P*;*-;h30",
+                              "inputs": {
+                                "VALUE-0": {
+                                  "block": {
+                                    "type": "GetVariable",
+                                    "id": "/lTH}Fj4I$=kI+Ap8}Z/",
+                                    "inputs": {
+                                      "VALUE-0": {
+                                        "block": {
+                                          "type": "variableReferenceBlock",
+                                          "id": "39`J4]cd@Ugv#O?s+:*j",
+                                          "extraState": {
+                                            "isObjectVar": false
+                                          },
+                                          "fields": {
+                                            "OBJECTTYPE": "Global",
+                                            "VAR": {
+                                              "id": "ZCBg+S5Y0?xD[@GpnRJ."
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "subroutineBlock",
+        "id": "m65)w39M+jnfmG8T}H/.",
+        "x": 3921,
+        "y": 9495,
+        "extraState": {
+          "subroutineName": "EveryTickGlobal",
+          "parameters": []
+        },
+        "fields": {
+          "SUBROUTINE_NAME": "EveryTickGlobal"
+        },
+        "inputs": {
+          "ACTIONS": {
+            "block": {
+              "type": "subroutineInstanceBlock",
+              "id": "NmQCY}EGq6redXFWm;_v",
+              "extraState": {
+                "subroutineName": "MCOMTracker",
+                "parameters": []
+              },
+              "fields": {
+                "SUBROUTINE_NAME": "MCOMTracker"
+              },
+              "next": {
+                "block": {
+                  "type": "subroutineInstanceBlock",
+                  "id": ":.xtzL98L+s3cL?q4XGG",
+                  "extraState": {
+                    "subroutineName": "UI",
+                    "parameters": []
+                  },
+                  "fields": {
+                    "SUBROUTINE_NAME": "UI"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "subroutineBlock",
+        "id": "ewJked[j(4W_OAGdTuI+",
+        "x": 3921,
+        "y": 9791,
+        "extraState": {
+          "subroutineName": "UI",
+          "parameters": []
+        },
+        "fields": {
+          "SUBROUTINE_NAME": "UI"
+        },
+        "inputs": {
+          "ACTIONS": {
+            "block": {
+              "type": "If",
+              "id": "zr$6Zsm?N{.Ot.K1nNYc",
+              "extraState": {},
+              "inputs": {
+                "VALUE-0": {
+                  "block": {
+                    "type": "Equals",
+                    "id": "aa?}[rs+xIq_KHiu%=cl",
+                    "inputs": {
+                      "VALUE-0": {
+                        "block": {
+                          "type": "GetVariable",
+                          "id": "`5`xK85yjcyq}P{]Ubas",
+                          "inputs": {
+                            "VALUE-0": {
+                              "block": {
+                                "type": "variableReferenceBlock",
+                                "id": "uineUK5E4R*U[!H(kgnZ",
+                                "extraState": {
+                                  "isObjectVar": false
+                                },
+                                "fields": {
+                                  "OBJECTTYPE": "Global",
+                                  "VAR": {
+                                    "id": "=8OY*aWMGF4.T^k6uLUl"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "VALUE-1": {
+                        "block": {
+                          "type": "GetVariable",
+                          "id": "nhBm8{Ad:Hvn*}!C-bwl",
+                          "inputs": {
+                            "VALUE-0": {
+                              "block": {
+                                "type": "variableReferenceBlock",
+                                "id": "7NfjAEiW$bfb;}z}8;RF",
+                                "extraState": {
+                                  "isObjectVar": false
+                                },
+                                "fields": {
+                                  "OBJECTTYPE": "Global",
+                                  "VAR": {
+                                    "id": "*%AGr_rl5x3.om4(DqsJ"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "DO": {
+                  "block": {
+                    "type": "DisplayCustomNotificationMessage",
+                    "id": "P,+c%^:2|pC}UA1n~9Z+",
+                    "inputs": {
+                      "VALUE-0": {
+                        "block": {
+                          "type": "Message",
+                          "id": "SY01WsL~FH/H6e5jKvVn",
+                          "inputs": {
+                            "VALUE-0": {
+                              "block": {
+                                "type": "Text",
+                                "id": "l{@X;+{`[`z,G@y5x2Nb",
+                                "fields": {
+                                  "TEXT": "Game Starting Soon"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "VALUE-1": {
+                        "block": {
+                          "type": "CustomMessagesItem",
+                          "id": "5?Xu]h:9XxnjQETynSK5",
+                          "fields": {
+                            "VALUE-0": "CustomMessages",
+                            "VALUE-1": "HeaderText"
+                          }
+                        }
+                      },
+                      "VALUE-2": {
+                        "block": {
+                          "type": "Number",
+                          "id": "J]S,Xfmsiazvy,H,N^hV",
+                          "fields": {
+                            "NUM": 1
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "next": {
+                "block": {
+                  "type": "If",
+                  "id": "sSUEv~p2J6cYmpoobsf0",
+                  "extraState": {},
+                  "inputs": {
+                    "VALUE-0": {
+                      "block": {
+                        "type": "Equals",
+                        "id": "MKN{fVo3T45yaOH%Y]SW",
+                        "inputs": {
+                          "VALUE-0": {
+                            "block": {
+                              "type": "GetVariable",
+                              "id": "LsFQ}]**jNz~|V^I,.`Y",
+                              "inputs": {
+                                "VALUE-0": {
+                                  "block": {
+                                    "type": "variableReferenceBlock",
+                                    "id": "O`;L;D|5m]#gIau({;M_",
+                                    "extraState": {
+                                      "isObjectVar": false
+                                    },
+                                    "fields": {
+                                      "OBJECTTYPE": "Global",
+                                      "VAR": {
+                                        "id": "=8OY*aWMGF4.T^k6uLUl"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "VALUE-1": {
+                            "block": {
+                              "type": "GetVariable",
+                              "id": "e46-[uTU~liEE^_a7+3F",
+                              "inputs": {
+                                "VALUE-0": {
+                                  "block": {
+                                    "type": "variableReferenceBlock",
+                                    "id": "m[ROw.))W=+P{2P.ymMk",
+                                    "extraState": {
+                                      "isObjectVar": false
+                                    },
+                                    "fields": {
+                                      "OBJECTTYPE": "Global",
+                                      "VAR": {
+                                        "id": "**%O*!0`FJS;40@p6=u|"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "DO": {
+                      "block": {
+                        "type": "DisplayCustomNotificationMessage",
+                        "id": "*4`pr1lK`eSpT|Y[)T?U",
+                        "inputs": {
+                          "VALUE-0": {
+                            "block": {
+                              "type": "Message",
+                              "id": "G1Ycf^XF$ERNyvCRS7.W",
+                              "inputs": {
+                                "VALUE-0": {
+                                  "block": {
+                                    "type": "Text",
+                                    "id": ";ds|^E@*rxV^egwkClnO",
+                                    "fields": {
+                                      "TEXT": "MCOM A Fuse : {}"
+                                    }
+                                  }
+                                },
+                                "VALUE-1": {
+                                  "block": {
+                                    "type": "RoundToInteger",
+                                    "id": "[05oO7@|(?C`*dK$Q9Zb",
+                                    "inputs": {
+                                      "VALUE-0": {
+                                        "block": {
+                                          "type": "GetVariable",
+                                          "id": "@KbwxkV[;nXnk1r4/(-5",
+                                          "inputs": {
+                                            "VALUE-0": {
+                                              "block": {
+                                                "type": "variableReferenceBlock",
+                                                "id": "MYyw[A3vQJJ4W@`TRe.|",
+                                                "extraState": {
+                                                  "isObjectVar": false
+                                                },
+                                                "fields": {
+                                                  "OBJECTTYPE": "Global",
+                                                  "VAR": {
+                                                    "id": "WmLAWml]VVTbibIk]jA/"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "VALUE-1": {
+                            "block": {
+                              "type": "CustomMessagesItem",
+                              "id": "2!]1{ElA5QxZiMUt^t|J",
+                              "fields": {
+                                "VALUE-0": "CustomMessages",
+                                "VALUE-1": "MessageText2"
+                              }
+                            }
+                          },
+                          "VALUE-2": {
+                            "block": {
+                              "type": "Number",
+                              "id": "-nZ.*[NnszztR{1.AUUW",
+                              "fields": {
+                                "NUM": 1
+                              }
+                            }
+                          }
+                        },
+                        "next": {
+                          "block": {
+                            "type": "DisplayCustomNotificationMessage",
+                            "id": "X4=szR2847kElh4@CQR6",
+                            "inputs": {
+                              "VALUE-0": {
+                                "block": {
+                                  "type": "Message",
+                                  "id": "Lp;E)oJz)RiBEs8CM?l^",
+                                  "inputs": {
+                                    "VALUE-0": {
+                                      "block": {
+                                        "type": "Text",
+                                        "id": "^ZWLU.D;KN/!Lc7jjp=0",
+                                        "fields": {
+                                          "TEXT": "MCOM B Fuse: {}"
+                                        }
+                                      }
+                                    },
+                                    "VALUE-1": {
+                                      "block": {
+                                        "type": "RoundToInteger",
+                                        "id": "$2G2-]Xv)+enT`zRp9KJ",
+                                        "inputs": {
+                                          "VALUE-0": {
+                                            "block": {
+                                              "type": "GetVariable",
+                                              "id": "zk449re7,vsl7.QonzNt",
+                                              "inputs": {
+                                                "VALUE-0": {
+                                                  "block": {
+                                                    "type": "variableReferenceBlock",
+                                                    "id": "hAt8D.@.sXBMUBYD8I3Z",
+                                                    "extraState": {
+                                                      "isObjectVar": false
+                                                    },
+                                                    "fields": {
+                                                      "OBJECTTYPE": "Global",
+                                                      "VAR": {
+                                                        "id": "c[z#A9bNIqE/7|%xj;-G"
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "VALUE-1": {
+                                "block": {
+                                  "type": "CustomMessagesItem",
+                                  "id": "|*PZx%5MgaIzRRbFGfnL",
+                                  "fields": {
+                                    "VALUE-0": "CustomMessages",
+                                    "VALUE-1": "MessageText3"
+                                  }
+                                }
+                              },
+                              "VALUE-2": {
+                                "block": {
+                                  "type": "Number",
+                                  "id": "HW%|#u-DbM,6/4^gO4c*",
+                                  "fields": {
+                                    "NUM": 1
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "next": {
+                    "block": {
+                      "type": "If",
+                      "id": "/P^,Iurz^Ux]sx!SgF6o",
+                      "extraState": {},
+                      "inputs": {
+                        "VALUE-0": {
+                          "block": {
+                            "type": "Equals",
+                            "id": "_g^3c0Z=I4[OThM@Tqty",
+                            "inputs": {
+                              "VALUE-0": {
+                                "block": {
+                                  "type": "GetVariable",
+                                  "id": "EMq;q5CzPOuO0Sav9y;[",
+                                  "inputs": {
+                                    "VALUE-0": {
+                                      "block": {
+                                        "type": "variableReferenceBlock",
+                                        "id": "[UZ5{+W7*|CTGaVwvai9",
+                                        "extraState": {
+                                          "isObjectVar": false
+                                        },
+                                        "fields": {
+                                          "OBJECTTYPE": "Global",
+                                          "VAR": {
+                                            "id": "=8OY*aWMGF4.T^k6uLUl"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "VALUE-1": {
+                                "block": {
+                                  "type": "GetVariable",
+                                  "id": ";#x_B*_De|I.F#Syw?FY",
+                                  "inputs": {
+                                    "VALUE-0": {
+                                      "block": {
+                                        "type": "variableReferenceBlock",
+                                        "id": "4wmQ/ftI7dZHZ~jN69n#",
+                                        "extraState": {
+                                          "isObjectVar": false
+                                        },
+                                        "fields": {
+                                          "OBJECTTYPE": "Global",
+                                          "VAR": {
+                                            "id": "Xr?o?acUGgeUMdeaBx?x"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "DO": {
+                          "block": {
+                            "type": "DisplayCustomNotificationMessage",
+                            "id": "(095ZZ3=,FwC6tnOA9zE",
+                            "inputs": {
+                              "VALUE-0": {
+                                "block": {
+                                  "type": "Message",
+                                  "id": "VvutaH{^l}$If.q4}.WC",
+                                  "inputs": {
+                                    "VALUE-0": {
+                                      "block": {
+                                        "type": "Text",
+                                        "id": "{g!:cU20(Xln+1mcdjxC",
+                                        "fields": {
+                                          "TEXT": "Next Round Starting Soon..."
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "VALUE-1": {
+                                "block": {
+                                  "type": "CustomMessagesItem",
+                                  "id": "z_,6oFc2J)xv_QiH[DX$",
+                                  "fields": {
+                                    "VALUE-0": "CustomMessages",
+                                    "VALUE-1": "HeaderText"
+                                  }
+                                }
+                              },
+                              "VALUE-2": {
+                                "block": {
+                                  "type": "Number",
+                                  "id": "`PeaadQdYE$Jt#p+Hz3a",
+                                  "fields": {
+                                    "NUM": 1
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "next": {
+                        "block": {
+                          "type": "If",
+                          "id": ";cuyKK|GDGTbc7X7f6Fe",
+                          "extraState": {},
+                          "inputs": {
+                            "VALUE-0": {
+                              "block": {
+                                "type": "Equals",
+                                "id": "sMl5guC9GX$?X_%$R^7L",
+                                "inputs": {
+                                  "VALUE-0": {
+                                    "block": {
+                                      "type": "GetVariable",
+                                      "id": "{[DM~j*M|NKLDjQBs,2o",
+                                      "inputs": {
+                                        "VALUE-0": {
+                                          "block": {
+                                            "type": "variableReferenceBlock",
+                                            "id": "B#DWgb6NvCL/CPF~SdUE",
+                                            "extraState": {
+                                              "isObjectVar": false
+                                            },
+                                            "fields": {
+                                              "OBJECTTYPE": "Global",
+                                              "VAR": {
+                                                "id": "=8OY*aWMGF4.T^k6uLUl"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "VALUE-1": {
+                                    "block": {
+                                      "type": "GetVariable",
+                                      "id": "sB[eYz2NeP!^)l$oAlcX",
+                                      "inputs": {
+                                        "VALUE-0": {
+                                          "block": {
+                                            "type": "variableReferenceBlock",
+                                            "id": "gqhW;mum+4Q;rE=VFT$i",
+                                            "extraState": {
+                                              "isObjectVar": false
+                                            },
+                                            "fields": {
+                                              "OBJECTTYPE": "Global",
+                                              "VAR": {
+                                                "id": "ML+?PN8B2+zUSlDEx$/,"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "DO": {
+                              "block": {
+                                "type": "DisplayCustomNotificationMessage",
+                                "id": "}#|}$L/bCq8MPt=K}RPs",
+                                "inputs": {
+                                  "VALUE-0": {
+                                    "block": {
+                                      "type": "Message",
+                                      "id": "}eo+ph{W8Sbe:7p%:Mbu",
+                                      "inputs": {
+                                        "VALUE-0": {
+                                          "block": {
+                                            "type": "Text",
+                                            "id": "YHK:M_ae.#]C#VR7Tn@f",
+                                            "fields": {
+                                              "TEXT": "Round Starting In: {}"
+                                            }
+                                          }
+                                        },
+                                        "VALUE-1": {
+                                          "block": {
+                                            "type": "GetVariable",
+                                            "id": "PmZJip+bF_COL^qf!swe",
+                                            "inputs": {
+                                              "VALUE-0": {
+                                                "block": {
+                                                  "type": "variableReferenceBlock",
+                                                  "id": "}%,u$BKKIQM.CR|Oqeqt",
+                                                  "extraState": {
+                                                    "isObjectVar": false
+                                                  },
+                                                  "fields": {
+                                                    "OBJECTTYPE": "Global",
+                                                    "VAR": {
+                                                      "id": "me;7Fh3D?S}otNQPC%]w"
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "VALUE-1": {
+                                    "block": {
+                                      "type": "CustomMessagesItem",
+                                      "id": "luEHejzsy^hui8hEG[?k",
+                                      "fields": {
+                                        "VALUE-0": "CustomMessages",
+                                        "VALUE-1": "HeaderText"
+                                      }
+                                    }
+                                  },
+                                  "VALUE-2": {
+                                    "block": {
+                                      "type": "Number",
+                                      "id": "eo$0h.QLb{SlI?g4_5F1",
+                                      "fields": {
+                                        "NUM": 1
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "subroutineBlock",
+        "id": "KCWW;~j)udT%Ppo_`FyW",
+        "x": 3922,
+        "y": 8375,
+        "extraState": {
+          "subroutineName": "RoundTimer",
+          "parameters": []
+        },
+        "fields": {
+          "SUBROUTINE_NAME": "RoundTimer"
+        },
+        "inputs": {
+          "ACTIONS": {
+            "block": {
+              "type": "SetVariable",
+              "id": "*BmZ[SbDz_inm%ZjhiFm",
+              "inputs": {
+                "VALUE-0": {
+                  "block": {
+                    "type": "variableReferenceBlock",
+                    "id": "zETt)0]H~Fn-iVJ$?i|o",
+                    "extraState": {
+                      "isObjectVar": false
+                    },
+                    "fields": {
+                      "OBJECTTYPE": "Global",
+                      "VAR": {
+                        "id": "=8OY*aWMGF4.T^k6uLUl"
+                      }
+                    }
+                  }
+                },
+                "VALUE-1": {
+                  "block": {
+                    "type": "GetVariable",
+                    "id": ",qXxC6W*SEKi-^/*JXQY",
+                    "inputs": {
+                      "VALUE-0": {
+                        "block": {
+                          "type": "variableReferenceBlock",
+                          "id": "*n,^~9mzJo_cSH7i9jik",
+                          "extraState": {
+                            "isObjectVar": false
+                          },
+                          "fields": {
+                            "OBJECTTYPE": "Global",
+                            "VAR": {
+                              "id": "ML+?PN8B2+zUSlDEx$/,"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "next": {
+                "block": {
+                  "type": "ForVariable",
+                  "id": "?0/y:k/k`H6xv=T-9GaC",
+                  "inputs": {
+                    "VALUE-0": {
+                      "block": {
+                        "type": "variableReferenceBlock",
+                        "id": "^7);@whM^7;01JI~;v(N",
+                        "extraState": {
+                          "isObjectVar": false
+                        },
+                        "fields": {
+                          "OBJECTTYPE": "Global",
+                          "VAR": {
+                            "id": "me;7Fh3D?S}otNQPC%]w"
+                          }
+                        }
+                      }
+                    },
+                    "VALUE-1": {
+                      "block": {
+                        "type": "Number",
+                        "id": "hlx.?cC()|r#sU@(G!IX",
+                        "fields": {
+                          "NUM": 25
+                        }
+                      }
+                    },
+                    "VALUE-2": {
+                      "block": {
+                        "type": "Number",
+                        "id": "/wO%@(LEgj6/0J(^0RsZ",
+                        "fields": {
+                          "NUM": 0
+                        }
+                      }
+                    },
+                    "VALUE-3": {
+                      "block": {
+                        "type": "Number",
+                        "id": "zQzzZ*kp/@4EtolMuC:f",
+                        "fields": {
+                          "NUM": -1
+                        }
+                      }
+                    },
+                    "DO": {
+                      "block": {
+                        "type": "Wait",
+                        "id": "7Z3ilyTD7ioACCbq+KF%",
+                        "inputs": {
+                          "VALUE-0": {
+                            "block": {
+                              "type": "Number",
+                              "id": ",Cr4S35bry1}?qxM2d(n",
+                              "fields": {
+                                "NUM": 1
+                              }
+                            }
+                          }
+                        },
+                        "next": {
+                          "block": {
+                            "type": "If",
+                            "id": "uUe1*M2r:1jDW,nx_Hcs",
+                            "extraState": {
+                              "elseif": 0,
+                              "else": 1
+                            },
+                            "inputs": {
+                              "VALUE-0": {
+                                "block": {
+                                  "type": "LessThan",
+                                  "id": "JF~zX`bvwc:z{!Ek^j(,",
+                                  "inputs": {
+                                    "VALUE-0": {
+                                      "block": {
+                                        "type": "GetVariable",
+                                        "id": "G`FVk+TNYK`1EX-@Vlr3",
+                                        "inputs": {
+                                          "VALUE-0": {
+                                            "block": {
+                                              "type": "variableReferenceBlock",
+                                              "id": "~Aw(krMB^.91JHo86^Gz",
+                                              "extraState": {
+                                                "isObjectVar": false
+                                              },
+                                              "fields": {
+                                                "OBJECTTYPE": "Global",
+                                                "VAR": {
+                                                  "id": "me;7Fh3D?S}otNQPC%]w"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "VALUE-1": {
+                                      "block": {
+                                        "type": "Number",
+                                        "id": "tGB.^R6HAsV4aX1GjbaH",
+                                        "fields": {
+                                          "NUM": 10
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "DO": {
+                                "block": {
+                                  "type": "TriggerAudio",
+                                  "id": "m]=Nx23cxp~)@fnq2;E8",
+                                  "inputs": {
+                                    "VALUE-0": {
+                                      "block": {
+                                        "type": "SoundsItem",
+                                        "id": "^S2}x6%sHsI$e4*OpjmO",
+                                        "fields": {
+                                          "VALUE-0": "Sounds",
+                                          "VALUE-1": "ObjectiveCappingComplete"
+                                        }
+                                      }
+                                    },
+                                    "VALUE-1": {
+                                      "block": {
+                                        "type": "GetTeamId",
+                                        "id": "tV;t6$ApvMm#MkvJN/#8",
+                                        "inputs": {
+                                          "VALUE-0": {
+                                            "block": {
+                                              "type": "Number",
+                                              "id": ")1Gs5p{@Z5P1xhqxMp+J",
+                                              "fields": {
+                                                "NUM": 1
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "next": {
+                                    "block": {
+                                      "type": "TriggerAudio",
+                                      "id": "n;2==B|WM.9fqTc@(Pcl",
+                                      "inputs": {
+                                        "VALUE-0": {
+                                          "block": {
+                                            "type": "SoundsItem",
+                                            "id": "e^T4n]##3{N2tLQY/P@I",
+                                            "fields": {
+                                              "VALUE-0": "Sounds",
+                                              "VALUE-1": "ObjectiveCappingComplete"
+                                            }
+                                          }
+                                        },
+                                        "VALUE-1": {
+                                          "block": {
+                                            "type": "GetTeamId",
+                                            "id": "Cnu8CE2F9L#ItZd[(a5L",
+                                            "inputs": {
+                                              "VALUE-0": {
+                                                "block": {
+                                                  "type": "Number",
+                                                  "id": "/WaLta83tE!Geti:A_y$",
+                                                  "fields": {
+                                                    "NUM": 2
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "ELSE": {
+                                "block": {
+                                  "type": "TriggerAudio",
+                                  "id": ".zI;VjuqWT/?N7+*FQbG",
+                                  "inputs": {
+                                    "VALUE-0": {
+                                      "block": {
+                                        "type": "SoundsItem",
+                                        "id": "jjG}2SlzUa1ShgKKWisv",
+                                        "fields": {
+                                          "VALUE-0": "Sounds",
+                                          "VALUE-1": "ObjectiveCapping"
+                                        }
+                                      }
+                                    },
+                                    "VALUE-1": {
+                                      "block": {
+                                        "type": "GetTeamId",
+                                        "id": "+SMRHTc,GUZl`kJ):N~C",
+                                        "inputs": {
+                                          "VALUE-0": {
+                                            "block": {
+                                              "type": "Number",
+                                              "id": "|VT9.i;}0`I%pXhb2pD2",
+                                              "fields": {
+                                                "NUM": 1
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "next": {
+                                    "block": {
+                                      "type": "TriggerAudio",
+                                      "id": "j8KYFat.,l]hG)DS.j21",
+                                      "inputs": {
+                                        "VALUE-0": {
+                                          "block": {
+                                            "type": "SoundsItem",
+                                            "id": "d8+)TF%;KNMvnq%prGnf",
+                                            "fields": {
+                                              "VALUE-0": "Sounds",
+                                              "VALUE-1": "ObjectiveCapping"
+                                            }
+                                          }
+                                        },
+                                        "VALUE-1": {
+                                          "block": {
+                                            "type": "GetTeamId",
+                                            "id": "bE4:Dg!jG]]3g/8rl?#)",
+                                            "inputs": {
+                                              "VALUE-0": {
+                                                "block": {
+                                                  "type": "Number",
+                                                  "id": "=({7]s52BC{g3vH-d?6S",
+                                                  "fields": {
+                                                    "NUM": 2
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "next": {
+                    "block": {
+                      "type": "SetVariable",
+                      "id": "kAk|W0ER|xACE,RIO.K_",
+                      "inputs": {
+                        "VALUE-0": {
+                          "block": {
+                            "type": "variableReferenceBlock",
+                            "id": "+$i7dQv;QF#??y0Odx9B",
+                            "extraState": {
+                              "isObjectVar": false
+                            },
+                            "fields": {
+                              "OBJECTTYPE": "Global",
+                              "VAR": {
+                                "id": "=8OY*aWMGF4.T^k6uLUl"
+                              }
+                            }
+                          }
+                        },
+                        "VALUE-1": {
+                          "block": {
+                            "type": "GetVariable",
+                            "id": "XK;$4?XR6Bh~rrgl#.3}",
+                            "inputs": {
+                              "VALUE-0": {
+                                "block": {
+                                  "type": "variableReferenceBlock",
+                                  "id": "}e1XVIX6Q,IC*CNqPHm{",
+                                  "extraState": {
+                                    "isObjectVar": false
+                                  },
+                                  "fields": {
+                                    "OBJECTTYPE": "Global",
+                                    "VAR": {
+                                      "id": "**%O*!0`FJS;40@p6=u|"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "next": {
+                        "block": {
+                          "type": "TriggerAudio",
+                          "id": "([Z8#[X9Pi*aIg.LujIY",
+                          "inputs": {
+                            "VALUE-0": {
+                              "block": {
+                                "type": "SoundsItem",
+                                "id": "9,p!,5p-8W/CZkK1W@Iy",
+                                "fields": {
+                                  "VALUE-0": "Sounds",
+                                  "VALUE-1": "ObjectiveUpdated"
+                                }
+                              }
+                            },
+                            "VALUE-1": {
+                              "block": {
+                                "type": "GetTeamId",
+                                "id": "o=(CB]}wa(czI#ci4LJJ",
+                                "inputs": {
+                                  "VALUE-0": {
+                                    "block": {
+                                      "type": "Number",
+                                      "id": "8hg|,5pEQHL._,{8:ym#",
+                                      "fields": {
+                                        "NUM": 1
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "next": {
+                            "block": {
+                              "type": "TriggerAudio",
+                              "id": "fVyCQ1fIv)=u_].O;XaI",
+                              "inputs": {
+                                "VALUE-0": {
+                                  "block": {
+                                    "type": "SoundsItem",
+                                    "id": "a4!_(H|^bc9=u~oL(5cY",
+                                    "fields": {
+                                      "VALUE-0": "Sounds",
+                                      "VALUE-1": "ObjectiveUpdated"
+                                    }
+                                  }
+                                },
+                                "VALUE-1": {
+                                  "block": {
+                                    "type": "GetTeamId",
+                                    "id": "gWLrprCxcBIqY7i7FL_?",
+                                    "inputs": {
+                                      "VALUE-0": {
+                                        "block": {
+                                          "type": "Number",
+                                          "id": "[O;FO7p5hE7[blG4)uj=",
+                                          "fields": {
+                                            "NUM": 2
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     ]
   },
   "variables": [
     {
-      "name": "HQ",
+      "name": "HQ_Boundary",
       "id": "~!s}ovrs?jb7Yd/X[z2!",
       "type": "TeamId"
+    },
+    {
+      "name": "SpawnLocation",
+      "id": ")85N/!w[yu2n1i{J:kG%",
+      "type": "TeamId"
+    },
+    {
+      "name": "inArea",
+      "id": "RtgD|X+%@!)n$MrP;5vL",
+      "type": "Player"
+    },
+    {
+      "name": "yaw",
+      "id": "Q5Zu0keSSA7tlAfVDnKZ",
+      "type": "Player"
+    },
+    {
+      "name": "LastPosition",
+      "id": "_-Lg+r#4h2a6}2ISA-:J",
+      "type": "Player"
+    },
+    {
+      "name": "TeamPlayers",
+      "id": "Ja]@k]U!U8$Jv5S~jX*y",
+      "type": "Player"
+    },
+    {
+      "name": "Alive",
+      "id": "IRu4,i0nyGI*8goT1`+u",
+      "type": "Player"
     },
     {
       "name": "PlayArea",
@@ -2784,9 +11044,99 @@
       "type": "Global"
     },
     {
-      "name": "inArea",
-      "id": "RtgD|X+%@!)n$MrP;5vL",
-      "type": "Player"
+      "name": "Sector",
+      "id": ";2]y+lLHsxSWFYjcQjhk",
+      "type": "Global"
+    },
+    {
+      "name": "MCOM1_Location",
+      "id": "]dWwQ+kkD!f)85rwAEAQ",
+      "type": "Global"
+    },
+    {
+      "name": "MCOM1_Yaw",
+      "id": "eF$rR9X[_su_hNxhGZ`R",
+      "type": "Global"
+    },
+    {
+      "name": "MCOM2_Location",
+      "id": "s;)yD}A?@5f!E58$,z[c",
+      "type": "Global"
+    },
+    {
+      "name": "MCOM2_Yaw",
+      "id": "x8Nn45#O(#5EaIGY=`@u",
+      "type": "Global"
+    },
+    {
+      "name": "MCOM1",
+      "id": "W?M=066mWT~Tf=[ON!`$",
+      "type": "Global"
+    },
+    {
+      "name": "MCOM2",
+      "id": "ZCBg+S5Y0?xD[@GpnRJ.",
+      "type": "Global"
+    },
+    {
+      "name": "DebugMode",
+      "id": "{EF$oQ94sNRA2*og65H/",
+      "type": "Global"
+    },
+    {
+      "name": "MCOM1_RemainingFuse",
+      "id": "WmLAWml]VVTbibIk]jA/",
+      "type": "Global"
+    },
+    {
+      "name": "MCOM2_RemainingFuse",
+      "id": "c[z#A9bNIqE/7|%xj;-G",
+      "type": "Global"
+    },
+    {
+      "name": "DefaultFuseTime",
+      "id": "G8`8D):j~iWsK^BLzR?n",
+      "type": "Global"
+    },
+    {
+      "name": "loopIndex",
+      "id": "me;7Fh3D?S}otNQPC%]w",
+      "type": "Global"
+    },
+    {
+      "name": "Tick",
+      "id": "!76]mYssfI{X9uUcqv2%",
+      "type": "Global"
+    },
+    {
+      "name": "Phase",
+      "id": "=8OY*aWMGF4.T^k6uLUl",
+      "type": "Global"
+    },
+    {
+      "name": "RoundIntro",
+      "id": "*%AGr_rl5x3.om4(DqsJ",
+      "type": "Global"
+    },
+    {
+      "name": "InProgress",
+      "id": "**%O*!0`FJS;40@p6=u|",
+      "type": "Global"
+    },
+    {
+      "name": "EndRound",
+      "id": "Xr?o?acUGgeUMdeaBx?x",
+      "type": "Global"
+    },
+    {
+      "name": "NextRound",
+      "id": "ML+?PN8B2+zUSlDEx$/,",
+      "type": "Global"
+    },
+    {
+      "name": "DEBUG_PlayDefence",
+      "id": "}^*LIdpxV;$%E-l3ayo=",
+      "type": "Global"
     }
   ]
 }

--- a/workspace.json
+++ b/workspace.json
@@ -1310,26 +1310,33 @@
                                                     "CONDITIONS": {
                                                       "block": {
                                                         "type": "conditionBlock",
-                                                        "id": "AckQB$,x?2Y2!Ko]cL~$",
+                                                        "id": "csDO@PHC6Q(rq.`wbmU~",
                                                         "inputs": {
                                                           "CONDITION": {
                                                             "block": {
-                                                              "type": "GetSoldierState",
-                                                              "id": "b;,Gn%yWxHxlt^G6{cne",
+                                                              "type": "GetVariable",
+                                                              "id": "gFXe;_@QL9.,Kj*(OBfL",
                                                               "inputs": {
                                                                 "VALUE-0": {
                                                                   "block": {
-                                                                    "type": "EventPlayer",
-                                                                    "id": "i%3!U}2%b%p9ZTg7f+4`"
-                                                                  }
-                                                                },
-                                                                "VALUE-1": {
-                                                                  "block": {
-                                                                    "type": "SoldierStateBoolItem",
-                                                                    "id": "_xDq{9qX:,:ERA^LZduE",
+                                                                    "type": "variableReferenceBlock",
+                                                                    "id": "a@|.NjP*mL.k}]a66CX@",
+                                                                    "extraState": {
+                                                                      "isObjectVar": true
+                                                                    },
                                                                     "fields": {
-                                                                      "VALUE-0": "SoldierStateBool",
-                                                                      "VALUE-1": "IsAlive"
+                                                                      "OBJECTTYPE": "Player",
+                                                                      "VAR": {
+                                                                        "id": "IRu4,i0nyGI*8goT1`+u"
+                                                                      }
+                                                                    },
+                                                                    "inputs": {
+                                                                      "OBJECT": {
+                                                                        "block": {
+                                                                          "type": "EventPlayer",
+                                                                          "id": "iCl}P4wOF2yav8.YhlfZ"
+                                                                        }
+                                                                      }
                                                                     }
                                                                   }
                                                                 }
@@ -1441,26 +1448,33 @@
                                                         "CONDITIONS": {
                                                           "block": {
                                                             "type": "conditionBlock",
-                                                            "id": "h_mFjc)Fen+LaXe.{wv7",
+                                                            "id": "P2H8xKfsXOqifAlMZirx",
                                                             "inputs": {
                                                               "CONDITION": {
                                                                 "block": {
-                                                                  "type": "GetSoldierState",
-                                                                  "id": "_8#]k2?~m4#ui8$iO59j",
+                                                                  "type": "GetVariable",
+                                                                  "id": "eUN@cP_IW_Ml?PJM9t23",
                                                                   "inputs": {
                                                                     "VALUE-0": {
                                                                       "block": {
-                                                                        "type": "EventPlayer",
-                                                                        "id": "G$l[:8A}x#+d?,xn}2/$"
-                                                                      }
-                                                                    },
-                                                                    "VALUE-1": {
-                                                                      "block": {
-                                                                        "type": "SoldierStateBoolItem",
-                                                                        "id": "R8@PqfS0s9XE?MZ4jFn*",
+                                                                        "type": "variableReferenceBlock",
+                                                                        "id": "m%ZpY;^ZI)!w~U2YC]L+",
+                                                                        "extraState": {
+                                                                          "isObjectVar": true
+                                                                        },
                                                                         "fields": {
-                                                                          "VALUE-0": "SoldierStateBool",
-                                                                          "VALUE-1": "IsAlive"
+                                                                          "OBJECTTYPE": "Player",
+                                                                          "VAR": {
+                                                                            "id": "IRu4,i0nyGI*8goT1`+u"
+                                                                          }
+                                                                        },
+                                                                        "inputs": {
+                                                                          "OBJECT": {
+                                                                            "block": {
+                                                                              "type": "EventPlayer",
+                                                                              "id": "`cA*:X4g)Owk:*iwCYD_"
+                                                                            }
+                                                                          }
                                                                         }
                                                                       }
                                                                     }


### PR DESCRIPTION
Added the following:
- Playable map with 2 layouts (Orbital)
- 2 MCOMs per sector
- Score functionality for the MCOMs
- MCOMs keep their remaining time when diffused
- Overhauled the Map initialisation to make it easier to set up
- Added pre round timer setup with UI and sounds
- When both MCOMs are destroyed all players are now undeployed and wait for the next round
- Debug MCOMs are added for AI to play the objective (can be toggled)
- Debug mode to play as defence has been added
- A manual player alive check is in place as Undeploying the player via the editor is not updating the default game alive state causing issues with the boundaries and UI conflicting states.
- Game ends after round 2

The current layout is inspired by the proposed images by Deadzigs. Alternations were made to round 1 due to visibility and default game boundaries. However this build is mainly to test the core functionality.

The attacking team score has not been implemented yet, this is planned to be done later. Focus for now is testing the 