### PR TITLE
Added classes, score and ability to spawn on squad and spawn becons

### DIFF
--- a/workspace.json
+++ b/workspace.json
@@ -307,22 +307,20 @@
                                                         },
                                                         "next": {
                                                           "block": {
-                                                            "type": "SetGamemodeScore",
-                                                            "id": "+Vwvrig$)+a%ZAU}WPuM",
+                                                            "type": "SetVariable",
+                                                            "id": "V`DHEg0Or60{*A{qE7I)",
                                                             "inputs": {
                                                               "VALUE-0": {
                                                                 "block": {
-                                                                  "type": "GetTeamId",
-                                                                  "id": "_EaS(AMVN$Gp(|0rpcX2",
-                                                                  "inputs": {
-                                                                    "VALUE-0": {
-                                                                      "block": {
-                                                                        "type": "Number",
-                                                                        "id": "8@rq^Q0wn6VYQ]y)ofJs",
-                                                                        "fields": {
-                                                                          "NUM": 1
-                                                                        }
-                                                                      }
+                                                                  "type": "variableReferenceBlock",
+                                                                  "id": ":y6@Ng~[fJ=#[[ip%9ZL",
+                                                                  "extraState": {
+                                                                    "isObjectVar": false
+                                                                  },
+                                                                  "fields": {
+                                                                    "OBJECTTYPE": "Global",
+                                                                    "VAR": {
+                                                                      "id": "wNy%6`mCB3RKeeWT}eH("
                                                                     }
                                                                   }
                                                                 }
@@ -330,7 +328,7 @@
                                                               "VALUE-1": {
                                                                 "block": {
                                                                   "type": "Number",
-                                                                  "id": "l?vXVxq%jLv}Y=^T;1ml",
+                                                                  "id": ",,%yb4LeUM#tQH94ovaG",
                                                                   "fields": {
                                                                     "NUM": 100
                                                                   }
@@ -340,19 +338,19 @@
                                                             "next": {
                                                               "block": {
                                                                 "type": "SetGamemodeScore",
-                                                                "id": "q-~Sv)#bZM$+a6Q*s[i^",
+                                                                "id": "+Vwvrig$)+a%ZAU}WPuM",
                                                                 "inputs": {
                                                                   "VALUE-0": {
                                                                     "block": {
                                                                       "type": "GetTeamId",
-                                                                      "id": "4?-W`O7fUWhd~bw(q65.",
+                                                                      "id": "_EaS(AMVN$Gp(|0rpcX2",
                                                                       "inputs": {
                                                                         "VALUE-0": {
                                                                           "block": {
                                                                             "type": "Number",
-                                                                            "id": "/%1]k@MVnsdVD7?p{i-:",
+                                                                            "id": "8@rq^Q0wn6VYQ]y)ofJs",
                                                                             "fields": {
-                                                                              "NUM": 2
+                                                                              "NUM": 1
                                                                             }
                                                                           }
                                                                         }
@@ -361,57 +359,76 @@
                                                                   },
                                                                   "VALUE-1": {
                                                                     "block": {
-                                                                      "type": "Number",
-                                                                      "id": "x/=:`=+j_@3ZW#K~oakS",
-                                                                      "fields": {
-                                                                        "NUM": 4
+                                                                      "type": "GetVariable",
+                                                                      "id": "z.7EVIt){v?@MXWDKN}C",
+                                                                      "inputs": {
+                                                                        "VALUE-0": {
+                                                                          "block": {
+                                                                            "type": "variableReferenceBlock",
+                                                                            "id": "nvDinxkzYgKhur=1-9Wh",
+                                                                            "extraState": {
+                                                                              "isObjectVar": false
+                                                                            },
+                                                                            "fields": {
+                                                                              "OBJECTTYPE": "Global",
+                                                                              "VAR": {
+                                                                                "id": "wNy%6`mCB3RKeeWT}eH("
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
                                                                       }
                                                                     }
                                                                   }
                                                                 },
                                                                 "next": {
                                                                   "block": {
-                                                                    "type": "SetVariable",
-                                                                    "id": "eB[i6{2Cgs[KsUm[UCOI",
+                                                                    "type": "SetGamemodeScore",
+                                                                    "id": "q-~Sv)#bZM$+a6Q*s[i^",
                                                                     "inputs": {
                                                                       "VALUE-0": {
                                                                         "block": {
-                                                                          "type": "variableReferenceBlock",
-                                                                          "id": "%LQ!tG;@ynLiabyDZi9(",
-                                                                          "extraState": {
-                                                                            "isObjectVar": false
-                                                                          },
-                                                                          "fields": {
-                                                                            "OBJECTTYPE": "Global",
-                                                                            "VAR": {
-                                                                              "id": "avhOM{5IU+T,cbtA-5?M"
+                                                                          "type": "GetTeamId",
+                                                                          "id": "4?-W`O7fUWhd~bw(q65.",
+                                                                          "inputs": {
+                                                                            "VALUE-0": {
+                                                                              "block": {
+                                                                                "type": "Number",
+                                                                                "id": "/%1]k@MVnsdVD7?p{i-:",
+                                                                                "fields": {
+                                                                                  "NUM": 2
+                                                                                }
+                                                                              }
                                                                             }
                                                                           }
                                                                         }
                                                                       },
                                                                       "VALUE-1": {
                                                                         "block": {
-                                                                          "type": "EmptyArray",
-                                                                          "id": "n@xvWC4_-%6Cv|^TMk=^"
+                                                                          "type": "Number",
+                                                                          "id": "x/=:`=+j_@3ZW#K~oakS",
+                                                                          "fields": {
+                                                                            "NUM": 4
+                                                                          }
                                                                         }
                                                                       }
                                                                     },
                                                                     "next": {
                                                                       "block": {
                                                                         "type": "SetVariable",
-                                                                        "id": "laQ+2mW-F_H{~V}ywk8e",
+                                                                        "id": "eB[i6{2Cgs[KsUm[UCOI",
                                                                         "inputs": {
                                                                           "VALUE-0": {
                                                                             "block": {
                                                                               "type": "variableReferenceBlock",
-                                                                              "id": "r/d0%OC3vT=TlSumf/b,",
+                                                                              "id": "%LQ!tG;@ynLiabyDZi9(",
                                                                               "extraState": {
                                                                                 "isObjectVar": false
                                                                               },
                                                                               "fields": {
                                                                                 "OBJECTTYPE": "Global",
                                                                                 "VAR": {
-                                                                                  "id": "I;O66Sw;VrFU](bV9s}."
+                                                                                  "id": "avhOM{5IU+T,cbtA-5?M"
                                                                                 }
                                                                               }
                                                                             }
@@ -419,26 +436,26 @@
                                                                           "VALUE-1": {
                                                                             "block": {
                                                                               "type": "EmptyArray",
-                                                                              "id": "2-#kP,#PXX)0GXHGd*E,"
+                                                                              "id": "n@xvWC4_-%6Cv|^TMk=^"
                                                                             }
                                                                           }
                                                                         },
                                                                         "next": {
                                                                           "block": {
                                                                             "type": "SetVariable",
-                                                                            "id": "smF`e!I*Sh!!2MyUXzAs",
+                                                                            "id": "laQ+2mW-F_H{~V}ywk8e",
                                                                             "inputs": {
                                                                               "VALUE-0": {
                                                                                 "block": {
                                                                                   "type": "variableReferenceBlock",
-                                                                                  "id": "!ibm=s*wSpKT#`3b5EJQ",
+                                                                                  "id": "r/d0%OC3vT=TlSumf/b,",
                                                                                   "extraState": {
                                                                                     "isObjectVar": false
                                                                                   },
                                                                                   "fields": {
                                                                                     "OBJECTTYPE": "Global",
                                                                                     "VAR": {
-                                                                                      "id": "(ZHqM}3*6qf%Gv}2bOzk"
+                                                                                      "id": "I;O66Sw;VrFU](bV9s}."
                                                                                     }
                                                                                   }
                                                                                 }
@@ -446,45 +463,26 @@
                                                                               "VALUE-1": {
                                                                                 "block": {
                                                                                   "type": "EmptyArray",
-                                                                                  "id": "5%?,[zO.,.O68;qWAdYd"
+                                                                                  "id": "2-#kP,#PXX)0GXHGd*E,"
                                                                                 }
                                                                               }
                                                                             },
                                                                             "next": {
                                                                               "block": {
                                                                                 "type": "SetVariable",
-                                                                                "id": "6NXn=7((W7ob}J8)t)BQ",
+                                                                                "id": "smF`e!I*Sh!!2MyUXzAs",
                                                                                 "inputs": {
                                                                                   "VALUE-0": {
                                                                                     "block": {
                                                                                       "type": "variableReferenceBlock",
-                                                                                      "id": "B:KL`PCJSj,82=m*pl8A",
+                                                                                      "id": "!ibm=s*wSpKT#`3b5EJQ",
                                                                                       "extraState": {
-                                                                                        "isObjectVar": true
+                                                                                        "isObjectVar": false
                                                                                       },
                                                                                       "fields": {
-                                                                                        "OBJECTTYPE": "TeamId",
+                                                                                        "OBJECTTYPE": "Global",
                                                                                         "VAR": {
-                                                                                          "id": "~!s}ovrs?jb7Yd/X[z2!"
-                                                                                        }
-                                                                                      },
-                                                                                      "inputs": {
-                                                                                        "OBJECT": {
-                                                                                          "block": {
-                                                                                            "type": "GetTeamId",
-                                                                                            "id": "`R2tzia{K@u5z}9MyNyJ",
-                                                                                            "inputs": {
-                                                                                              "VALUE-0": {
-                                                                                                "block": {
-                                                                                                  "type": "Number",
-                                                                                                  "id": "epQ||CEjt=zB_onvqv_!",
-                                                                                                  "fields": {
-                                                                                                    "NUM": 1
-                                                                                                  }
-                                                                                                }
-                                                                                              }
-                                                                                            }
-                                                                                          }
+                                                                                          "id": "(ZHqM}3*6qf%Gv}2bOzk"
                                                                                         }
                                                                                       }
                                                                                     }
@@ -492,19 +490,19 @@
                                                                                   "VALUE-1": {
                                                                                     "block": {
                                                                                       "type": "EmptyArray",
-                                                                                      "id": "jM[q|y##+s]z82Z0uGVj"
+                                                                                      "id": "5%?,[zO.,.O68;qWAdYd"
                                                                                     }
                                                                                   }
                                                                                 },
                                                                                 "next": {
                                                                                   "block": {
                                                                                     "type": "SetVariable",
-                                                                                    "id": "N?f`nY)EiI)LzbX.NV,f",
+                                                                                    "id": "6NXn=7((W7ob}J8)t)BQ",
                                                                                     "inputs": {
                                                                                       "VALUE-0": {
                                                                                         "block": {
                                                                                           "type": "variableReferenceBlock",
-                                                                                          "id": "GV]I@t|zEq6.us!+c1]{",
+                                                                                          "id": "B:KL`PCJSj,82=m*pl8A",
                                                                                           "extraState": {
                                                                                             "isObjectVar": true
                                                                                           },
@@ -518,14 +516,14 @@
                                                                                             "OBJECT": {
                                                                                               "block": {
                                                                                                 "type": "GetTeamId",
-                                                                                                "id": "(azVV^U7kFaWp2A,86gd",
+                                                                                                "id": "`R2tzia{K@u5z}9MyNyJ",
                                                                                                 "inputs": {
                                                                                                   "VALUE-0": {
                                                                                                     "block": {
                                                                                                       "type": "Number",
-                                                                                                      "id": "JQ-,|8Npn(heW$YyRJX9",
+                                                                                                      "id": "epQ||CEjt=zB_onvqv_!",
                                                                                                       "fields": {
-                                                                                                        "NUM": 2
+                                                                                                        "NUM": 1
                                                                                                       }
                                                                                                     }
                                                                                                   }
@@ -538,65 +536,72 @@
                                                                                       "VALUE-1": {
                                                                                         "block": {
                                                                                           "type": "EmptyArray",
-                                                                                          "id": "QN@`E@Gfxb_WFQF!{yBP"
+                                                                                          "id": "jM[q|y##+s]z82Z0uGVj"
                                                                                         }
                                                                                       }
                                                                                     },
                                                                                     "next": {
                                                                                       "block": {
                                                                                         "type": "SetVariable",
-                                                                                        "id": "7De!g2sTa,M5qFwugcc+",
+                                                                                        "id": "N?f`nY)EiI)LzbX.NV,f",
                                                                                         "inputs": {
                                                                                           "VALUE-0": {
                                                                                             "block": {
                                                                                               "type": "variableReferenceBlock",
-                                                                                              "id": "@]|+5Yi#c+5f|0,%vO=)",
+                                                                                              "id": "GV]I@t|zEq6.us!+c1]{",
                                                                                               "extraState": {
-                                                                                                "isObjectVar": false
+                                                                                                "isObjectVar": true
                                                                                               },
                                                                                               "fields": {
-                                                                                                "OBJECTTYPE": "Global",
+                                                                                                "OBJECTTYPE": "TeamId",
                                                                                                 "VAR": {
-                                                                                                  "id": "W?M=066mWT~Tf=[ON!`$"
+                                                                                                  "id": "~!s}ovrs?jb7Yd/X[z2!"
+                                                                                                }
+                                                                                              },
+                                                                                              "inputs": {
+                                                                                                "OBJECT": {
+                                                                                                  "block": {
+                                                                                                    "type": "GetTeamId",
+                                                                                                    "id": "(azVV^U7kFaWp2A,86gd",
+                                                                                                    "inputs": {
+                                                                                                      "VALUE-0": {
+                                                                                                        "block": {
+                                                                                                          "type": "Number",
+                                                                                                          "id": "JQ-,|8Npn(heW$YyRJX9",
+                                                                                                          "fields": {
+                                                                                                            "NUM": 2
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
                                                                                                 }
                                                                                               }
                                                                                             }
                                                                                           },
                                                                                           "VALUE-1": {
                                                                                             "block": {
-                                                                                              "type": "GetCapturePoint",
-                                                                                              "id": "W7l4;@i6Zy/$+*wxJK7r",
-                                                                                              "inputs": {
-                                                                                                "VALUE-0": {
-                                                                                                  "block": {
-                                                                                                    "type": "MCOMsItem",
-                                                                                                    "id": "T[Ct6,4Uukf+la,BbW06",
-                                                                                                    "fields": {
-                                                                                                      "VALUE-0": "MCOMs",
-                                                                                                      "VALUE-1": "A"
-                                                                                                    }
-                                                                                                  }
-                                                                                                }
-                                                                                              }
+                                                                                              "type": "EmptyArray",
+                                                                                              "id": "QN@`E@Gfxb_WFQF!{yBP"
                                                                                             }
                                                                                           }
                                                                                         },
                                                                                         "next": {
                                                                                           "block": {
                                                                                             "type": "SetVariable",
-                                                                                            "id": "J8E5=G`AH*[4Kdv*s:H+",
+                                                                                            "id": "7De!g2sTa,M5qFwugcc+",
                                                                                             "inputs": {
                                                                                               "VALUE-0": {
                                                                                                 "block": {
                                                                                                   "type": "variableReferenceBlock",
-                                                                                                  "id": "pxBQy(!+ocyRKSons-~W",
+                                                                                                  "id": "@]|+5Yi#c+5f|0,%vO=)",
                                                                                                   "extraState": {
                                                                                                     "isObjectVar": false
                                                                                                   },
                                                                                                   "fields": {
                                                                                                     "OBJECTTYPE": "Global",
                                                                                                     "VAR": {
-                                                                                                      "id": "ZCBg+S5Y0?xD[@GpnRJ."
+                                                                                                      "id": "W?M=066mWT~Tf=[ON!`$"
                                                                                                     }
                                                                                                   }
                                                                                                 }
@@ -604,15 +609,15 @@
                                                                                               "VALUE-1": {
                                                                                                 "block": {
                                                                                                   "type": "GetCapturePoint",
-                                                                                                  "id": "0%A@hp$}DUYp%+mGZSXj",
+                                                                                                  "id": "W7l4;@i6Zy/$+*wxJK7r",
                                                                                                   "inputs": {
                                                                                                     "VALUE-0": {
                                                                                                       "block": {
                                                                                                         "type": "MCOMsItem",
-                                                                                                        "id": "B@k}Gm.ufBY,]7UUX,aU",
+                                                                                                        "id": "T[Ct6,4Uukf+la,BbW06",
                                                                                                         "fields": {
                                                                                                           "VALUE-0": "MCOMs",
-                                                                                                          "VALUE-1": "B"
+                                                                                                          "VALUE-1": "A"
                                                                                                         }
                                                                                                       }
                                                                                                     }
@@ -622,14 +627,162 @@
                                                                                             },
                                                                                             "next": {
                                                                                               "block": {
-                                                                                                "type": "subroutineInstanceBlock",
-                                                                                                "id": "U5`i8,Kgvr,CInh|-nO.",
-                                                                                                "extraState": {
-                                                                                                  "subroutineName": "MapDetect",
-                                                                                                  "parameters": []
+                                                                                                "type": "SetVariable",
+                                                                                                "id": "J8E5=G`AH*[4Kdv*s:H+",
+                                                                                                "inputs": {
+                                                                                                  "VALUE-0": {
+                                                                                                    "block": {
+                                                                                                      "type": "variableReferenceBlock",
+                                                                                                      "id": "pxBQy(!+ocyRKSons-~W",
+                                                                                                      "extraState": {
+                                                                                                        "isObjectVar": false
+                                                                                                      },
+                                                                                                      "fields": {
+                                                                                                        "OBJECTTYPE": "Global",
+                                                                                                        "VAR": {
+                                                                                                          "id": "ZCBg+S5Y0?xD[@GpnRJ."
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  },
+                                                                                                  "VALUE-1": {
+                                                                                                    "block": {
+                                                                                                      "type": "GetCapturePoint",
+                                                                                                      "id": "0%A@hp$}DUYp%+mGZSXj",
+                                                                                                      "inputs": {
+                                                                                                        "VALUE-0": {
+                                                                                                          "block": {
+                                                                                                            "type": "MCOMsItem",
+                                                                                                            "id": "B@k}Gm.ufBY,]7UUX,aU",
+                                                                                                            "fields": {
+                                                                                                              "VALUE-0": "MCOMs",
+                                                                                                              "VALUE-1": "B"
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
                                                                                                 },
-                                                                                                "fields": {
-                                                                                                  "SUBROUTINE_NAME": "MapDetect"
+                                                                                                "next": {
+                                                                                                  "block": {
+                                                                                                    "type": "SetVariable",
+                                                                                                    "id": "C:@5Fm7C9*99)@h%)M$n",
+                                                                                                    "inputs": {
+                                                                                                      "VALUE-0": {
+                                                                                                        "block": {
+                                                                                                          "type": "variableReferenceBlock",
+                                                                                                          "id": ",YI=?L^)YRto_sRa;,5s",
+                                                                                                          "extraState": {
+                                                                                                            "isObjectVar": false
+                                                                                                          },
+                                                                                                          "fields": {
+                                                                                                            "OBJECTTYPE": "Global",
+                                                                                                            "VAR": {
+                                                                                                              "id": "w_^Ni+6S]Sp8=OOP4#,a"
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      },
+                                                                                                      "VALUE-1": {
+                                                                                                        "block": {
+                                                                                                          "type": "EmptyArray",
+                                                                                                          "id": ";Tb~dxp@NR{}=!h_[Gxy"
+                                                                                                        }
+                                                                                                      }
+                                                                                                    },
+                                                                                                    "next": {
+                                                                                                      "block": {
+                                                                                                        "type": "subroutineInstanceBlock",
+                                                                                                        "id": "U5`i8,Kgvr,CInh|-nO.",
+                                                                                                        "extraState": {
+                                                                                                          "subroutineName": "MapDetect",
+                                                                                                          "parameters": []
+                                                                                                        },
+                                                                                                        "fields": {
+                                                                                                          "SUBROUTINE_NAME": "MapDetect"
+                                                                                                        },
+                                                                                                        "next": {
+                                                                                                          "block": {
+                                                                                                            "type": "subroutineInstanceBlock",
+                                                                                                            "id": "R5j{pBpAhmcWb5tH=*X=",
+                                                                                                            "extraState": {
+                                                                                                              "subroutineName": "Specialist_Setup",
+                                                                                                              "parameters": []
+                                                                                                            },
+                                                                                                            "fields": {
+                                                                                                              "SUBROUTINE_NAME": "Specialist_Setup"
+                                                                                                            },
+                                                                                                            "next": {
+                                                                                                              "block": {
+                                                                                                                "type": "subroutineInstanceBlock",
+                                                                                                                "id": "#`f7[iE?j/$t`$H_t1X{",
+                                                                                                                "extraState": {
+                                                                                                                  "subroutineName": "Other_Primary",
+                                                                                                                  "parameters": []
+                                                                                                                },
+                                                                                                                "fields": {
+                                                                                                                  "SUBROUTINE_NAME": "Other_Primary"
+                                                                                                                },
+                                                                                                                "next": {
+                                                                                                                  "block": {
+                                                                                                                    "type": "subroutineInstanceBlock",
+                                                                                                                    "id": "C~toO_;CCr^Jk:]pO0=2",
+                                                                                                                    "extraState": {
+                                                                                                                      "subroutineName": "Assault_Primary",
+                                                                                                                      "parameters": []
+                                                                                                                    },
+                                                                                                                    "fields": {
+                                                                                                                      "SUBROUTINE_NAME": "Assault_Primary"
+                                                                                                                    },
+                                                                                                                    "next": {
+                                                                                                                      "block": {
+                                                                                                                        "type": "subroutineInstanceBlock",
+                                                                                                                        "id": "80I9q^V~5-q3jk^5w~Qx",
+                                                                                                                        "extraState": {
+                                                                                                                          "subroutineName": "Medic_Primary",
+                                                                                                                          "parameters": []
+                                                                                                                        },
+                                                                                                                        "fields": {
+                                                                                                                          "SUBROUTINE_NAME": "Medic_Primary"
+                                                                                                                        },
+                                                                                                                        "next": {
+                                                                                                                          "block": {
+                                                                                                                            "type": "subroutineInstanceBlock",
+                                                                                                                            "id": "]8~yz!ASm70Wno^aoQS3",
+                                                                                                                            "extraState": {
+                                                                                                                              "subroutineName": "Engineer_Primary",
+                                                                                                                              "parameters": []
+                                                                                                                            },
+                                                                                                                            "fields": {
+                                                                                                                              "SUBROUTINE_NAME": "Engineer_Primary"
+                                                                                                                            },
+                                                                                                                            "next": {
+                                                                                                                              "block": {
+                                                                                                                                "type": "subroutineInstanceBlock",
+                                                                                                                                "id": "kE@*~jK#T4]vh;u[@gFQ",
+                                                                                                                                "extraState": {
+                                                                                                                                  "subroutineName": "Scout_Primary",
+                                                                                                                                  "parameters": []
+                                                                                                                                },
+                                                                                                                                "fields": {
+                                                                                                                                  "SUBROUTINE_NAME": "Scout_Primary"
+                                                                                                                                }
+                                                                                                                              }
+                                                                                                                            }
+                                                                                                                          }
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
                                                                                                 }
                                                                                               }
                                                                                             }
@@ -768,24 +921,24 @@
                       "next": {
                         "block": {
                           "type": "ruleBlock",
-                          "id": "A!DI32})}b_fx|@k)J#x",
+                          "id": "*.cu,ZrU|IjWh*7UU*ld",
                           "extraState": {
                             "isOngoingEvent": false
                           },
                           "fields": {
-                            "NAME": "PlayerUndeploy",
-                            "EVENTTYPE": "OnPlayerIrreversiblyDead"
+                            "NAME": "PlayerDied",
+                            "EVENTTYPE": "OnPlayerDied"
                           },
                           "inputs": {
                             "ACTIONS": {
                               "block": {
                                 "type": "SetVariable",
-                                "id": "o)Y1Qur`(0qZp6Ra/84^",
+                                "id": "[`^gC-ZQ~Q)-[Z~PP5(J",
                                 "inputs": {
                                   "VALUE-0": {
                                     "block": {
                                       "type": "variableReferenceBlock",
-                                      "id": "NJ+s`VMN-#*:9v-W[D%a",
+                                      "id": "SN(W^+VtXjhYU_sH0[AA",
                                       "extraState": {
                                         "isObjectVar": true
                                       },
@@ -799,7 +952,7 @@
                                         "OBJECT": {
                                           "block": {
                                             "type": "EventPlayer",
-                                            "id": "sav_w]~r,EBXV8Tn^yBK"
+                                            "id": "lCt+@nF;@a@M=V(3Tgu^"
                                           }
                                         }
                                       }
@@ -808,7 +961,7 @@
                                   "VALUE-1": {
                                     "block": {
                                       "type": "Boolean",
-                                      "id": "QnuT*bTVhhKgX$]1np%X",
+                                      "id": "qF~`.;Tf55s1+L6(yP_m",
                                       "fields": {
                                         "BOOL": "FALSE"
                                       }
@@ -821,24 +974,24 @@
                           "next": {
                             "block": {
                               "type": "ruleBlock",
-                              "id": "*.cu,ZrU|IjWh*7UU*ld",
+                              "id": "A!DI32})}b_fx|@k)J#x",
                               "extraState": {
                                 "isOngoingEvent": false
                               },
                               "fields": {
-                                "NAME": "PlayerDied",
-                                "EVENTTYPE": "OnPlayerDied"
+                                "NAME": "PlayerUndeploy",
+                                "EVENTTYPE": "OnPlayerIrreversiblyDead"
                               },
                               "inputs": {
                                 "ACTIONS": {
                                   "block": {
                                     "type": "SetVariable",
-                                    "id": "[`^gC-ZQ~Q)-[Z~PP5(J",
+                                    "id": "o)Y1Qur`(0qZp6Ra/84^",
                                     "inputs": {
                                       "VALUE-0": {
                                         "block": {
                                           "type": "variableReferenceBlock",
-                                          "id": "SN(W^+VtXjhYU_sH0[AA",
+                                          "id": "NJ+s`VMN-#*:9v-W[D%a",
                                           "extraState": {
                                             "isObjectVar": true
                                           },
@@ -852,7 +1005,7 @@
                                             "OBJECT": {
                                               "block": {
                                                 "type": "EventPlayer",
-                                                "id": "lCt+@nF;@a@M=V(3Tgu^"
+                                                "id": "sav_w]~r,EBXV8Tn^yBK"
                                               }
                                             }
                                           }
@@ -861,9 +1014,187 @@
                                       "VALUE-1": {
                                         "block": {
                                           "type": "Boolean",
-                                          "id": "qF~`.;Tf55s1+L6(yP_m",
+                                          "id": "QnuT*bTVhhKgX$]1np%X",
                                           "fields": {
                                             "BOOL": "FALSE"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "next": {
+                                      "block": {
+                                        "type": "If",
+                                        "id": "A+0JEJntLXXuibA=:xI@",
+                                        "extraState": {},
+                                        "inputs": {
+                                          "VALUE-0": {
+                                            "block": {
+                                              "type": "And",
+                                              "id": "/6T}4a*O9SMcqX1Ou6Ey",
+                                              "inline": false,
+                                              "inputs": {
+                                                "VALUE-0": {
+                                                  "block": {
+                                                    "type": "Equals",
+                                                    "id": "X0!w,)h/MA37/s*-1M6B",
+                                                    "inputs": {
+                                                      "VALUE-0": {
+                                                        "block": {
+                                                          "type": "GetTeamId",
+                                                          "id": "%QYWfvSHq{jw9S(kE6]4",
+                                                          "inputs": {
+                                                            "VALUE-0": {
+                                                              "block": {
+                                                                "type": "EventPlayer",
+                                                                "id": "qtv}{X#X!_l*0?kkV0n("
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      },
+                                                      "VALUE-1": {
+                                                        "block": {
+                                                          "type": "GetTeamId",
+                                                          "id": "X?TvMs!SWOP%~T91mm|M",
+                                                          "inputs": {
+                                                            "VALUE-0": {
+                                                              "block": {
+                                                                "type": "Number",
+                                                                "id": "?9LPZqEOb0VpnJodIh4%",
+                                                                "fields": {
+                                                                  "NUM": 1
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "VALUE-1": {
+                                                  "block": {
+                                                    "type": "Equals",
+                                                    "id": "=,EIx4I4tqPLMyiwxxN[",
+                                                    "inputs": {
+                                                      "VALUE-0": {
+                                                        "block": {
+                                                          "type": "GetVariable",
+                                                          "id": "]meNTf3*$FD]LFwl;P#m",
+                                                          "inputs": {
+                                                            "VALUE-0": {
+                                                              "block": {
+                                                                "type": "variableReferenceBlock",
+                                                                "id": ";vpHHJj%:)EI4/^+i4YV",
+                                                                "extraState": {
+                                                                  "isObjectVar": false
+                                                                },
+                                                                "fields": {
+                                                                  "OBJECTTYPE": "Global",
+                                                                  "VAR": {
+                                                                    "id": "=8OY*aWMGF4.T^k6uLUl"
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      },
+                                                      "VALUE-1": {
+                                                        "block": {
+                                                          "type": "GetVariable",
+                                                          "id": "XW*hxJea_nLDQtp_cc~T",
+                                                          "inputs": {
+                                                            "VALUE-0": {
+                                                              "block": {
+                                                                "type": "variableReferenceBlock",
+                                                                "id": "Hk+(%yF|z%bs)Xp1}5c-",
+                                                                "extraState": {
+                                                                  "isObjectVar": false
+                                                                },
+                                                                "fields": {
+                                                                  "OBJECTTYPE": "Global",
+                                                                  "VAR": {
+                                                                    "id": "**%O*!0`FJS;40@p6=u|"
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          },
+                                          "DO": {
+                                            "block": {
+                                              "type": "SetGamemodeScore",
+                                              "id": "(Exy)@19^x7^d2EL:47r",
+                                              "inputs": {
+                                                "VALUE-0": {
+                                                  "block": {
+                                                    "type": "GetTeamId",
+                                                    "id": "5.dlXBAzlf01}f](d)vM",
+                                                    "inputs": {
+                                                      "VALUE-0": {
+                                                        "block": {
+                                                          "type": "Number",
+                                                          "id": "JjENWmCT~5:KIo.NMPmh",
+                                                          "fields": {
+                                                            "NUM": 1
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "VALUE-1": {
+                                                  "block": {
+                                                    "type": "Subtract",
+                                                    "id": "o}aWX42DJ.*G0]ipAE2=",
+                                                    "inputs": {
+                                                      "VALUE-0": {
+                                                        "block": {
+                                                          "type": "GetGamemodeScore",
+                                                          "id": "w,f4+XYV9{znJ!6wsAEO",
+                                                          "inputs": {
+                                                            "VALUE-0": {
+                                                              "block": {
+                                                                "type": "GetTeamId",
+                                                                "id": ":_JXF18+WaeJ!J)u07T3",
+                                                                "inputs": {
+                                                                  "VALUE-0": {
+                                                                    "block": {
+                                                                      "type": "Number",
+                                                                      "id": ";o83:%rboRd.Hyr0t%Oi",
+                                                                      "fields": {
+                                                                        "NUM": 1
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      },
+                                                      "VALUE-1": {
+                                                        "block": {
+                                                          "type": "Number",
+                                                          "id": "M!qo6bTUXs:K7T6udm4T",
+                                                          "fields": {
+                                                            "NUM": 1
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
                                           }
                                         }
                                       }
@@ -1669,12 +2000,12 @@
                                                             "ACTIONS": {
                                                               "block": {
                                                                 "type": "SetVariable",
-                                                                "id": "BroC^6pc(RPW21h~pVFC",
+                                                                "id": "^Xrh0+;(Q@rgiR[q^HNj",
                                                                 "inputs": {
                                                                   "VALUE-0": {
                                                                     "block": {
                                                                       "type": "variableReferenceBlock",
-                                                                      "id": "iPQaziS71vjOli/q~pUo",
+                                                                      "id": "Qgs;@uhuR%{5WXW5t`sB",
                                                                       "extraState": {
                                                                         "isObjectVar": true
                                                                       },
@@ -1688,7 +2019,7 @@
                                                                         "OBJECT": {
                                                                           "block": {
                                                                             "type": "EventPlayer",
-                                                                            "id": "*7t0-#}r!m4slG!K(M:]"
+                                                                            "id": "a~g%=^wQ?V=7!vr{)TOE"
                                                                           }
                                                                         }
                                                                       }
@@ -1697,7 +2028,7 @@
                                                                   "VALUE-1": {
                                                                     "block": {
                                                                       "type": "Boolean",
-                                                                      "id": "@+x)CVnaWV9yDA8H[+)V",
+                                                                      "id": "=ZB(([A!yp*tQU7kSx4)",
                                                                       "fields": {
                                                                         "BOOL": "TRUE"
                                                                       }
@@ -1706,524 +2037,514 @@
                                                                 },
                                                                 "next": {
                                                                   "block": {
-                                                                    "type": "SetVariable",
-                                                                    "id": "sd=h:DiAX@8jkcY:5!34",
+                                                                    "type": "If",
+                                                                    "id": "yP0zTQdX:Q$]mkOdDJn!",
+                                                                    "extraState": {},
                                                                     "inputs": {
                                                                       "VALUE-0": {
                                                                         "block": {
-                                                                          "type": "variableReferenceBlock",
-                                                                          "id": "wfyDD(Otn`[PzSAHYX1%",
-                                                                          "extraState": {
-                                                                            "isObjectVar": true
-                                                                          },
-                                                                          "fields": {
-                                                                            "OBJECTTYPE": "Player",
-                                                                            "VAR": {
-                                                                              "id": "Ja]@k]U!U8$Jv5S~jX*y"
-                                                                            }
-                                                                          },
+                                                                          "type": "GetSoldierState",
+                                                                          "id": "S50#mkag_p_4F)5o3C;b",
                                                                           "inputs": {
-                                                                            "OBJECT": {
+                                                                            "VALUE-0": {
                                                                               "block": {
                                                                                 "type": "EventPlayer",
-                                                                                "id": "R*-/JFHga^[M|dTQ7rdg"
+                                                                                "id": "STC1:RZtm%UtUInYacu)"
+                                                                              }
+                                                                            },
+                                                                            "VALUE-1": {
+                                                                              "block": {
+                                                                                "type": "SoldierStateBoolItem",
+                                                                                "id": "pFu$-W#*Vy74coyJanAY",
+                                                                                "fields": {
+                                                                                  "VALUE-0": "SoldierStateBool",
+                                                                                  "VALUE-1": "IsAISoldier"
+                                                                                }
                                                                               }
                                                                             }
                                                                           }
                                                                         }
                                                                       },
-                                                                      "VALUE-1": {
+                                                                      "DO": {
                                                                         "block": {
-                                                                          "type": "EmptyArray",
-                                                                          "id": "YIysv5y$b.f{e?!fST14"
-                                                                        }
-                                                                      }
-                                                                    },
-                                                                    "next": {
-                                                                      "block": {
-                                                                        "type": "SetVariable",
-                                                                        "id": "a;6L|s*3a%G=3%x|H5VU",
-                                                                        "inputs": {
-                                                                          "VALUE-0": {
-                                                                            "block": {
-                                                                              "type": "variableReferenceBlock",
-                                                                              "id": "8%}/}6B/)%I.w:ata)vU",
-                                                                              "extraState": {
-                                                                                "isObjectVar": true
-                                                                              },
-                                                                              "fields": {
-                                                                                "OBJECTTYPE": "Player",
-                                                                                "VAR": {
-                                                                                  "id": "Ja]@k]U!U8$Jv5S~jX*y"
-                                                                                }
-                                                                              },
-                                                                              "inputs": {
-                                                                                "OBJECT": {
-                                                                                  "block": {
-                                                                                    "type": "EventPlayer",
-                                                                                    "id": "}yTss!iXP,STd}^/oNm^"
-                                                                                  }
-                                                                                }
-                                                                              }
-                                                                            }
-                                                                          },
-                                                                          "VALUE-1": {
-                                                                            "block": {
-                                                                              "type": "FilteredArray",
-                                                                              "id": "h7:1$S~D^!_;_z!HgMw_",
-                                                                              "inputs": {
-                                                                                "VALUE-0": {
-                                                                                  "block": {
-                                                                                    "type": "AllPlayers",
-                                                                                    "id": "K+MlW+hK6C5{G]pUd7b6"
-                                                                                  }
-                                                                                },
-                                                                                "VALUE-1": {
-                                                                                  "block": {
-                                                                                    "type": "And",
-                                                                                    "id": "T#+JWsP2tiVUb32`2Q*R",
-                                                                                    "inputs": {
-                                                                                      "VALUE-0": {
-                                                                                        "block": {
-                                                                                          "type": "GetSoldierState",
-                                                                                          "id": "[Os0Yl3Fq8t+hk%~T,,o",
-                                                                                          "inputs": {
-                                                                                            "VALUE-0": {
-                                                                                              "block": {
-                                                                                                "type": "CurrentArrayElement",
-                                                                                                "id": "DC?A~~OU+X(8E-/Y__LU"
-                                                                                              }
-                                                                                            },
-                                                                                            "VALUE-1": {
-                                                                                              "block": {
-                                                                                                "type": "SoldierStateBoolItem",
-                                                                                                "id": "t)-e4ML+wEkbU%xH%D[9",
-                                                                                                "fields": {
-                                                                                                  "VALUE-0": "SoldierStateBool",
-                                                                                                  "VALUE-1": "IsAlive"
-                                                                                                }
-                                                                                              }
-                                                                                            }
-                                                                                          }
-                                                                                        }
-                                                                                      },
-                                                                                      "VALUE-1": {
-                                                                                        "block": {
-                                                                                          "type": "And",
-                                                                                          "id": "w5yNiA/_PMb!Eqpfl]pH",
-                                                                                          "inline": false,
-                                                                                          "inputs": {
-                                                                                            "VALUE-0": {
-                                                                                              "block": {
-                                                                                                "type": "Equals",
-                                                                                                "id": "+M`*aA)=T5P@A;J-D|MT",
-                                                                                                "inputs": {
-                                                                                                  "VALUE-0": {
-                                                                                                    "block": {
-                                                                                                      "type": "GetTeamId",
-                                                                                                      "id": "Q6f/qJt+d%o:,^IX~7KF",
-                                                                                                      "inputs": {
-                                                                                                        "VALUE-0": {
-                                                                                                          "block": {
-                                                                                                            "type": "CurrentArrayElement",
-                                                                                                            "id": "]Y4I5`}c)^0_%%]84AEk"
-                                                                                                          }
-                                                                                                        }
-                                                                                                      }
-                                                                                                    }
-                                                                                                  },
-                                                                                                  "VALUE-1": {
-                                                                                                    "block": {
-                                                                                                      "type": "GetTeamId",
-                                                                                                      "id": "1`d~}.,G,2448VL}z*T%",
-                                                                                                      "inputs": {
-                                                                                                        "VALUE-0": {
-                                                                                                          "block": {
-                                                                                                            "type": "EventPlayer",
-                                                                                                            "id": "3ANSXnCET%T;Jv^yEHNt"
-                                                                                                          }
-                                                                                                        }
-                                                                                                      }
-                                                                                                    }
-                                                                                                  }
-                                                                                                }
-                                                                                              }
-                                                                                            },
-                                                                                            "VALUE-1": {
-                                                                                              "block": {
-                                                                                                "type": "NotEqualTo",
-                                                                                                "id": "[_F^zzU3g-zQpQGJ[F(N",
-                                                                                                "inputs": {
-                                                                                                  "VALUE-0": {
-                                                                                                    "block": {
-                                                                                                      "type": "CurrentArrayElement",
-                                                                                                      "id": "XuTz],i/OcnY:{lK]dh^"
-                                                                                                    }
-                                                                                                  },
-                                                                                                  "VALUE-1": {
-                                                                                                    "block": {
-                                                                                                      "type": "EventPlayer",
-                                                                                                      "id": "xDSoWL:O?I+KtG4}-nRO"
-                                                                                                    }
-                                                                                                  }
-                                                                                                }
-                                                                                              }
-                                                                                            }
-                                                                                          }
-                                                                                        }
-                                                                                      }
-                                                                                    }
-                                                                                  }
-                                                                                }
-                                                                              }
-                                                                            }
-                                                                          }
-                                                                        },
-                                                                        "next": {
-                                                                          "block": {
-                                                                            "type": "If",
-                                                                            "id": "yxVT?m8(NhlD;*3s3!fQ",
-                                                                            "extraState": {
-                                                                              "elseif": 0,
-                                                                              "else": 1
-                                                                            },
-                                                                            "inputs": {
-                                                                              "VALUE-0": {
-                                                                                "block": {
-                                                                                  "type": "GreaterThan",
-                                                                                  "id": "0/jo,|RvRE^zIwDj(nLa",
-                                                                                  "inputs": {
-                                                                                    "VALUE-0": {
-                                                                                      "block": {
-                                                                                        "type": "CountOf",
-                                                                                        "id": "@N}Mk}kP:}OIhLj%RyiK",
-                                                                                        "inputs": {
-                                                                                          "VALUE-0": {
-                                                                                            "block": {
-                                                                                              "type": "GetVariable",
-                                                                                              "id": "ORC5U_.I6xJu+zdG_1sU",
-                                                                                              "inputs": {
-                                                                                                "VALUE-0": {
-                                                                                                  "block": {
-                                                                                                    "type": "variableReferenceBlock",
-                                                                                                    "id": "s_Do~$UMpb[:3;F]Rjc6",
-                                                                                                    "extraState": {
-                                                                                                      "isObjectVar": true
-                                                                                                    },
-                                                                                                    "fields": {
-                                                                                                      "OBJECTTYPE": "Player",
-                                                                                                      "VAR": {
-                                                                                                        "id": "Ja]@k]U!U8$Jv5S~jX*y"
-                                                                                                      }
-                                                                                                    },
-                                                                                                    "inputs": {
-                                                                                                      "OBJECT": {
-                                                                                                        "block": {
-                                                                                                          "type": "EventPlayer",
-                                                                                                          "id": "z(1qRs@Gi/Uj4%Z:Iap}"
-                                                                                                        }
-                                                                                                      }
-                                                                                                    }
-                                                                                                  }
-                                                                                                }
-                                                                                              }
-                                                                                            }
-                                                                                          }
-                                                                                        }
-                                                                                      }
-                                                                                    },
-                                                                                    "VALUE-1": {
-                                                                                      "block": {
-                                                                                        "type": "Number",
-                                                                                        "id": "MEu5C(jCPKdAj%Ixzin^",
-                                                                                        "fields": {
-                                                                                          "NUM": 0
-                                                                                        }
-                                                                                      }
-                                                                                    }
-                                                                                  }
-                                                                                }
-                                                                              },
-                                                                              "DO": {
-                                                                                "block": {
-                                                                                  "type": "If",
-                                                                                  "id": "Z4d:z~bfAd`0GQ?y;`q8",
-                                                                                  "extraState": {},
-                                                                                  "inputs": {
-                                                                                    "VALUE-0": {
-                                                                                      "block": {
-                                                                                        "type": "IsTrueForAll",
-                                                                                        "id": "F^a{wu#T(_lA_:U^K*Yr",
-                                                                                        "inputs": {
-                                                                                          "VALUE-0": {
-                                                                                            "block": {
-                                                                                              "type": "GetVariable",
-                                                                                              "id": "wOEC0K9bez9_f`ezP!`4",
-                                                                                              "inputs": {
-                                                                                                "VALUE-0": {
-                                                                                                  "block": {
-                                                                                                    "type": "variableReferenceBlock",
-                                                                                                    "id": "[@i+%5.Ib.17rC/!5hUs",
-                                                                                                    "extraState": {
-                                                                                                      "isObjectVar": true
-                                                                                                    },
-                                                                                                    "fields": {
-                                                                                                      "OBJECTTYPE": "Player",
-                                                                                                      "VAR": {
-                                                                                                        "id": "Ja]@k]U!U8$Jv5S~jX*y"
-                                                                                                      }
-                                                                                                    },
-                                                                                                    "inputs": {
-                                                                                                      "OBJECT": {
-                                                                                                        "block": {
-                                                                                                          "type": "EventPlayer",
-                                                                                                          "id": "^N@=Az%uh75s;xn6wiwp"
-                                                                                                        }
-                                                                                                      }
-                                                                                                    }
-                                                                                                  }
-                                                                                                }
-                                                                                              }
-                                                                                            }
-                                                                                          },
-                                                                                          "VALUE-1": {
-                                                                                            "block": {
-                                                                                              "type": "GreaterThan",
-                                                                                              "id": "u$-eheG!#XE}PsDL?i04",
-                                                                                              "inputs": {
-                                                                                                "VALUE-0": {
-                                                                                                  "block": {
-                                                                                                    "type": "DistanceBetween",
-                                                                                                    "id": "4s1n{)keq]SmLw_kI4oL",
-                                                                                                    "inline": false,
-                                                                                                    "inputs": {
-                                                                                                      "VALUE-0": {
-                                                                                                        "block": {
-                                                                                                          "type": "GetSoldierState",
-                                                                                                          "id": "AEY=XM:!2%9Q?RM6UR}4",
-                                                                                                          "inputs": {
-                                                                                                            "VALUE-0": {
-                                                                                                              "block": {
-                                                                                                                "type": "CurrentArrayElement",
-                                                                                                                "id": "S.Zl(,lib~lbK+tLN=OV"
-                                                                                                              }
-                                                                                                            },
-                                                                                                            "VALUE-1": {
-                                                                                                              "block": {
-                                                                                                                "type": "SoldierStateVectorItem",
-                                                                                                                "id": "=HK[na*;s$J+u+qv*?$a",
-                                                                                                                "fields": {
-                                                                                                                  "VALUE-0": "SoldierStateVector",
-                                                                                                                  "VALUE-1": "GetPosition"
-                                                                                                                }
-                                                                                                              }
-                                                                                                            }
-                                                                                                          }
-                                                                                                        }
-                                                                                                      },
-                                                                                                      "VALUE-1": {
-                                                                                                        "block": {
-                                                                                                          "type": "GetSoldierState",
-                                                                                                          "id": "`7dSn+DS_=khYa-^!RyO",
-                                                                                                          "inputs": {
-                                                                                                            "VALUE-0": {
-                                                                                                              "block": {
-                                                                                                                "type": "EventPlayer",
-                                                                                                                "id": "#fiHijw@%B$g9?G0JFU]"
-                                                                                                              }
-                                                                                                            },
-                                                                                                            "VALUE-1": {
-                                                                                                              "block": {
-                                                                                                                "type": "SoldierStateVectorItem",
-                                                                                                                "id": "l-0J,[89Un29zlb.Jwz_",
-                                                                                                                "fields": {
-                                                                                                                  "VALUE-0": "SoldierStateVector",
-                                                                                                                  "VALUE-1": "GetPosition"
-                                                                                                                }
-                                                                                                              }
-                                                                                                            }
-                                                                                                          }
-                                                                                                        }
-                                                                                                      }
-                                                                                                    }
-                                                                                                  }
-                                                                                                },
-                                                                                                "VALUE-1": {
-                                                                                                  "block": {
-                                                                                                    "type": "Number",
-                                                                                                    "id": "}KV1IK]QbP=FI2OIEyeE",
-                                                                                                    "fields": {
-                                                                                                      "NUM": 15
-                                                                                                    }
-                                                                                                  }
-                                                                                                }
-                                                                                              }
-                                                                                            }
-                                                                                          }
-                                                                                        }
-                                                                                      }
-                                                                                    },
-                                                                                    "DO": {
-                                                                                      "block": {
-                                                                                        "type": "Teleport",
-                                                                                        "id": "YCL_5+WLz(Z90}|b+QVK",
-                                                                                        "inputs": {
-                                                                                          "VALUE-0": {
-                                                                                            "block": {
-                                                                                              "type": "EventPlayer",
-                                                                                              "id": "[SS2/,wEnpTPS`@:[+HS"
-                                                                                            }
-                                                                                          },
-                                                                                          "VALUE-1": {
-                                                                                            "block": {
-                                                                                              "type": "GetVariable",
-                                                                                              "id": "RoPVO^4[VfR)G?0P/[qU",
-                                                                                              "inputs": {
-                                                                                                "VALUE-0": {
-                                                                                                  "block": {
-                                                                                                    "type": "variableReferenceBlock",
-                                                                                                    "id": "+?qodHm%UYBFWEg0LQ~}",
-                                                                                                    "extraState": {
-                                                                                                      "isObjectVar": true
-                                                                                                    },
-                                                                                                    "fields": {
-                                                                                                      "OBJECTTYPE": "TeamId",
-                                                                                                      "VAR": {
-                                                                                                        "id": ")85N/!w[yu2n1i{J:kG%"
-                                                                                                      }
-                                                                                                    },
-                                                                                                    "inputs": {
-                                                                                                      "OBJECT": {
-                                                                                                        "block": {
-                                                                                                          "type": "GetTeamId",
-                                                                                                          "id": "|mwy|:.mMFdVtQ{z`DT(",
-                                                                                                          "inputs": {
-                                                                                                            "VALUE-0": {
-                                                                                                              "block": {
-                                                                                                                "type": "EventPlayer",
-                                                                                                                "id": "E*~uNcDH[oL6ve[+hCvY"
-                                                                                                              }
-                                                                                                            }
-                                                                                                          }
-                                                                                                        }
-                                                                                                      }
-                                                                                                    }
-                                                                                                  }
-                                                                                                }
-                                                                                              }
-                                                                                            }
-                                                                                          },
-                                                                                          "VALUE-2": {
-                                                                                            "block": {
-                                                                                              "type": "Number",
-                                                                                              "id": ",M6f--hC%Kx%WE/utR!7",
-                                                                                              "fields": {
-                                                                                                "NUM": 0
-                                                                                              }
-                                                                                            }
-                                                                                          }
-                                                                                        }
-                                                                                      }
-                                                                                    }
-                                                                                  }
-                                                                                }
-                                                                              },
-                                                                              "ELSE": {
-                                                                                "block": {
-                                                                                  "type": "Teleport",
-                                                                                  "id": "^u%`C1HU4-O:+@G9L0=w",
-                                                                                  "inputs": {
-                                                                                    "VALUE-0": {
-                                                                                      "block": {
-                                                                                        "type": "EventPlayer",
-                                                                                        "id": "lW}tU8bS=aTY||=Pl!ZS"
-                                                                                      }
-                                                                                    },
-                                                                                    "VALUE-1": {
-                                                                                      "block": {
-                                                                                        "type": "GetVariable",
-                                                                                        "id": "=?a-njy4WUisrMbdca$X",
-                                                                                        "inputs": {
-                                                                                          "VALUE-0": {
-                                                                                            "block": {
-                                                                                              "type": "variableReferenceBlock",
-                                                                                              "id": "{+8Y1/g]Lo?f9@Seq/:_",
-                                                                                              "extraState": {
-                                                                                                "isObjectVar": true
-                                                                                              },
-                                                                                              "fields": {
-                                                                                                "OBJECTTYPE": "TeamId",
-                                                                                                "VAR": {
-                                                                                                  "id": ")85N/!w[yu2n1i{J:kG%"
-                                                                                                }
-                                                                                              },
-                                                                                              "inputs": {
-                                                                                                "OBJECT": {
-                                                                                                  "block": {
-                                                                                                    "type": "GetTeamId",
-                                                                                                    "id": "jcA}RpEwTCxH?R/`l+?=",
-                                                                                                    "inputs": {
-                                                                                                      "VALUE-0": {
-                                                                                                        "block": {
-                                                                                                          "type": "EventPlayer",
-                                                                                                          "id": "@69[W|3P`ao?,k%v~]#f"
-                                                                                                        }
-                                                                                                      }
-                                                                                                    }
-                                                                                                  }
-                                                                                                }
-                                                                                              }
-                                                                                            }
-                                                                                          }
-                                                                                        }
-                                                                                      }
-                                                                                    },
-                                                                                    "VALUE-2": {
-                                                                                      "block": {
-                                                                                        "type": "Number",
-                                                                                        "id": "T,RNz*QzJHtW]x@5T)Oa",
-                                                                                        "fields": {
-                                                                                          "NUM": 0
-                                                                                        }
-                                                                                      }
-                                                                                    }
-                                                                                  }
-                                                                                }
-                                                                              }
-                                                                            },
-                                                                            "next": {
+                                                                          "type": "SetPlayerKit",
+                                                                          "id": "n{=,$:?|W6a;r7CpU`:[",
+                                                                          "inputs": {
+                                                                            "VALUE-0": {
                                                                               "block": {
-                                                                                "type": "subroutineInstanceBlock",
-                                                                                "id": "vEdtg{@3#|:Ou?cC~}Ab",
-                                                                                "extraState": {
-                                                                                  "subroutineName": "CheckBoundaries",
-                                                                                  "parameters": [
-                                                                                    {
-                                                                                      "types": "Array",
-                                                                                      "name": "Location"
-                                                                                    }
-                                                                                  ]
-                                                                                },
-                                                                                "fields": {
-                                                                                  "SUBROUTINE_NAME": "CheckBoundaries"
-                                                                                },
+                                                                                "type": "EventPlayer",
+                                                                                "id": ",I,h!f]fKuZswY8t1:zS"
+                                                                              }
+                                                                            },
+                                                                            "VALUE-1": {
+                                                                              "block": {
+                                                                                "type": "RandomValueInArray",
+                                                                                "id": "+23+BlNj)TLGwVNpkPF[",
                                                                                 "inputs": {
-                                                                                  "PARAM-0": {
+                                                                                  "VALUE-0": {
                                                                                     "block": {
                                                                                       "type": "GetVariable",
-                                                                                      "id": "+DC8aA=x0O3J?0L^_[Bl",
+                                                                                      "id": "_G9,g$Y?`j:d*)8@0XYv",
                                                                                       "inputs": {
                                                                                         "VALUE-0": {
                                                                                           "block": {
                                                                                             "type": "variableReferenceBlock",
-                                                                                            "id": "oAn,G[_/3Mv2-7mH]+nl",
+                                                                                            "id": "22OnN64nWwOLjXtPw_$_",
                                                                                             "extraState": {
                                                                                               "isObjectVar": false
                                                                                             },
                                                                                             "fields": {
                                                                                               "OBJECTTYPE": "Global",
                                                                                               "VAR": {
-                                                                                                "id": "avhOM{5IU+T,cbtA-5?M"
+                                                                                                "id": "PQt,8tYaHP%Y^xyuN2vr"
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    "next": {
+                                                                      "block": {
+                                                                        "type": "If",
+                                                                        "id": "2o(gF``d!]!;%G4!sfZ@",
+                                                                        "extraState": {
+                                                                          "elseif": 3,
+                                                                          "else": 1
+                                                                        },
+                                                                        "inputs": {
+                                                                          "VALUE-0": {
+                                                                            "block": {
+                                                                              "type": "IsTrueForAny",
+                                                                              "id": "?f:Oy7qmfldo,?kPB~lw",
+                                                                              "inputs": {
+                                                                                "VALUE-0": {
+                                                                                  "block": {
+                                                                                    "type": "GetVariable",
+                                                                                    "id": "BAI)Rj8sS:IRXU%]8fiN",
+                                                                                    "inputs": {
+                                                                                      "VALUE-0": {
+                                                                                        "block": {
+                                                                                          "type": "variableReferenceBlock",
+                                                                                          "id": "1t}uxyciZ#M0@G3+DY*w",
+                                                                                          "extraState": {
+                                                                                            "isObjectVar": false
+                                                                                          },
+                                                                                          "fields": {
+                                                                                            "OBJECTTYPE": "Global",
+                                                                                            "VAR": {
+                                                                                              "id": "}Zluh/,.+*V:1v$3);ao"
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                },
+                                                                                "VALUE-1": {
+                                                                                  "block": {
+                                                                                    "type": "IsUsingKit",
+                                                                                    "id": "CFf.X)LiWtzTZ$~r4,#s",
+                                                                                    "inputs": {
+                                                                                      "VALUE-0": {
+                                                                                        "block": {
+                                                                                          "type": "EventPlayer",
+                                                                                          "id": "%zk%hGGSplK?_QPzi)o|"
+                                                                                        }
+                                                                                      },
+                                                                                      "VALUE-1": {
+                                                                                        "block": {
+                                                                                          "type": "CurrentArrayElement",
+                                                                                          "id": "yhfpV!+=pbA*6o}CwIY["
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          "DO": {
+                                                                            "block": {
+                                                                              "type": "subroutineInstanceBlock",
+                                                                              "id": "DWf/i*Y+yuRP+U79tI~C",
+                                                                              "extraState": {
+                                                                                "subroutineName": "Assault",
+                                                                                "parameters": []
+                                                                              },
+                                                                              "fields": {
+                                                                                "SUBROUTINE_NAME": "Assault"
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          "IF1": {
+                                                                            "block": {
+                                                                              "type": "IsTrueForAny",
+                                                                              "id": "vxRNZ/l}-t!4/Gw}DXKa",
+                                                                              "inputs": {
+                                                                                "VALUE-0": {
+                                                                                  "block": {
+                                                                                    "type": "GetVariable",
+                                                                                    "id": "chh!|dudmP@|s[nd7-2P",
+                                                                                    "inputs": {
+                                                                                      "VALUE-0": {
+                                                                                        "block": {
+                                                                                          "type": "variableReferenceBlock",
+                                                                                          "id": "qE$S6!]j%_W*BVo%vWnQ",
+                                                                                          "extraState": {
+                                                                                            "isObjectVar": false
+                                                                                          },
+                                                                                          "fields": {
+                                                                                            "OBJECTTYPE": "Global",
+                                                                                            "VAR": {
+                                                                                              "id": "Oy^]7IX.zwi.UFR*ty79"
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                },
+                                                                                "VALUE-1": {
+                                                                                  "block": {
+                                                                                    "type": "IsUsingKit",
+                                                                                    "id": "A+$mC^~m3lfuH69a{qk5",
+                                                                                    "inputs": {
+                                                                                      "VALUE-0": {
+                                                                                        "block": {
+                                                                                          "type": "EventPlayer",
+                                                                                          "id": "_6MOucOxW9?b4|rM|`Hn"
+                                                                                        }
+                                                                                      },
+                                                                                      "VALUE-1": {
+                                                                                        "block": {
+                                                                                          "type": "CurrentArrayElement",
+                                                                                          "id": "qAE16El#,lII/?^A4)aQ"
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          "DO1": {
+                                                                            "block": {
+                                                                              "type": "subroutineInstanceBlock",
+                                                                              "id": "KxwB0EJdL5Q~GGqAbgH:",
+                                                                              "extraState": {
+                                                                                "subroutineName": "Medic",
+                                                                                "parameters": []
+                                                                              },
+                                                                              "fields": {
+                                                                                "SUBROUTINE_NAME": "Medic"
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          "IF2": {
+                                                                            "block": {
+                                                                              "type": "IsTrueForAny",
+                                                                              "id": "Q4GdqqTr%j./0e}dKXq5",
+                                                                              "inputs": {
+                                                                                "VALUE-0": {
+                                                                                  "block": {
+                                                                                    "type": "GetVariable",
+                                                                                    "id": "IaGvVJr6H{TtXrt=i9}g",
+                                                                                    "inputs": {
+                                                                                      "VALUE-0": {
+                                                                                        "block": {
+                                                                                          "type": "variableReferenceBlock",
+                                                                                          "id": "SWXkW)E[~gtAe^21^tx=",
+                                                                                          "extraState": {
+                                                                                            "isObjectVar": false
+                                                                                          },
+                                                                                          "fields": {
+                                                                                            "OBJECTTYPE": "Global",
+                                                                                            "VAR": {
+                                                                                              "id": "%YI,HkG5QqE*1#EzZxjM"
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                },
+                                                                                "VALUE-1": {
+                                                                                  "block": {
+                                                                                    "type": "IsUsingKit",
+                                                                                    "id": "Qsk4g{CjTxSgm-ZVjyI%",
+                                                                                    "inputs": {
+                                                                                      "VALUE-0": {
+                                                                                        "block": {
+                                                                                          "type": "EventPlayer",
+                                                                                          "id": "?FW3gB$__)?g}JMrdk[#"
+                                                                                        }
+                                                                                      },
+                                                                                      "VALUE-1": {
+                                                                                        "block": {
+                                                                                          "type": "CurrentArrayElement",
+                                                                                          "id": "?]^[kp?=laj@^PT#Fk(G"
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          "DO2": {
+                                                                            "block": {
+                                                                              "type": "subroutineInstanceBlock",
+                                                                              "id": "G^ae|;-m)]f(u1s2vNbf",
+                                                                              "extraState": {
+                                                                                "subroutineName": "Engineer",
+                                                                                "parameters": []
+                                                                              },
+                                                                              "fields": {
+                                                                                "SUBROUTINE_NAME": "Engineer"
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          "IF3": {
+                                                                            "block": {
+                                                                              "type": "IsTrueForAny",
+                                                                              "id": "Y3%$`Se[qov!EKRQ;?xY",
+                                                                              "inputs": {
+                                                                                "VALUE-0": {
+                                                                                  "block": {
+                                                                                    "type": "GetVariable",
+                                                                                    "id": "+DJlk]Zj]u*z=Tj)8OIV",
+                                                                                    "inputs": {
+                                                                                      "VALUE-0": {
+                                                                                        "block": {
+                                                                                          "type": "variableReferenceBlock",
+                                                                                          "id": "a2L}brZ|Wl_KR;rk;Ob_",
+                                                                                          "extraState": {
+                                                                                            "isObjectVar": false
+                                                                                          },
+                                                                                          "fields": {
+                                                                                            "OBJECTTYPE": "Global",
+                                                                                            "VAR": {
+                                                                                              "id": "hypM!0ohL^cA%HtBrJ7;"
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                },
+                                                                                "VALUE-1": {
+                                                                                  "block": {
+                                                                                    "type": "IsUsingKit",
+                                                                                    "id": "INb6x#CKeb?[9X*Q[=SC",
+                                                                                    "inputs": {
+                                                                                      "VALUE-0": {
+                                                                                        "block": {
+                                                                                          "type": "EventPlayer",
+                                                                                          "id": "L$yI_%r|)5EE1)qC,R+`"
+                                                                                        }
+                                                                                      },
+                                                                                      "VALUE-1": {
+                                                                                        "block": {
+                                                                                          "type": "CurrentArrayElement",
+                                                                                          "id": ";tY5M4rkD/OP9,HO(tP^"
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          "DO3": {
+                                                                            "block": {
+                                                                              "type": "subroutineInstanceBlock",
+                                                                              "id": "gvbLQd%,X:F0nWhqZlLQ",
+                                                                              "extraState": {
+                                                                                "subroutineName": "Scout",
+                                                                                "parameters": []
+                                                                              },
+                                                                              "fields": {
+                                                                                "SUBROUTINE_NAME": "Scout"
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        },
+                                                                        "next": {
+                                                                          "block": {
+                                                                            "type": "SetVariable",
+                                                                            "id": "sd=h:DiAX@8jkcY:5!34",
+                                                                            "inputs": {
+                                                                              "VALUE-0": {
+                                                                                "block": {
+                                                                                  "type": "variableReferenceBlock",
+                                                                                  "id": "wfyDD(Otn`[PzSAHYX1%",
+                                                                                  "extraState": {
+                                                                                    "isObjectVar": true
+                                                                                  },
+                                                                                  "fields": {
+                                                                                    "OBJECTTYPE": "Player",
+                                                                                    "VAR": {
+                                                                                      "id": "Ja]@k]U!U8$Jv5S~jX*y"
+                                                                                    }
+                                                                                  },
+                                                                                  "inputs": {
+                                                                                    "OBJECT": {
+                                                                                      "block": {
+                                                                                        "type": "EventPlayer",
+                                                                                        "id": "R*-/JFHga^[M|dTQ7rdg"
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              },
+                                                                              "VALUE-1": {
+                                                                                "block": {
+                                                                                  "type": "EmptyArray",
+                                                                                  "id": "YIysv5y$b.f{e?!fST14"
+                                                                                }
+                                                                              }
+                                                                            },
+                                                                            "next": {
+                                                                              "block": {
+                                                                                "type": "SetVariable",
+                                                                                "id": "a;6L|s*3a%G=3%x|H5VU",
+                                                                                "inputs": {
+                                                                                  "VALUE-0": {
+                                                                                    "block": {
+                                                                                      "type": "variableReferenceBlock",
+                                                                                      "id": "8%}/}6B/)%I.w:ata)vU",
+                                                                                      "extraState": {
+                                                                                        "isObjectVar": true
+                                                                                      },
+                                                                                      "fields": {
+                                                                                        "OBJECTTYPE": "Player",
+                                                                                        "VAR": {
+                                                                                          "id": "Ja]@k]U!U8$Jv5S~jX*y"
+                                                                                        }
+                                                                                      },
+                                                                                      "inputs": {
+                                                                                        "OBJECT": {
+                                                                                          "block": {
+                                                                                            "type": "EventPlayer",
+                                                                                            "id": "}yTss!iXP,STd}^/oNm^"
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  },
+                                                                                  "VALUE-1": {
+                                                                                    "block": {
+                                                                                      "type": "FilteredArray",
+                                                                                      "id": "h7:1$S~D^!_;_z!HgMw_",
+                                                                                      "inputs": {
+                                                                                        "VALUE-0": {
+                                                                                          "block": {
+                                                                                            "type": "AllPlayers",
+                                                                                            "id": "K+MlW+hK6C5{G]pUd7b6"
+                                                                                          }
+                                                                                        },
+                                                                                        "VALUE-1": {
+                                                                                          "block": {
+                                                                                            "type": "And",
+                                                                                            "id": "T#+JWsP2tiVUb32`2Q*R",
+                                                                                            "inline": false,
+                                                                                            "inputs": {
+                                                                                              "VALUE-0": {
+                                                                                                "block": {
+                                                                                                  "type": "GetSoldierState",
+                                                                                                  "id": "[Os0Yl3Fq8t+hk%~T,,o",
+                                                                                                  "inputs": {
+                                                                                                    "VALUE-0": {
+                                                                                                      "block": {
+                                                                                                        "type": "CurrentArrayElement",
+                                                                                                        "id": "DC?A~~OU+X(8E-/Y__LU"
+                                                                                                      }
+                                                                                                    },
+                                                                                                    "VALUE-1": {
+                                                                                                      "block": {
+                                                                                                        "type": "SoldierStateBoolItem",
+                                                                                                        "id": "t)-e4ML+wEkbU%xH%D[9",
+                                                                                                        "fields": {
+                                                                                                          "VALUE-0": "SoldierStateBool",
+                                                                                                          "VALUE-1": "IsAlive"
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              },
+                                                                                              "VALUE-1": {
+                                                                                                "block": {
+                                                                                                  "type": "And",
+                                                                                                  "id": "w5yNiA/_PMb!Eqpfl]pH",
+                                                                                                  "inline": false,
+                                                                                                  "inputs": {
+                                                                                                    "VALUE-0": {
+                                                                                                      "block": {
+                                                                                                        "type": "Equals",
+                                                                                                        "id": "+M`*aA)=T5P@A;J-D|MT",
+                                                                                                        "inputs": {
+                                                                                                          "VALUE-0": {
+                                                                                                            "block": {
+                                                                                                              "type": "GetTeamId",
+                                                                                                              "id": "Q6f/qJt+d%o:,^IX~7KF",
+                                                                                                              "inputs": {
+                                                                                                                "VALUE-0": {
+                                                                                                                  "block": {
+                                                                                                                    "type": "CurrentArrayElement",
+                                                                                                                    "id": "]Y4I5`}c)^0_%%]84AEk"
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          },
+                                                                                                          "VALUE-1": {
+                                                                                                            "block": {
+                                                                                                              "type": "GetTeamId",
+                                                                                                              "id": "1`d~}.,G,2448VL}z*T%",
+                                                                                                              "inputs": {
+                                                                                                                "VALUE-0": {
+                                                                                                                  "block": {
+                                                                                                                    "type": "EventPlayer",
+                                                                                                                    "id": "3ANSXnCET%T;Jv^yEHNt"
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    },
+                                                                                                    "VALUE-1": {
+                                                                                                      "block": {
+                                                                                                        "type": "NotEqualTo",
+                                                                                                        "id": "[_F^zzU3g-zQpQGJ[F(N",
+                                                                                                        "inputs": {
+                                                                                                          "VALUE-0": {
+                                                                                                            "block": {
+                                                                                                              "type": "CurrentArrayElement",
+                                                                                                              "id": "XuTz],i/OcnY:{lK]dh^"
+                                                                                                            }
+                                                                                                          },
+                                                                                                          "VALUE-1": {
+                                                                                                            "block": {
+                                                                                                              "type": "EventPlayer",
+                                                                                                              "id": "xDSoWL:O?I+KtG4}-nRO"
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
                                                                                               }
                                                                                             }
                                                                                           }
@@ -2235,39 +2556,87 @@
                                                                                 "next": {
                                                                                   "block": {
                                                                                     "type": "If",
-                                                                                    "id": "l%z=5uWd2m@Vo@Z.0f4D",
+                                                                                    "id": "3J[oY^4@u2#%~@hR5+{{",
                                                                                     "extraState": {},
                                                                                     "inputs": {
                                                                                       "VALUE-0": {
                                                                                         "block": {
-                                                                                          "type": "Not",
-                                                                                          "id": "$B#6znkq;wp;ci81czNf",
+                                                                                          "type": "IsTrueForAll",
+                                                                                          "id": "ky)${M3OJA}@zgH/pDT$",
                                                                                           "inputs": {
                                                                                             "VALUE-0": {
                                                                                               "block": {
                                                                                                 "type": "GetVariable",
-                                                                                                "id": "83/{MnyYEQoUy(M^lP2W",
+                                                                                                "id": "]Juw{i(JmEZ@t+yYV}Jb",
                                                                                                 "inputs": {
                                                                                                   "VALUE-0": {
                                                                                                     "block": {
                                                                                                       "type": "variableReferenceBlock",
-                                                                                                      "id": "8Xd*dEAiQhn=K%!`Ow?_",
+                                                                                                      "id": "+x`5j]Td1r$H)R.;8u:m",
                                                                                                       "extraState": {
-                                                                                                        "isObjectVar": true
+                                                                                                        "isObjectVar": false
                                                                                                       },
                                                                                                       "fields": {
-                                                                                                        "OBJECTTYPE": "Player",
+                                                                                                        "OBJECTTYPE": "Global",
                                                                                                         "VAR": {
-                                                                                                          "id": "RtgD|X+%@!)n$MrP;5vL"
+                                                                                                          "id": "w_^Ni+6S]Sp8=OOP4#,a"
                                                                                                         }
-                                                                                                      },
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            },
+                                                                                            "VALUE-1": {
+                                                                                              "block": {
+                                                                                                "type": "GreaterThan",
+                                                                                                "id": "TAd$:K-{xx6L!=qsL{($",
+                                                                                                "inputs": {
+                                                                                                  "VALUE-0": {
+                                                                                                    "block": {
+                                                                                                      "type": "DistanceBetween",
+                                                                                                      "id": "w.3w~P8|+uQ2u/`dKy?B",
+                                                                                                      "inline": false,
                                                                                                       "inputs": {
-                                                                                                        "OBJECT": {
+                                                                                                        "VALUE-0": {
                                                                                                           "block": {
-                                                                                                            "type": "EventPlayer",
-                                                                                                            "id": "y+wO@=0;oy-/pvNf*TIo"
+                                                                                                            "type": "GetSoldierState",
+                                                                                                            "id": "0*aLbkA-o$ajdu4(zpZ[",
+                                                                                                            "inputs": {
+                                                                                                              "VALUE-0": {
+                                                                                                                "block": {
+                                                                                                                  "type": "EventPlayer",
+                                                                                                                  "id": "e5]%q/gwC44G.TWHgqa`"
+                                                                                                                }
+                                                                                                              },
+                                                                                                              "VALUE-1": {
+                                                                                                                "block": {
+                                                                                                                  "type": "SoldierStateVectorItem",
+                                                                                                                  "id": "El`+7Q{VCG[fN$yAb3=x",
+                                                                                                                  "fields": {
+                                                                                                                    "VALUE-0": "SoldierStateVector",
+                                                                                                                    "VALUE-1": "GetPosition"
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        },
+                                                                                                        "VALUE-1": {
+                                                                                                          "block": {
+                                                                                                            "type": "CurrentArrayElement",
+                                                                                                            "id": "TUj$em^BQ,!XFAb]=r);"
                                                                                                           }
                                                                                                         }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  },
+                                                                                                  "VALUE-1": {
+                                                                                                    "block": {
+                                                                                                      "type": "Number",
+                                                                                                      "id": "^;`J7jdA#wgylp+/2$]]",
+                                                                                                      "fields": {
+                                                                                                        "NUM": 10
                                                                                                       }
                                                                                                     }
                                                                                                   }
@@ -2279,95 +2648,47 @@
                                                                                       },
                                                                                       "DO": {
                                                                                         "block": {
-                                                                                          "type": "subroutineInstanceBlock",
-                                                                                          "id": "8sP4m+O0DeH]k?WHK4Oj",
+                                                                                          "type": "If",
+                                                                                          "id": "yxVT?m8(NhlD;*3s3!fQ",
                                                                                           "extraState": {
-                                                                                            "subroutineName": "CheckBoundaries",
-                                                                                            "parameters": [
-                                                                                              {
-                                                                                                "types": "Array",
-                                                                                                "name": "Location"
-                                                                                              }
-                                                                                            ]
-                                                                                          },
-                                                                                          "fields": {
-                                                                                            "SUBROUTINE_NAME": "CheckBoundaries"
+                                                                                            "elseif": 0,
+                                                                                            "else": 1
                                                                                           },
                                                                                           "inputs": {
-                                                                                            "PARAM-0": {
+                                                                                            "VALUE-0": {
                                                                                               "block": {
-                                                                                                "type": "GetVariable",
-                                                                                                "id": "fXwVA)bhqG==XLNhxPjj",
+                                                                                                "type": "GreaterThan",
+                                                                                                "id": "0/jo,|RvRE^zIwDj(nLa",
                                                                                                 "inputs": {
                                                                                                   "VALUE-0": {
                                                                                                     "block": {
-                                                                                                      "type": "variableReferenceBlock",
-                                                                                                      "id": "e}j_zGf|8VF|-@u;(#0*",
-                                                                                                      "extraState": {
-                                                                                                        "isObjectVar": true
-                                                                                                      },
-                                                                                                      "fields": {
-                                                                                                        "OBJECTTYPE": "TeamId",
-                                                                                                        "VAR": {
-                                                                                                          "id": "~!s}ovrs?jb7Yd/X[z2!"
-                                                                                                        }
-                                                                                                      },
+                                                                                                      "type": "CountOf",
+                                                                                                      "id": "@N}Mk}kP:}OIhLj%RyiK",
                                                                                                       "inputs": {
-                                                                                                        "OBJECT": {
+                                                                                                        "VALUE-0": {
                                                                                                           "block": {
-                                                                                                            "type": "GetTeamId",
-                                                                                                            "id": "N8U[%]Op|!:;|{_HhV(l",
+                                                                                                            "type": "GetVariable",
+                                                                                                            "id": "ORC5U_.I6xJu+zdG_1sU",
                                                                                                             "inputs": {
                                                                                                               "VALUE-0": {
                                                                                                                 "block": {
-                                                                                                                  "type": "EventPlayer",
-                                                                                                                  "id": ":b%V3_33|cMjvp^6p0W^"
-                                                                                                                }
-                                                                                                              }
-                                                                                                            }
-                                                                                                          }
-                                                                                                        }
-                                                                                                      }
-                                                                                                    }
-                                                                                                  }
-                                                                                                }
-                                                                                              }
-                                                                                            }
-                                                                                          },
-                                                                                          "next": {
-                                                                                            "block": {
-                                                                                              "type": "If",
-                                                                                              "id": "/cX+vDlEl:C](w5zzk~g",
-                                                                                              "extraState": {},
-                                                                                              "inputs": {
-                                                                                                "VALUE-0": {
-                                                                                                  "block": {
-                                                                                                    "type": "Not",
-                                                                                                    "id": "UPO;wG--jx?E|nEzl^n3",
-                                                                                                    "inputs": {
-                                                                                                      "VALUE-0": {
-                                                                                                        "block": {
-                                                                                                          "type": "GetVariable",
-                                                                                                          "id": "XEe2Fmurk%P`_jp3HJ4$",
-                                                                                                          "inputs": {
-                                                                                                            "VALUE-0": {
-                                                                                                              "block": {
-                                                                                                                "type": "variableReferenceBlock",
-                                                                                                                "id": "pfl*Ksr)lAH|TPdfcw}A",
-                                                                                                                "extraState": {
-                                                                                                                  "isObjectVar": true
-                                                                                                                },
-                                                                                                                "fields": {
-                                                                                                                  "OBJECTTYPE": "Player",
-                                                                                                                  "VAR": {
-                                                                                                                    "id": "RtgD|X+%@!)n$MrP;5vL"
-                                                                                                                  }
-                                                                                                                },
-                                                                                                                "inputs": {
-                                                                                                                  "OBJECT": {
-                                                                                                                    "block": {
-                                                                                                                      "type": "EventPlayer",
-                                                                                                                      "id": "Q:0V@g|$h:Nkc:70[~hE"
+                                                                                                                  "type": "variableReferenceBlock",
+                                                                                                                  "id": "s_Do~$UMpb[:3;F]Rjc6",
+                                                                                                                  "extraState": {
+                                                                                                                    "isObjectVar": true
+                                                                                                                  },
+                                                                                                                  "fields": {
+                                                                                                                    "OBJECTTYPE": "Player",
+                                                                                                                    "VAR": {
+                                                                                                                      "id": "Ja]@k]U!U8$Jv5S~jX*y"
+                                                                                                                    }
+                                                                                                                  },
+                                                                                                                  "inputs": {
+                                                                                                                    "OBJECT": {
+                                                                                                                      "block": {
+                                                                                                                        "type": "EventPlayer",
+                                                                                                                        "id": "z(1qRs@Gi/Uj4%Z:Iap}"
+                                                                                                                      }
                                                                                                                     }
                                                                                                                   }
                                                                                                                 }
@@ -2377,48 +2698,246 @@
                                                                                                         }
                                                                                                       }
                                                                                                     }
+                                                                                                  },
+                                                                                                  "VALUE-1": {
+                                                                                                    "block": {
+                                                                                                      "type": "Number",
+                                                                                                      "id": "MEu5C(jCPKdAj%Ixzin^",
+                                                                                                      "fields": {
+                                                                                                        "NUM": 0
+                                                                                                      }
+                                                                                                    }
                                                                                                   }
+                                                                                                }
+                                                                                              }
+                                                                                            },
+                                                                                            "DO": {
+                                                                                              "block": {
+                                                                                                "type": "If",
+                                                                                                "id": "Z4d:z~bfAd`0GQ?y;`q8",
+                                                                                                "extraState": {
+                                                                                                  "elseif": 0,
+                                                                                                  "else": 1
                                                                                                 },
-                                                                                                "DO": {
+                                                                                                "inputs": {
+                                                                                                  "VALUE-0": {
+                                                                                                    "block": {
+                                                                                                      "type": "IsTrueForAll",
+                                                                                                      "id": "F^a{wu#T(_lA_:U^K*Yr",
+                                                                                                      "inputs": {
+                                                                                                        "VALUE-0": {
+                                                                                                          "block": {
+                                                                                                            "type": "GetVariable",
+                                                                                                            "id": "wOEC0K9bez9_f`ezP!`4",
+                                                                                                            "inputs": {
+                                                                                                              "VALUE-0": {
+                                                                                                                "block": {
+                                                                                                                  "type": "variableReferenceBlock",
+                                                                                                                  "id": "[@i+%5.Ib.17rC/!5hUs",
+                                                                                                                  "extraState": {
+                                                                                                                    "isObjectVar": true
+                                                                                                                  },
+                                                                                                                  "fields": {
+                                                                                                                    "OBJECTTYPE": "Player",
+                                                                                                                    "VAR": {
+                                                                                                                      "id": "Ja]@k]U!U8$Jv5S~jX*y"
+                                                                                                                    }
+                                                                                                                  },
+                                                                                                                  "inputs": {
+                                                                                                                    "OBJECT": {
+                                                                                                                      "block": {
+                                                                                                                        "type": "EventPlayer",
+                                                                                                                        "id": "^N@=Az%uh75s;xn6wiwp"
+                                                                                                                      }
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        },
+                                                                                                        "VALUE-1": {
+                                                                                                          "block": {
+                                                                                                            "type": "GreaterThan",
+                                                                                                            "id": "u$-eheG!#XE}PsDL?i04",
+                                                                                                            "inputs": {
+                                                                                                              "VALUE-0": {
+                                                                                                                "block": {
+                                                                                                                  "type": "DistanceBetween",
+                                                                                                                  "id": "4s1n{)keq]SmLw_kI4oL",
+                                                                                                                  "inline": false,
+                                                                                                                  "inputs": {
+                                                                                                                    "VALUE-0": {
+                                                                                                                      "block": {
+                                                                                                                        "type": "GetSoldierState",
+                                                                                                                        "id": "AEY=XM:!2%9Q?RM6UR}4",
+                                                                                                                        "inputs": {
+                                                                                                                          "VALUE-0": {
+                                                                                                                            "block": {
+                                                                                                                              "type": "CurrentArrayElement",
+                                                                                                                              "id": "S.Zl(,lib~lbK+tLN=OV"
+                                                                                                                            }
+                                                                                                                          },
+                                                                                                                          "VALUE-1": {
+                                                                                                                            "block": {
+                                                                                                                              "type": "SoldierStateVectorItem",
+                                                                                                                              "id": "=HK[na*;s$J+u+qv*?$a",
+                                                                                                                              "fields": {
+                                                                                                                                "VALUE-0": "SoldierStateVector",
+                                                                                                                                "VALUE-1": "GetPosition"
+                                                                                                                              }
+                                                                                                                            }
+                                                                                                                          }
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    },
+                                                                                                                    "VALUE-1": {
+                                                                                                                      "block": {
+                                                                                                                        "type": "GetSoldierState",
+                                                                                                                        "id": "`7dSn+DS_=khYa-^!RyO",
+                                                                                                                        "inputs": {
+                                                                                                                          "VALUE-0": {
+                                                                                                                            "block": {
+                                                                                                                              "type": "EventPlayer",
+                                                                                                                              "id": "#fiHijw@%B$g9?G0JFU]"
+                                                                                                                            }
+                                                                                                                          },
+                                                                                                                          "VALUE-1": {
+                                                                                                                            "block": {
+                                                                                                                              "type": "SoldierStateVectorItem",
+                                                                                                                              "id": "l-0J,[89Un29zlb.Jwz_",
+                                                                                                                              "fields": {
+                                                                                                                                "VALUE-0": "SoldierStateVector",
+                                                                                                                                "VALUE-1": "GetPosition"
+                                                                                                                              }
+                                                                                                                            }
+                                                                                                                          }
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              },
+                                                                                                              "VALUE-1": {
+                                                                                                                "block": {
+                                                                                                                  "type": "Number",
+                                                                                                                  "id": "}KV1IK]QbP=FI2OIEyeE",
+                                                                                                                  "fields": {
+                                                                                                                    "NUM": 15
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  },
+                                                                                                  "DO": {
+                                                                                                    "block": {
+                                                                                                      "type": "subroutineInstanceBlock",
+                                                                                                      "id": "-bphN(bSh169#)J0i!$m",
+                                                                                                      "extraState": {
+                                                                                                        "subroutineName": "Teleport",
+                                                                                                        "parameters": []
+                                                                                                      },
+                                                                                                      "fields": {
+                                                                                                        "SUBROUTINE_NAME": "Teleport"
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            },
+                                                                                            "ELSE": {
+                                                                                              "block": {
+                                                                                                "type": "subroutineInstanceBlock",
+                                                                                                "id": "XpjyK(P-mzKI7//2=.Bn",
+                                                                                                "extraState": {
+                                                                                                  "subroutineName": "Teleport",
+                                                                                                  "parameters": []
+                                                                                                },
+                                                                                                "fields": {
+                                                                                                  "SUBROUTINE_NAME": "Teleport"
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          },
+                                                                                          "next": {
+                                                                                            "block": {
+                                                                                              "type": "subroutineInstanceBlock",
+                                                                                              "id": "vEdtg{@3#|:Ou?cC~}Ab",
+                                                                                              "extraState": {
+                                                                                                "subroutineName": "CheckBoundaries",
+                                                                                                "parameters": [
+                                                                                                  {
+                                                                                                    "types": "Array",
+                                                                                                    "name": "Location"
+                                                                                                  }
+                                                                                                ]
+                                                                                              },
+                                                                                              "fields": {
+                                                                                                "SUBROUTINE_NAME": "CheckBoundaries"
+                                                                                              },
+                                                                                              "inputs": {
+                                                                                                "PARAM-0": {
                                                                                                   "block": {
-                                                                                                    "type": "Teleport",
-                                                                                                    "id": "D~M+NAmA)njPSF~@j0nr",
+                                                                                                    "type": "GetVariable",
+                                                                                                    "id": "+DC8aA=x0O3J?0L^_[Bl",
                                                                                                     "inputs": {
                                                                                                       "VALUE-0": {
                                                                                                         "block": {
-                                                                                                          "type": "EventPlayer",
-                                                                                                          "id": "tAp$_CzH4,pS#%N_(=sD"
+                                                                                                          "type": "variableReferenceBlock",
+                                                                                                          "id": "oAn,G[_/3Mv2-7mH]+nl",
+                                                                                                          "extraState": {
+                                                                                                            "isObjectVar": false
+                                                                                                          },
+                                                                                                          "fields": {
+                                                                                                            "OBJECTTYPE": "Global",
+                                                                                                            "VAR": {
+                                                                                                              "id": "avhOM{5IU+T,cbtA-5?M"
+                                                                                                            }
+                                                                                                          }
                                                                                                         }
-                                                                                                      },
-                                                                                                      "VALUE-1": {
-                                                                                                        "block": {
-                                                                                                          "type": "GetVariable",
-                                                                                                          "id": "`nLs@Fg=5OqPU(.z^uWf",
-                                                                                                          "inputs": {
-                                                                                                            "VALUE-0": {
-                                                                                                              "block": {
-                                                                                                                "type": "variableReferenceBlock",
-                                                                                                                "id": "+q^2R;_CCy@iCYz?|3y%",
-                                                                                                                "extraState": {
-                                                                                                                  "isObjectVar": true
-                                                                                                                },
-                                                                                                                "fields": {
-                                                                                                                  "OBJECTTYPE": "TeamId",
-                                                                                                                  "VAR": {
-                                                                                                                    "id": ")85N/!w[yu2n1i{J:kG%"
-                                                                                                                  }
-                                                                                                                },
-                                                                                                                "inputs": {
-                                                                                                                  "OBJECT": {
-                                                                                                                    "block": {
-                                                                                                                      "type": "GetTeamId",
-                                                                                                                      "id": "LZ.hAb)Z2kC9hJR(.f)q",
-                                                                                                                      "inputs": {
-                                                                                                                        "VALUE-0": {
-                                                                                                                          "block": {
-                                                                                                                            "type": "EventPlayer",
-                                                                                                                            "id": "p=1f,{pbL_oRX*uDy#_S"
-                                                                                                                          }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              },
+                                                                                              "next": {
+                                                                                                "block": {
+                                                                                                  "type": "If",
+                                                                                                  "id": "l%z=5uWd2m@Vo@Z.0f4D",
+                                                                                                  "extraState": {},
+                                                                                                  "inputs": {
+                                                                                                    "VALUE-0": {
+                                                                                                      "block": {
+                                                                                                        "type": "Not",
+                                                                                                        "id": "$B#6znkq;wp;ci81czNf",
+                                                                                                        "inputs": {
+                                                                                                          "VALUE-0": {
+                                                                                                            "block": {
+                                                                                                              "type": "GetVariable",
+                                                                                                              "id": "83/{MnyYEQoUy(M^lP2W",
+                                                                                                              "inputs": {
+                                                                                                                "VALUE-0": {
+                                                                                                                  "block": {
+                                                                                                                    "type": "variableReferenceBlock",
+                                                                                                                    "id": "8Xd*dEAiQhn=K%!`Ow?_",
+                                                                                                                    "extraState": {
+                                                                                                                      "isObjectVar": true
+                                                                                                                    },
+                                                                                                                    "fields": {
+                                                                                                                      "OBJECTTYPE": "Player",
+                                                                                                                      "VAR": {
+                                                                                                                        "id": "RtgD|X+%@!)n$MrP;5vL"
+                                                                                                                      }
+                                                                                                                    },
+                                                                                                                    "inputs": {
+                                                                                                                      "OBJECT": {
+                                                                                                                        "block": {
+                                                                                                                          "type": "EventPlayer",
+                                                                                                                          "id": "y+wO@=0;oy-/pvNf*TIo"
                                                                                                                         }
                                                                                                                       }
                                                                                                                     }
@@ -2428,13 +2947,124 @@
                                                                                                             }
                                                                                                           }
                                                                                                         }
-                                                                                                      },
-                                                                                                      "VALUE-2": {
-                                                                                                        "block": {
-                                                                                                          "type": "Number",
-                                                                                                          "id": "H@9r:xy(bjoiJIcAk3IG",
-                                                                                                          "fields": {
-                                                                                                            "NUM": 0
+                                                                                                      }
+                                                                                                    },
+                                                                                                    "DO": {
+                                                                                                      "block": {
+                                                                                                        "type": "subroutineInstanceBlock",
+                                                                                                        "id": "8sP4m+O0DeH]k?WHK4Oj",
+                                                                                                        "extraState": {
+                                                                                                          "subroutineName": "CheckBoundaries",
+                                                                                                          "parameters": [
+                                                                                                            {
+                                                                                                              "types": "Array",
+                                                                                                              "name": "Location"
+                                                                                                            }
+                                                                                                          ]
+                                                                                                        },
+                                                                                                        "fields": {
+                                                                                                          "SUBROUTINE_NAME": "CheckBoundaries"
+                                                                                                        },
+                                                                                                        "inputs": {
+                                                                                                          "PARAM-0": {
+                                                                                                            "block": {
+                                                                                                              "type": "GetVariable",
+                                                                                                              "id": "fXwVA)bhqG==XLNhxPjj",
+                                                                                                              "inputs": {
+                                                                                                                "VALUE-0": {
+                                                                                                                  "block": {
+                                                                                                                    "type": "variableReferenceBlock",
+                                                                                                                    "id": "e}j_zGf|8VF|-@u;(#0*",
+                                                                                                                    "extraState": {
+                                                                                                                      "isObjectVar": true
+                                                                                                                    },
+                                                                                                                    "fields": {
+                                                                                                                      "OBJECTTYPE": "TeamId",
+                                                                                                                      "VAR": {
+                                                                                                                        "id": "~!s}ovrs?jb7Yd/X[z2!"
+                                                                                                                      }
+                                                                                                                    },
+                                                                                                                    "inputs": {
+                                                                                                                      "OBJECT": {
+                                                                                                                        "block": {
+                                                                                                                          "type": "GetTeamId",
+                                                                                                                          "id": "N8U[%]Op|!:;|{_HhV(l",
+                                                                                                                          "inputs": {
+                                                                                                                            "VALUE-0": {
+                                                                                                                              "block": {
+                                                                                                                                "type": "EventPlayer",
+                                                                                                                                "id": ":b%V3_33|cMjvp^6p0W^"
+                                                                                                                              }
+                                                                                                                            }
+                                                                                                                          }
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        },
+                                                                                                        "next": {
+                                                                                                          "block": {
+                                                                                                            "type": "If",
+                                                                                                            "id": "/cX+vDlEl:C](w5zzk~g",
+                                                                                                            "extraState": {},
+                                                                                                            "inputs": {
+                                                                                                              "VALUE-0": {
+                                                                                                                "block": {
+                                                                                                                  "type": "Not",
+                                                                                                                  "id": "UPO;wG--jx?E|nEzl^n3",
+                                                                                                                  "inputs": {
+                                                                                                                    "VALUE-0": {
+                                                                                                                      "block": {
+                                                                                                                        "type": "GetVariable",
+                                                                                                                        "id": "XEe2Fmurk%P`_jp3HJ4$",
+                                                                                                                        "inputs": {
+                                                                                                                          "VALUE-0": {
+                                                                                                                            "block": {
+                                                                                                                              "type": "variableReferenceBlock",
+                                                                                                                              "id": "pfl*Ksr)lAH|TPdfcw}A",
+                                                                                                                              "extraState": {
+                                                                                                                                "isObjectVar": true
+                                                                                                                              },
+                                                                                                                              "fields": {
+                                                                                                                                "OBJECTTYPE": "Player",
+                                                                                                                                "VAR": {
+                                                                                                                                  "id": "RtgD|X+%@!)n$MrP;5vL"
+                                                                                                                                }
+                                                                                                                              },
+                                                                                                                              "inputs": {
+                                                                                                                                "OBJECT": {
+                                                                                                                                  "block": {
+                                                                                                                                    "type": "EventPlayer",
+                                                                                                                                    "id": "Q:0V@g|$h:Nkc:70[~hE"
+                                                                                                                                  }
+                                                                                                                                }
+                                                                                                                              }
+                                                                                                                            }
+                                                                                                                          }
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              },
+                                                                                                              "DO": {
+                                                                                                                "block": {
+                                                                                                                  "type": "subroutineInstanceBlock",
+                                                                                                                  "id": "Pat9BOT8%ef/.j%}L:;U",
+                                                                                                                  "extraState": {
+                                                                                                                    "subroutineName": "Teleport",
+                                                                                                                    "parameters": []
+                                                                                                                  },
+                                                                                                                  "fields": {
+                                                                                                                    "SUBROUTINE_NAME": "Teleport"
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
                                                                                                           }
                                                                                                         }
                                                                                                       }
@@ -3026,52 +3656,210 @@
                                                               "next": {
                                                                 "block": {
                                                                   "type": "ruleBlock",
-                                                                  "id": ";]qD3c?*zqHjuo]+N3[U",
+                                                                  "id": "9spr^~YP114_2UTu@m:*",
                                                                   "extraState": {
-                                                                    "isOngoingEvent": false
+                                                                    "isOngoingEvent": true
                                                                   },
                                                                   "fields": {
-                                                                    "NAME": "Stop Tracking Fuse",
-                                                                    "EVENTTYPE": "OnMCOMDefused"
+                                                                    "NAME": "Check Player Firing With Tracer Dart Gun",
+                                                                    "EVENTTYPE": "Ongoing",
+                                                                    "OBJECTTYPE": "Player"
                                                                   },
                                                                   "inputs": {
+                                                                    "CONDITIONS": {
+                                                                      "block": {
+                                                                        "type": "conditionBlock",
+                                                                        "id": "`Dkf}h+TMLG?aanz1[~Q",
+                                                                        "inputs": {
+                                                                          "CONDITION": {
+                                                                            "block": {
+                                                                              "type": "GetSoldierState",
+                                                                              "id": "N/6Z6,WI,~zgLC(cjIOC",
+                                                                              "inputs": {
+                                                                                "VALUE-0": {
+                                                                                  "block": {
+                                                                                    "type": "EventPlayer",
+                                                                                    "id": "!}m2UEG3qoQmE|6p3`9Z"
+                                                                                  }
+                                                                                },
+                                                                                "VALUE-1": {
+                                                                                  "block": {
+                                                                                    "type": "SoldierStateBoolItem",
+                                                                                    "id": "UmV$-.y;dXaCtB!G;Q|*",
+                                                                                    "fields": {
+                                                                                      "VALUE-0": "SoldierStateBool",
+                                                                                      "VALUE-1": "IsAlive"
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        },
+                                                                        "next": {
+                                                                          "block": {
+                                                                            "type": "conditionBlock",
+                                                                            "id": "ot{3|),4]NUC?]`@dyB%",
+                                                                            "inputs": {
+                                                                              "CONDITION": {
+                                                                                "block": {
+                                                                                  "type": "IsInventorySlotActive",
+                                                                                  "id": "!+[Y|~@e),.5E?bFhF2W",
+                                                                                  "inputs": {
+                                                                                    "VALUE-0": {
+                                                                                      "block": {
+                                                                                        "type": "EventPlayer",
+                                                                                        "id": "T4n^qVGg;X!uPtS(Cd4b"
+                                                                                      }
+                                                                                    },
+                                                                                    "VALUE-1": {
+                                                                                      "block": {
+                                                                                        "type": "InventorySlotsItem",
+                                                                                        "id": "yz`I#|O]y$If6bq?gD;#",
+                                                                                        "fields": {
+                                                                                          "VALUE-0": "InventorySlots",
+                                                                                          "VALUE-1": "ClassGadget"
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            },
+                                                                            "next": {
+                                                                              "block": {
+                                                                                "type": "conditionBlock",
+                                                                                "id": "H@ZcTz?yje/mZPosidzW",
+                                                                                "inputs": {
+                                                                                  "CONDITION": {
+                                                                                    "block": {
+                                                                                      "type": "HasInventory",
+                                                                                      "id": "?iqU8/hG);Qu1O@[(ky=",
+                                                                                      "inputs": {
+                                                                                        "VALUE-0": {
+                                                                                          "block": {
+                                                                                            "type": "EventPlayer",
+                                                                                            "id": "5,y1{,:I@g.k3edQ]SyR"
+                                                                                          }
+                                                                                        },
+                                                                                        "VALUE-1": {
+                                                                                          "block": {
+                                                                                            "type": "ClassGadgetsItem",
+                                                                                            "id": "HG[0ZRica$KEfWR8v~y6",
+                                                                                            "fields": {
+                                                                                              "VALUE-0": "ClassGadgetsKingston",
+                                                                                              "VALUE-1": "SpawnBeacon"
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                },
+                                                                                "next": {
+                                                                                  "block": {
+                                                                                    "type": "conditionBlock",
+                                                                                    "id": "?iYn0*,}}n:@TQQs3fbB",
+                                                                                    "inputs": {
+                                                                                      "CONDITION": {
+                                                                                        "block": {
+                                                                                          "type": "GetSoldierState",
+                                                                                          "id": "?C^.S)).;vzEd_@7#K5[",
+                                                                                          "inputs": {
+                                                                                            "VALUE-0": {
+                                                                                              "block": {
+                                                                                                "type": "EventPlayer",
+                                                                                                "id": "Rcax#L.tjDKO[v{2V*[9"
+                                                                                              }
+                                                                                            },
+                                                                                            "VALUE-1": {
+                                                                                              "block": {
+                                                                                                "type": "SoldierStateBoolItem",
+                                                                                                "id": "49xC][j:)P_w7%s/(EIW",
+                                                                                                "fields": {
+                                                                                                  "VALUE-0": "SoldierStateBool",
+                                                                                                  "VALUE-1": "IsFiring"
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    },
                                                                     "ACTIONS": {
                                                                       "block": {
-                                                                        "type": "If",
-                                                                        "id": "2_(/SJL$TI!/HU*2ze=Z",
-                                                                        "extraState": {
-                                                                          "elseif": 0,
-                                                                          "else": 1
-                                                                        },
+                                                                        "type": "SetVariable",
+                                                                        "id": "4mYr?Quko|{_!(k/J$pO",
                                                                         "inputs": {
                                                                           "VALUE-0": {
                                                                             "block": {
-                                                                              "type": "Equals",
-                                                                              "id": "XQx-hd~riC*:1%chEo}W",
+                                                                              "type": "variableReferenceBlock",
+                                                                              "id": "~/kybM={14|f}z]E#esz",
+                                                                              "extraState": {
+                                                                                "isObjectVar": false
+                                                                              },
+                                                                              "fields": {
+                                                                                "OBJECTTYPE": "Global",
+                                                                                "VAR": {
+                                                                                  "id": "w_^Ni+6S]Sp8=OOP4#,a"
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          "VALUE-1": {
+                                                                            "block": {
+                                                                              "type": "AppendToArray",
+                                                                              "id": "vAOQibg#.(3yfm3JrOZK",
                                                                               "inputs": {
                                                                                 "VALUE-0": {
                                                                                   "block": {
-                                                                                    "type": "EventMCOM",
-                                                                                    "id": "0JG];:Rq=LF$X/9;7zpM"
-                                                                                  }
-                                                                                },
-                                                                                "VALUE-1": {
-                                                                                  "block": {
                                                                                     "type": "GetVariable",
-                                                                                    "id": "~|9!HR?)E-Ljd*j=E(DX",
+                                                                                    "id": "H7QWgcphB|r4.LdoB`2g",
                                                                                     "inputs": {
                                                                                       "VALUE-0": {
                                                                                         "block": {
                                                                                           "type": "variableReferenceBlock",
-                                                                                          "id": ".8okNMbFM;:UQMNyc/6P",
+                                                                                          "id": "S1V?x8?RU$#oWLFxQ$,F",
                                                                                           "extraState": {
                                                                                             "isObjectVar": false
                                                                                           },
                                                                                           "fields": {
                                                                                             "OBJECTTYPE": "Global",
                                                                                             "VAR": {
-                                                                                              "id": "W?M=066mWT~Tf=[ON!`$"
+                                                                                              "id": "w_^Ni+6S]Sp8=OOP4#,a"
                                                                                             }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                },
+                                                                                "VALUE-1": {
+                                                                                  "block": {
+                                                                                    "type": "GetSoldierState",
+                                                                                    "id": "5NN%l8ydyDY:{nP(h8Zk",
+                                                                                    "inputs": {
+                                                                                      "VALUE-0": {
+                                                                                        "block": {
+                                                                                          "type": "EventPlayer",
+                                                                                          "id": "x{F?Zm`-.Wy;^6Ibf2`a"
+                                                                                        }
+                                                                                      },
+                                                                                      "VALUE-1": {
+                                                                                        "block": {
+                                                                                          "type": "SoldierStateVectorItem",
+                                                                                          "id": "Re)Gf0tFC(Ua`iA=;{b.",
+                                                                                          "fields": {
+                                                                                            "VALUE-0": "SoldierStateVector",
+                                                                                            "VALUE-1": "GetPosition"
                                                                                           }
                                                                                         }
                                                                                       }
@@ -3080,105 +3868,139 @@
                                                                                 }
                                                                               }
                                                                             }
-                                                                          },
-                                                                          "DO": {
-                                                                            "block": {
-                                                                              "type": "SetMCOMFuseTime",
-                                                                              "id": "7GGSqpCjJh:h~e{5^_0[",
-                                                                              "inputs": {
-                                                                                "VALUE-0": {
-                                                                                  "block": {
-                                                                                    "type": "GetVariable",
-                                                                                    "id": "dq@AwLvo{JGG2UR}b]GA",
-                                                                                    "inputs": {
-                                                                                      "VALUE-0": {
-                                                                                        "block": {
-                                                                                          "type": "variableReferenceBlock",
-                                                                                          "id": "f~Rf{w-A+RJzeWiq*Tu)",
-                                                                                          "extraState": {
-                                                                                            "isObjectVar": false
-                                                                                          },
-                                                                                          "fields": {
-                                                                                            "OBJECTTYPE": "Global",
-                                                                                            "VAR": {
-                                                                                              "id": "W?M=066mWT~Tf=[ON!`$"
+                                                                          }
+                                                                        },
+                                                                        "next": {
+                                                                          "block": {
+                                                                            "type": "If",
+                                                                            "id": "Oax+pH3Mwqj.IJnvo)8C",
+                                                                            "extraState": {},
+                                                                            "inputs": {
+                                                                              "VALUE-0": {
+                                                                                "block": {
+                                                                                  "type": "GreaterThan",
+                                                                                  "id": "0Dfs*eLkz8(y4%PQqbgw",
+                                                                                  "inputs": {
+                                                                                    "VALUE-0": {
+                                                                                      "block": {
+                                                                                        "type": "CountOf",
+                                                                                        "id": "bfK-R_6w39cx=avKGwC,",
+                                                                                        "inputs": {
+                                                                                          "VALUE-0": {
+                                                                                            "block": {
+                                                                                              "type": "GetVariable",
+                                                                                              "id": "R:(x3}xWw^`woTj;qpK,",
+                                                                                              "inputs": {
+                                                                                                "VALUE-0": {
+                                                                                                  "block": {
+                                                                                                    "type": "variableReferenceBlock",
+                                                                                                    "id": "i5{cM@_A~bGNWInGIL{e",
+                                                                                                    "extraState": {
+                                                                                                      "isObjectVar": false
+                                                                                                    },
+                                                                                                    "fields": {
+                                                                                                      "OBJECTTYPE": "Global",
+                                                                                                      "VAR": {
+                                                                                                        "id": "w_^Ni+6S]Sp8=OOP4#,a"
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
                                                                                             }
                                                                                           }
                                                                                         }
                                                                                       }
-                                                                                    }
-                                                                                  }
-                                                                                },
-                                                                                "VALUE-1": {
-                                                                                  "block": {
-                                                                                    "type": "GetVariable",
-                                                                                    "id": "+/=2lxrmaEv-ygDTcl@~",
-                                                                                    "inputs": {
-                                                                                      "VALUE-0": {
-                                                                                        "block": {
-                                                                                          "type": "variableReferenceBlock",
-                                                                                          "id": "YFI2Vu3YYleU]`u[zfAs",
-                                                                                          "extraState": {
-                                                                                            "isObjectVar": false
-                                                                                          },
-                                                                                          "fields": {
-                                                                                            "OBJECTTYPE": "Global",
-                                                                                            "VAR": {
-                                                                                              "id": "WmLAWml]VVTbibIk]jA/"
-                                                                                            }
-                                                                                          }
+                                                                                    },
+                                                                                    "VALUE-1": {
+                                                                                      "block": {
+                                                                                        "type": "Number",
+                                                                                        "id": "eL[XBu)I2B^6^REAO*#t",
+                                                                                        "fields": {
+                                                                                          "NUM": 20
                                                                                         }
                                                                                       }
                                                                                     }
                                                                                   }
                                                                                 }
-                                                                              }
-                                                                            }
-                                                                          },
-                                                                          "ELSE": {
-                                                                            "block": {
-                                                                              "type": "SetMCOMFuseTime",
-                                                                              "id": "Ff^;*H;vNg99A|:3jv2}",
-                                                                              "inputs": {
-                                                                                "VALUE-0": {
-                                                                                  "block": {
-                                                                                    "type": "GetVariable",
-                                                                                    "id": "dNM%r;k?;c;$?q[ki*V@",
-                                                                                    "inputs": {
-                                                                                      "VALUE-0": {
-                                                                                        "block": {
-                                                                                          "type": "variableReferenceBlock",
-                                                                                          "id": "[-LnGPd|y5K:,E[8a1+U",
-                                                                                          "extraState": {
-                                                                                            "isObjectVar": false
-                                                                                          },
-                                                                                          "fields": {
-                                                                                            "OBJECTTYPE": "Global",
-                                                                                            "VAR": {
-                                                                                              "id": "ZCBg+S5Y0?xD[@GpnRJ."
-                                                                                            }
+                                                                              },
+                                                                              "DO": {
+                                                                                "block": {
+                                                                                  "type": "SetVariable",
+                                                                                  "id": "zx@2i0!#Z`11;b|rgMT6",
+                                                                                  "inputs": {
+                                                                                    "VALUE-0": {
+                                                                                      "block": {
+                                                                                        "type": "variableReferenceBlock",
+                                                                                        "id": "E,MB1I/o(X!+)/;FhKvC",
+                                                                                        "extraState": {
+                                                                                          "isObjectVar": false
+                                                                                        },
+                                                                                        "fields": {
+                                                                                          "OBJECTTYPE": "Global",
+                                                                                          "VAR": {
+                                                                                            "id": "w_^Ni+6S]Sp8=OOP4#,a"
                                                                                           }
                                                                                         }
                                                                                       }
-                                                                                    }
-                                                                                  }
-                                                                                },
-                                                                                "VALUE-1": {
-                                                                                  "block": {
-                                                                                    "type": "GetVariable",
-                                                                                    "id": "Tdhl:8w[XZFHjN5E0e!-",
-                                                                                    "inputs": {
-                                                                                      "VALUE-0": {
-                                                                                        "block": {
-                                                                                          "type": "variableReferenceBlock",
-                                                                                          "id": "pUz=qU2i*iGb^1$//Py/",
-                                                                                          "extraState": {
-                                                                                            "isObjectVar": false
+                                                                                    },
+                                                                                    "VALUE-1": {
+                                                                                      "block": {
+                                                                                        "type": "RemoveFromArray",
+                                                                                        "id": "7fAeo5^avb+9g!~AZ:e1",
+                                                                                        "inputs": {
+                                                                                          "VALUE-0": {
+                                                                                            "block": {
+                                                                                              "type": "GetVariable",
+                                                                                              "id": "xOaN~/`k09-9C)aA[hq5",
+                                                                                              "inputs": {
+                                                                                                "VALUE-0": {
+                                                                                                  "block": {
+                                                                                                    "type": "variableReferenceBlock",
+                                                                                                    "id": "-.BrVd*K49BLwP[)q.sg",
+                                                                                                    "extraState": {
+                                                                                                      "isObjectVar": false
+                                                                                                    },
+                                                                                                    "fields": {
+                                                                                                      "OBJECTTYPE": "Global",
+                                                                                                      "VAR": {
+                                                                                                        "id": "w_^Ni+6S]Sp8=OOP4#,a"
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
                                                                                           },
-                                                                                          "fields": {
-                                                                                            "OBJECTTYPE": "Global",
-                                                                                            "VAR": {
-                                                                                              "id": "c[z#A9bNIqE/7|%xj;-G"
+                                                                                          "VALUE-1": {
+                                                                                            "block": {
+                                                                                              "type": "FirstOf",
+                                                                                              "id": "o##N3ujCr@G]W4U;6n!1",
+                                                                                              "inputs": {
+                                                                                                "VALUE-0": {
+                                                                                                  "block": {
+                                                                                                    "type": "GetVariable",
+                                                                                                    "id": ":]6z``z?1_n]n{{F$fYi",
+                                                                                                    "inputs": {
+                                                                                                      "VALUE-0": {
+                                                                                                        "block": {
+                                                                                                          "type": "variableReferenceBlock",
+                                                                                                          "id": "^yWiECSZowNzFa73%6(z",
+                                                                                                          "extraState": {
+                                                                                                            "isObjectVar": false
+                                                                                                          },
+                                                                                                          "fields": {
+                                                                                                            "OBJECTTYPE": "Global",
+                                                                                                            "VAR": {
+                                                                                                              "id": "w_^Ni+6S]Sp8=OOP4#,a"
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
                                                                                             }
                                                                                           }
                                                                                         }
@@ -3196,19 +4018,19 @@
                                                                   "next": {
                                                                     "block": {
                                                                       "type": "ruleBlock",
-                                                                      "id": "tSMy,ctWSdNm*N@E*%ko",
+                                                                      "id": ";]qD3c?*zqHjuo]+N3[U",
                                                                       "extraState": {
                                                                         "isOngoingEvent": false
                                                                       },
                                                                       "fields": {
-                                                                        "NAME": "MCOM Destroyed",
-                                                                        "EVENTTYPE": "OnMCOMDestroyed"
+                                                                        "NAME": "Stop Tracking Fuse",
+                                                                        "EVENTTYPE": "OnMCOMDefused"
                                                                       },
                                                                       "inputs": {
                                                                         "ACTIONS": {
                                                                           "block": {
                                                                             "type": "If",
-                                                                            "id": "^J#@bTLLdVxW~GBL(}4A",
+                                                                            "id": "2_(/SJL$TI!/HU*2ze=Z",
                                                                             "extraState": {
                                                                               "elseif": 0,
                                                                               "else": 1
@@ -3217,23 +4039,23 @@
                                                                               "VALUE-0": {
                                                                                 "block": {
                                                                                   "type": "Equals",
-                                                                                  "id": "2R#W3rFUXm,H+|^m]{t|",
+                                                                                  "id": "XQx-hd~riC*:1%chEo}W",
                                                                                   "inputs": {
                                                                                     "VALUE-0": {
                                                                                       "block": {
                                                                                         "type": "EventMCOM",
-                                                                                        "id": "s_r5P!qwCr!Xcb4#54=q"
+                                                                                        "id": "0JG];:Rq=LF$X/9;7zpM"
                                                                                       }
                                                                                     },
                                                                                     "VALUE-1": {
                                                                                       "block": {
                                                                                         "type": "GetVariable",
-                                                                                        "id": ";Iv)_XHu;Y=um{=S;QLq",
+                                                                                        "id": "~|9!HR?)E-Ljd*j=E(DX",
                                                                                         "inputs": {
                                                                                           "VALUE-0": {
                                                                                             "block": {
                                                                                               "type": "variableReferenceBlock",
-                                                                                              "id": "|^U6*o9,L]eNjtmwo#jT",
+                                                                                              "id": ".8okNMbFM;:UQMNyc/6P",
                                                                                               "extraState": {
                                                                                                 "isObjectVar": false
                                                                                               },
@@ -3253,21 +4075,26 @@
                                                                               },
                                                                               "DO": {
                                                                                 "block": {
-                                                                                  "type": "EnableObjective",
-                                                                                  "id": "u!50Q#45N9L(oO]wrc,#",
+                                                                                  "type": "SetMCOMFuseTime",
+                                                                                  "id": "7GGSqpCjJh:h~e{5^_0[",
                                                                                   "inputs": {
                                                                                     "VALUE-0": {
                                                                                       "block": {
-                                                                                        "type": "GetCapturePoint",
-                                                                                        "id": "D)abzk%JJ2k%f3~dA10:",
+                                                                                        "type": "GetVariable",
+                                                                                        "id": "dq@AwLvo{JGG2UR}b]GA",
                                                                                         "inputs": {
                                                                                           "VALUE-0": {
                                                                                             "block": {
-                                                                                              "type": "MCOMsItem",
-                                                                                              "id": "kv]}gwq/}#QEvW|FhMr(",
+                                                                                              "type": "variableReferenceBlock",
+                                                                                              "id": "f~Rf{w-A+RJzeWiq*Tu)",
+                                                                                              "extraState": {
+                                                                                                "isObjectVar": false
+                                                                                              },
                                                                                               "fields": {
-                                                                                                "VALUE-0": "MCOMs",
-                                                                                                "VALUE-1": "E"
+                                                                                                "OBJECTTYPE": "Global",
+                                                                                                "VAR": {
+                                                                                                  "id": "W?M=066mWT~Tf=[ON!`$"
+                                                                                                }
                                                                                               }
                                                                                             }
                                                                                           }
@@ -3276,10 +4103,24 @@
                                                                                     },
                                                                                     "VALUE-1": {
                                                                                       "block": {
-                                                                                        "type": "Boolean",
-                                                                                        "id": "%#E9A^H#AfSvzFe;NgJY",
-                                                                                        "fields": {
-                                                                                          "BOOL": "FALSE"
+                                                                                        "type": "GetVariable",
+                                                                                        "id": "+/=2lxrmaEv-ygDTcl@~",
+                                                                                        "inputs": {
+                                                                                          "VALUE-0": {
+                                                                                            "block": {
+                                                                                              "type": "variableReferenceBlock",
+                                                                                              "id": "YFI2Vu3YYleU]`u[zfAs",
+                                                                                              "extraState": {
+                                                                                                "isObjectVar": false
+                                                                                              },
+                                                                                              "fields": {
+                                                                                                "OBJECTTYPE": "Global",
+                                                                                                "VAR": {
+                                                                                                  "id": "WmLAWml]VVTbibIk]jA/"
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
                                                                                         }
                                                                                       }
                                                                                     }
@@ -3288,21 +4129,26 @@
                                                                               },
                                                                               "ELSE": {
                                                                                 "block": {
-                                                                                  "type": "EnableObjective",
-                                                                                  "id": "^6G~dW4-:|G06DE_zv[U",
+                                                                                  "type": "SetMCOMFuseTime",
+                                                                                  "id": "Ff^;*H;vNg99A|:3jv2}",
                                                                                   "inputs": {
                                                                                     "VALUE-0": {
                                                                                       "block": {
-                                                                                        "type": "GetCapturePoint",
-                                                                                        "id": "_7*:#ek!i]sv^mAafp[-",
+                                                                                        "type": "GetVariable",
+                                                                                        "id": "dNM%r;k?;c;$?q[ki*V@",
                                                                                         "inputs": {
                                                                                           "VALUE-0": {
                                                                                             "block": {
-                                                                                              "type": "MCOMsItem",
-                                                                                              "id": "z|Yp/LgXOHPA0a]$^Y0$",
+                                                                                              "type": "variableReferenceBlock",
+                                                                                              "id": "[-LnGPd|y5K:,E[8a1+U",
+                                                                                              "extraState": {
+                                                                                                "isObjectVar": false
+                                                                                              },
                                                                                               "fields": {
-                                                                                                "VALUE-0": "MCOMs",
-                                                                                                "VALUE-1": "F"
+                                                                                                "OBJECTTYPE": "Global",
+                                                                                                "VAR": {
+                                                                                                  "id": "ZCBg+S5Y0?xD[@GpnRJ."
+                                                                                                }
                                                                                               }
                                                                                             }
                                                                                           }
@@ -3311,63 +4157,109 @@
                                                                                     },
                                                                                     "VALUE-1": {
                                                                                       "block": {
-                                                                                        "type": "Boolean",
-                                                                                        "id": "n5(9H*$a%~~%B*T#=w1@",
-                                                                                        "fields": {
-                                                                                          "BOOL": "FALSE"
+                                                                                        "type": "GetVariable",
+                                                                                        "id": "Tdhl:8w[XZFHjN5E0e!-",
+                                                                                        "inputs": {
+                                                                                          "VALUE-0": {
+                                                                                            "block": {
+                                                                                              "type": "variableReferenceBlock",
+                                                                                              "id": "pUz=qU2i*iGb^1$//Py/",
+                                                                                              "extraState": {
+                                                                                                "isObjectVar": false
+                                                                                              },
+                                                                                              "fields": {
+                                                                                                "OBJECTTYPE": "Global",
+                                                                                                "VAR": {
+                                                                                                  "id": "c[z#A9bNIqE/7|%xj;-G"
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
                                                                                         }
                                                                                       }
                                                                                     }
                                                                                   }
                                                                                 }
                                                                               }
-                                                                            },
-                                                                            "next": {
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      },
+                                                                      "next": {
+                                                                        "block": {
+                                                                          "type": "ruleBlock",
+                                                                          "id": "tSMy,ctWSdNm*N@E*%ko",
+                                                                          "extraState": {
+                                                                            "isOngoingEvent": false
+                                                                          },
+                                                                          "fields": {
+                                                                            "NAME": "MCOM Destroyed",
+                                                                            "EVENTTYPE": "OnMCOMDestroyed"
+                                                                          },
+                                                                          "inputs": {
+                                                                            "ACTIONS": {
                                                                               "block": {
-                                                                                "type": "SetGamemodeScore",
-                                                                                "id": "i18g1ZmTmZ4!|IlPUA9`",
+                                                                                "type": "If",
+                                                                                "id": "^J#@bTLLdVxW~GBL(}4A",
+                                                                                "extraState": {
+                                                                                  "elseif": 0,
+                                                                                  "else": 1
+                                                                                },
                                                                                 "inputs": {
                                                                                   "VALUE-0": {
                                                                                     "block": {
-                                                                                      "type": "GetTeamId",
-                                                                                      "id": "sLrkQ|XXD9@fE;ek`{CF",
+                                                                                      "type": "Equals",
+                                                                                      "id": "2R#W3rFUXm,H+|^m]{t|",
                                                                                       "inputs": {
                                                                                         "VALUE-0": {
                                                                                           "block": {
-                                                                                            "type": "Number",
-                                                                                            "id": "d1`~f2X)Gd#%(gxxpq1!",
-                                                                                            "fields": {
-                                                                                              "NUM": 2
+                                                                                            "type": "EventMCOM",
+                                                                                            "id": "s_r5P!qwCr!Xcb4#54=q"
+                                                                                          }
+                                                                                        },
+                                                                                        "VALUE-1": {
+                                                                                          "block": {
+                                                                                            "type": "GetVariable",
+                                                                                            "id": ";Iv)_XHu;Y=um{=S;QLq",
+                                                                                            "inputs": {
+                                                                                              "VALUE-0": {
+                                                                                                "block": {
+                                                                                                  "type": "variableReferenceBlock",
+                                                                                                  "id": "|^U6*o9,L]eNjtmwo#jT",
+                                                                                                  "extraState": {
+                                                                                                    "isObjectVar": false
+                                                                                                  },
+                                                                                                  "fields": {
+                                                                                                    "OBJECTTYPE": "Global",
+                                                                                                    "VAR": {
+                                                                                                      "id": "W?M=066mWT~Tf=[ON!`$"
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
                                                                                             }
                                                                                           }
                                                                                         }
                                                                                       }
                                                                                     }
                                                                                   },
-                                                                                  "VALUE-1": {
+                                                                                  "DO": {
                                                                                     "block": {
-                                                                                      "type": "Subtract",
-                                                                                      "id": "hk5qsrqF?:1rB#:I|9hr",
+                                                                                      "type": "EnableObjective",
+                                                                                      "id": "u!50Q#45N9L(oO]wrc,#",
                                                                                       "inputs": {
                                                                                         "VALUE-0": {
                                                                                           "block": {
-                                                                                            "type": "GetGamemodeScore",
-                                                                                            "id": "}-cKcshyk@h|0~*AjskS",
+                                                                                            "type": "GetCapturePoint",
+                                                                                            "id": "D)abzk%JJ2k%f3~dA10:",
                                                                                             "inputs": {
                                                                                               "VALUE-0": {
                                                                                                 "block": {
-                                                                                                  "type": "GetTeamId",
-                                                                                                  "id": "g`DDYD|Qu4%Lo[y%$OuH",
-                                                                                                  "inputs": {
-                                                                                                    "VALUE-0": {
-                                                                                                      "block": {
-                                                                                                        "type": "Number",
-                                                                                                        "id": "s;7s;fP[t1xByc!}nMtn",
-                                                                                                        "fields": {
-                                                                                                          "NUM": 2
-                                                                                                        }
-                                                                                                      }
-                                                                                                    }
+                                                                                                  "type": "MCOMsItem",
+                                                                                                  "id": "kv]}gwq/}#QEvW|FhMr(",
+                                                                                                  "fields": {
+                                                                                                    "VALUE-0": "MCOMs",
+                                                                                                    "VALUE-1": "E"
                                                                                                   }
                                                                                                 }
                                                                                               }
@@ -3376,10 +4268,45 @@
                                                                                         },
                                                                                         "VALUE-1": {
                                                                                           "block": {
-                                                                                            "type": "Number",
-                                                                                            "id": "T#Tr^e~qA_+I_MGy8]OC",
+                                                                                            "type": "Boolean",
+                                                                                            "id": "%#E9A^H#AfSvzFe;NgJY",
                                                                                             "fields": {
-                                                                                              "NUM": 1
+                                                                                              "BOOL": "FALSE"
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  },
+                                                                                  "ELSE": {
+                                                                                    "block": {
+                                                                                      "type": "EnableObjective",
+                                                                                      "id": "^6G~dW4-:|G06DE_zv[U",
+                                                                                      "inputs": {
+                                                                                        "VALUE-0": {
+                                                                                          "block": {
+                                                                                            "type": "GetCapturePoint",
+                                                                                            "id": "_7*:#ek!i]sv^mAafp[-",
+                                                                                            "inputs": {
+                                                                                              "VALUE-0": {
+                                                                                                "block": {
+                                                                                                  "type": "MCOMsItem",
+                                                                                                  "id": "z|Yp/LgXOHPA0a]$^Y0$",
+                                                                                                  "fields": {
+                                                                                                    "VALUE-0": "MCOMs",
+                                                                                                    "VALUE-1": "F"
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        },
+                                                                                        "VALUE-1": {
+                                                                                          "block": {
+                                                                                            "type": "Boolean",
+                                                                                            "id": "n5(9H*$a%~~%B*T#=w1@",
+                                                                                            "fields": {
+                                                                                              "BOOL": "FALSE"
                                                                                             }
                                                                                           }
                                                                                         }
@@ -3389,47 +4316,18 @@
                                                                                 },
                                                                                 "next": {
                                                                                   "block": {
-                                                                                    "type": "If",
-                                                                                    "id": "]{4?#wcGXN5VY4%LvYc2",
-                                                                                    "extraState": {
-                                                                                      "elseif": 1,
-                                                                                      "else": 1
-                                                                                    },
+                                                                                    "type": "SetGamemodeScore",
+                                                                                    "id": "i18g1ZmTmZ4!|IlPUA9`",
                                                                                     "inputs": {
                                                                                       "VALUE-0": {
                                                                                         "block": {
-                                                                                          "type": "Equals",
-                                                                                          "id": "gZ;711z,J~-kymN]KB07",
+                                                                                          "type": "GetTeamId",
+                                                                                          "id": "sLrkQ|XXD9@fE;ek`{CF",
                                                                                           "inputs": {
                                                                                             "VALUE-0": {
                                                                                               "block": {
-                                                                                                "type": "GetGamemodeScore",
-                                                                                                "id": "}sMJMZwvxi7#DOnj9I{K",
-                                                                                                "inputs": {
-                                                                                                  "VALUE-0": {
-                                                                                                    "block": {
-                                                                                                      "type": "GetTeamId",
-                                                                                                      "id": "dn_0HU-SjWX/(yA:JDM3",
-                                                                                                      "inputs": {
-                                                                                                        "VALUE-0": {
-                                                                                                          "block": {
-                                                                                                            "type": "Number",
-                                                                                                            "id": "D#5HvhOS{3uUkkCGn_(z",
-                                                                                                            "fields": {
-                                                                                                              "NUM": 2
-                                                                                                            }
-                                                                                                          }
-                                                                                                        }
-                                                                                                      }
-                                                                                                    }
-                                                                                                  }
-                                                                                                }
-                                                                                              }
-                                                                                            },
-                                                                                            "VALUE-1": {
-                                                                                              "block": {
                                                                                                 "type": "Number",
-                                                                                                "id": "(V82MEHInu#IfglzI5Et",
+                                                                                                "id": "d1`~f2X)Gd#%(gxxpq1!",
                                                                                                 "fields": {
                                                                                                   "NUM": 2
                                                                                                 }
@@ -3438,298 +4336,25 @@
                                                                                           }
                                                                                         }
                                                                                       },
-                                                                                      "DO": {
+                                                                                      "VALUE-1": {
                                                                                         "block": {
-                                                                                          "type": "SetVariable",
-                                                                                          "id": "I(|-d%N@nDD1IZ$Oi%C5",
-                                                                                          "inputs": {
-                                                                                            "VALUE-0": {
-                                                                                              "block": {
-                                                                                                "type": "variableReferenceBlock",
-                                                                                                "id": "=XPP;dY;21NYC:i/usIi",
-                                                                                                "extraState": {
-                                                                                                  "isObjectVar": false
-                                                                                                },
-                                                                                                "fields": {
-                                                                                                  "OBJECTTYPE": "Global",
-                                                                                                  "VAR": {
-                                                                                                    "id": "=8OY*aWMGF4.T^k6uLUl"
-                                                                                                  }
-                                                                                                }
-                                                                                              }
-                                                                                            },
-                                                                                            "VALUE-1": {
-                                                                                              "block": {
-                                                                                                "type": "GetVariable",
-                                                                                                "id": "8WvKniysVuj=4|3**-w/",
-                                                                                                "inputs": {
-                                                                                                  "VALUE-0": {
-                                                                                                    "block": {
-                                                                                                      "type": "variableReferenceBlock",
-                                                                                                      "id": "`_~=|Vr6K#Qnywb*rD3w",
-                                                                                                      "extraState": {
-                                                                                                        "isObjectVar": false
-                                                                                                      },
-                                                                                                      "fields": {
-                                                                                                        "OBJECTTYPE": "Global",
-                                                                                                        "VAR": {
-                                                                                                          "id": "Xr?o?acUGgeUMdeaBx?x"
-                                                                                                        }
-                                                                                                      }
-                                                                                                    }
-                                                                                                  }
-                                                                                                }
-                                                                                              }
-                                                                                            }
-                                                                                          },
-                                                                                          "next": {
-                                                                                            "block": {
-                                                                                              "type": "Wait",
-                                                                                              "id": "{r59qWj9?k3BApT/!BII",
-                                                                                              "inputs": {
-                                                                                                "VALUE-0": {
-                                                                                                  "block": {
-                                                                                                    "type": "Number",
-                                                                                                    "id": "}zrwF4|Y7T1D:Js[%;1#",
-                                                                                                    "fields": {
-                                                                                                      "NUM": 3
-                                                                                                    }
-                                                                                                  }
-                                                                                                }
-                                                                                              },
-                                                                                              "next": {
-                                                                                                "block": {
-                                                                                                  "type": "UnspawnAllPlayers",
-                                                                                                  "id": "!3%10T|*H;D!|=}2U0hj",
-                                                                                                  "next": {
-                                                                                                    "block": {
-                                                                                                      "type": "EnablePlayerSpawning",
-                                                                                                      "id": "IA:T8=0iS1;Fuyn-2j9%",
-                                                                                                      "inputs": {
-                                                                                                        "VALUE-0": {
-                                                                                                          "block": {
-                                                                                                            "type": "Boolean",
-                                                                                                            "id": "=]TgqI:US3;biMT#R-j3",
-                                                                                                            "fields": {
-                                                                                                              "BOOL": "FALSE"
-                                                                                                            }
-                                                                                                          }
-                                                                                                        }
-                                                                                                      },
-                                                                                                      "next": {
-                                                                                                        "block": {
-                                                                                                          "type": "SetVariable",
-                                                                                                          "id": "N,P!]CIrH.jdN++YQHuK",
-                                                                                                          "inputs": {
-                                                                                                            "VALUE-0": {
-                                                                                                              "block": {
-                                                                                                                "type": "variableReferenceBlock",
-                                                                                                                "id": "fJ4LS,O2_]@U@v.6f}AE",
-                                                                                                                "extraState": {
-                                                                                                                  "isObjectVar": false
-                                                                                                                },
-                                                                                                                "fields": {
-                                                                                                                  "OBJECTTYPE": "Global",
-                                                                                                                  "VAR": {
-                                                                                                                    "id": ";2]y+lLHsxSWFYjcQjhk"
-                                                                                                                  }
-                                                                                                                }
-                                                                                                              }
-                                                                                                            },
-                                                                                                            "VALUE-1": {
-                                                                                                              "block": {
-                                                                                                                "type": "Number",
-                                                                                                                "id": "?0XLKZ*,)4#es`-W,|WC",
-                                                                                                                "fields": {
-                                                                                                                  "NUM": 1
-                                                                                                                }
-                                                                                                              }
-                                                                                                            }
-                                                                                                          },
-                                                                                                          "next": {
-                                                                                                            "block": {
-                                                                                                              "type": "subroutineInstanceBlock",
-                                                                                                              "id": "j8vIyg^xQjp.CvgUOX(=",
-                                                                                                              "extraState": {
-                                                                                                                "subroutineName": "MapDetect",
-                                                                                                                "parameters": []
-                                                                                                              },
-                                                                                                              "fields": {
-                                                                                                                "SUBROUTINE_NAME": "MapDetect"
-                                                                                                              },
-                                                                                                              "next": {
-                                                                                                                "block": {
-                                                                                                                  "type": "SetVariable",
-                                                                                                                  "id": "HjVx4N0;`4vbblr-#VV@",
-                                                                                                                  "inputs": {
-                                                                                                                    "VALUE-0": {
-                                                                                                                      "block": {
-                                                                                                                        "type": "variableReferenceBlock",
-                                                                                                                        "id": "j10m_8gXSQG7bW{]Ao7j",
-                                                                                                                        "extraState": {
-                                                                                                                          "isObjectVar": false
-                                                                                                                        },
-                                                                                                                        "fields": {
-                                                                                                                          "OBJECTTYPE": "Global",
-                                                                                                                          "VAR": {
-                                                                                                                            "id": "W?M=066mWT~Tf=[ON!`$"
-                                                                                                                          }
-                                                                                                                        }
-                                                                                                                      }
-                                                                                                                    },
-                                                                                                                    "VALUE-1": {
-                                                                                                                      "block": {
-                                                                                                                        "type": "GetCapturePoint",
-                                                                                                                        "id": "Q@,mF-V=zYJ:{_0%$kM-",
-                                                                                                                        "inputs": {
-                                                                                                                          "VALUE-0": {
-                                                                                                                            "block": {
-                                                                                                                              "type": "MCOMsItem",
-                                                                                                                              "id": "z+jum4dO5r[t$[;mRpP}",
-                                                                                                                              "fields": {
-                                                                                                                                "VALUE-0": "MCOMs",
-                                                                                                                                "VALUE-1": "C"
-                                                                                                                              }
-                                                                                                                            }
-                                                                                                                          }
-                                                                                                                        }
-                                                                                                                      }
-                                                                                                                    }
-                                                                                                                  },
-                                                                                                                  "next": {
-                                                                                                                    "block": {
-                                                                                                                      "type": "SetVariable",
-                                                                                                                      "id": "hw+)DYAI=WnwIa2,oWh_",
-                                                                                                                      "inputs": {
-                                                                                                                        "VALUE-0": {
-                                                                                                                          "block": {
-                                                                                                                            "type": "variableReferenceBlock",
-                                                                                                                            "id": "fXYV[J;r0)[s^3)sn5SM",
-                                                                                                                            "extraState": {
-                                                                                                                              "isObjectVar": false
-                                                                                                                            },
-                                                                                                                            "fields": {
-                                                                                                                              "OBJECTTYPE": "Global",
-                                                                                                                              "VAR": {
-                                                                                                                                "id": "ZCBg+S5Y0?xD[@GpnRJ."
-                                                                                                                              }
-                                                                                                                            }
-                                                                                                                          }
-                                                                                                                        },
-                                                                                                                        "VALUE-1": {
-                                                                                                                          "block": {
-                                                                                                                            "type": "GetCapturePoint",
-                                                                                                                            "id": "kH[hm8VOT5;|^,%91;(A",
-                                                                                                                            "inputs": {
-                                                                                                                              "VALUE-0": {
-                                                                                                                                "block": {
-                                                                                                                                  "type": "MCOMsItem",
-                                                                                                                                  "id": "B[w1_2ZEoBM1^!V6!nJE",
-                                                                                                                                  "fields": {
-                                                                                                                                    "VALUE-0": "MCOMs",
-                                                                                                                                    "VALUE-1": "D"
-                                                                                                                                  }
-                                                                                                                                }
-                                                                                                                              }
-                                                                                                                            }
-                                                                                                                          }
-                                                                                                                        }
-                                                                                                                      },
-                                                                                                                      "next": {
-                                                                                                                        "block": {
-                                                                                                                          "type": "subroutineInstanceBlock",
-                                                                                                                          "id": "x2%.vK]Tt/h]:P*{#RB@",
-                                                                                                                          "extraState": {
-                                                                                                                            "subroutineName": "MCOM_Setup",
-                                                                                                                            "parameters": []
-                                                                                                                          },
-                                                                                                                          "fields": {
-                                                                                                                            "SUBROUTINE_NAME": "MCOM_Setup"
-                                                                                                                          },
-                                                                                                                          "next": {
-                                                                                                                            "block": {
-                                                                                                                              "type": "Wait",
-                                                                                                                              "id": "ew?@aW~E9rrNY_h(Gc8+",
-                                                                                                                              "inputs": {
-                                                                                                                                "VALUE-0": {
-                                                                                                                                  "block": {
-                                                                                                                                    "type": "Number",
-                                                                                                                                    "id": "I1p)SKb:6G@*gDrc]zx@",
-                                                                                                                                    "fields": {
-                                                                                                                                      "NUM": 5
-                                                                                                                                    }
-                                                                                                                                  }
-                                                                                                                                }
-                                                                                                                              },
-                                                                                                                              "next": {
-                                                                                                                                "block": {
-                                                                                                                                  "type": "EnablePlayerSpawning",
-                                                                                                                                  "id": "xLC/X5{JUmior[#;rea;",
-                                                                                                                                  "inputs": {
-                                                                                                                                    "VALUE-0": {
-                                                                                                                                      "block": {
-                                                                                                                                        "type": "Boolean",
-                                                                                                                                        "id": "K/$L_Z.#t8x.!D~#b!uE",
-                                                                                                                                        "fields": {
-                                                                                                                                          "BOOL": "TRUE"
-                                                                                                                                        }
-                                                                                                                                      }
-                                                                                                                                    }
-                                                                                                                                  },
-                                                                                                                                  "next": {
-                                                                                                                                    "block": {
-                                                                                                                                      "type": "subroutineInstanceBlock",
-                                                                                                                                      "id": "tvN04M,pK!E,r{e4JcEm",
-                                                                                                                                      "extraState": {
-                                                                                                                                        "subroutineName": "RoundTimer",
-                                                                                                                                        "parameters": []
-                                                                                                                                      },
-                                                                                                                                      "fields": {
-                                                                                                                                        "SUBROUTINE_NAME": "RoundTimer"
-                                                                                                                                      }
-                                                                                                                                    }
-                                                                                                                                  }
-                                                                                                                                }
-                                                                                                                              }
-                                                                                                                            }
-                                                                                                                          }
-                                                                                                                        }
-                                                                                                                      }
-                                                                                                                    }
-                                                                                                                  }
-                                                                                                                }
-                                                                                                              }
-                                                                                                            }
-                                                                                                          }
-                                                                                                        }
-                                                                                                      }
-                                                                                                    }
-                                                                                                  }
-                                                                                                }
-                                                                                              }
-                                                                                            }
-                                                                                          }
-                                                                                        }
-                                                                                      },
-                                                                                      "IF1": {
-                                                                                        "block": {
-                                                                                          "type": "Equals",
-                                                                                          "id": "*%:x/RZGy#YM{egiw0Z^",
+                                                                                          "type": "Subtract",
+                                                                                          "id": "hk5qsrqF?:1rB#:I|9hr",
                                                                                           "inputs": {
                                                                                             "VALUE-0": {
                                                                                               "block": {
                                                                                                 "type": "GetGamemodeScore",
-                                                                                                "id": "LL|o@IbaB(sB*:%Ri]W{",
+                                                                                                "id": "}-cKcshyk@h|0~*AjskS",
                                                                                                 "inputs": {
                                                                                                   "VALUE-0": {
                                                                                                     "block": {
                                                                                                       "type": "GetTeamId",
-                                                                                                      "id": "p!,$tp*@`!^:ZQZx(v^8",
+                                                                                                      "id": "g`DDYD|Qu4%Lo[y%$OuH",
                                                                                                       "inputs": {
                                                                                                         "VALUE-0": {
                                                                                                           "block": {
                                                                                                             "type": "Number",
-                                                                                                            "id": "Pb9MP~5G+0A|ws!^x_,q",
+                                                                                                            "id": "s;7s;fP[t1xByc!}nMtn",
                                                                                                             "fields": {
                                                                                                               "NUM": 2
                                                                                                             }
@@ -3744,34 +4369,633 @@
                                                                                             "VALUE-1": {
                                                                                               "block": {
                                                                                                 "type": "Number",
-                                                                                                "id": "+:7C7Wz7v|I0CnvfSTrt",
+                                                                                                "id": "T#Tr^e~qA_+I_MGy8]OC",
                                                                                                 "fields": {
-                                                                                                  "NUM": 0
+                                                                                                  "NUM": 1
                                                                                                 }
                                                                                               }
                                                                                             }
                                                                                           }
                                                                                         }
-                                                                                      },
-                                                                                      "DO1": {
-                                                                                        "block": {
-                                                                                          "type": "EndRound",
-                                                                                          "id": "oFW2U5u[|gGPIRW]hZ^+",
-                                                                                          "inputs": {
-                                                                                            "VALUE-0": {
-                                                                                              "block": {
-                                                                                                "type": "GetTeamId",
-                                                                                                "id": "a5U#4xz((gz1,/vB.7C2",
-                                                                                                "inputs": {
-                                                                                                  "VALUE-0": {
-                                                                                                    "block": {
-                                                                                                      "type": "Number",
-                                                                                                      "id": "l1t8y_~~c9QC3|h6lkm(",
-                                                                                                      "fields": {
-                                                                                                        "NUM": 1
+                                                                                      }
+                                                                                    },
+                                                                                    "next": {
+                                                                                      "block": {
+                                                                                        "type": "If",
+                                                                                        "id": "]{4?#wcGXN5VY4%LvYc2",
+                                                                                        "extraState": {
+                                                                                          "elseif": 1,
+                                                                                          "else": 1
+                                                                                        },
+                                                                                        "inputs": {
+                                                                                          "VALUE-0": {
+                                                                                            "block": {
+                                                                                              "type": "Equals",
+                                                                                              "id": "gZ;711z,J~-kymN]KB07",
+                                                                                              "inputs": {
+                                                                                                "VALUE-0": {
+                                                                                                  "block": {
+                                                                                                    "type": "GetGamemodeScore",
+                                                                                                    "id": "}sMJMZwvxi7#DOnj9I{K",
+                                                                                                    "inputs": {
+                                                                                                      "VALUE-0": {
+                                                                                                        "block": {
+                                                                                                          "type": "GetTeamId",
+                                                                                                          "id": "dn_0HU-SjWX/(yA:JDM3",
+                                                                                                          "inputs": {
+                                                                                                            "VALUE-0": {
+                                                                                                              "block": {
+                                                                                                                "type": "Number",
+                                                                                                                "id": "D#5HvhOS{3uUkkCGn_(z",
+                                                                                                                "fields": {
+                                                                                                                  "NUM": 2
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
                                                                                                       }
                                                                                                     }
                                                                                                   }
+                                                                                                },
+                                                                                                "VALUE-1": {
+                                                                                                  "block": {
+                                                                                                    "type": "Number",
+                                                                                                    "id": "(V82MEHInu#IfglzI5Et",
+                                                                                                    "fields": {
+                                                                                                      "NUM": 2
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          },
+                                                                                          "DO": {
+                                                                                            "block": {
+                                                                                              "type": "SetVariable",
+                                                                                              "id": "I(|-d%N@nDD1IZ$Oi%C5",
+                                                                                              "inputs": {
+                                                                                                "VALUE-0": {
+                                                                                                  "block": {
+                                                                                                    "type": "variableReferenceBlock",
+                                                                                                    "id": "=XPP;dY;21NYC:i/usIi",
+                                                                                                    "extraState": {
+                                                                                                      "isObjectVar": false
+                                                                                                    },
+                                                                                                    "fields": {
+                                                                                                      "OBJECTTYPE": "Global",
+                                                                                                      "VAR": {
+                                                                                                        "id": "=8OY*aWMGF4.T^k6uLUl"
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                },
+                                                                                                "VALUE-1": {
+                                                                                                  "block": {
+                                                                                                    "type": "GetVariable",
+                                                                                                    "id": "8WvKniysVuj=4|3**-w/",
+                                                                                                    "inputs": {
+                                                                                                      "VALUE-0": {
+                                                                                                        "block": {
+                                                                                                          "type": "variableReferenceBlock",
+                                                                                                          "id": "`_~=|Vr6K#Qnywb*rD3w",
+                                                                                                          "extraState": {
+                                                                                                            "isObjectVar": false
+                                                                                                          },
+                                                                                                          "fields": {
+                                                                                                            "OBJECTTYPE": "Global",
+                                                                                                            "VAR": {
+                                                                                                              "id": "Xr?o?acUGgeUMdeaBx?x"
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              },
+                                                                                              "next": {
+                                                                                                "block": {
+                                                                                                  "type": "Wait",
+                                                                                                  "id": "{r59qWj9?k3BApT/!BII",
+                                                                                                  "inputs": {
+                                                                                                    "VALUE-0": {
+                                                                                                      "block": {
+                                                                                                        "type": "Number",
+                                                                                                        "id": "}zrwF4|Y7T1D:Js[%;1#",
+                                                                                                        "fields": {
+                                                                                                          "NUM": 3
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  },
+                                                                                                  "next": {
+                                                                                                    "block": {
+                                                                                                      "type": "SetGamemodeScore",
+                                                                                                      "id": "R,!CY-MydgQ[-z2LSkYQ",
+                                                                                                      "inputs": {
+                                                                                                        "VALUE-0": {
+                                                                                                          "block": {
+                                                                                                            "type": "GetTeamId",
+                                                                                                            "id": "1n/o^^GW/V$X0.43o(A5",
+                                                                                                            "inputs": {
+                                                                                                              "VALUE-0": {
+                                                                                                                "block": {
+                                                                                                                  "type": "Number",
+                                                                                                                  "id": "M3Ts)frQVcM?`si:PQ`7",
+                                                                                                                  "fields": {
+                                                                                                                    "NUM": 1
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        },
+                                                                                                        "VALUE-1": {
+                                                                                                          "block": {
+                                                                                                            "type": "GetVariable",
+                                                                                                            "id": "iK106XIpS;Z5lR,`98Hp",
+                                                                                                            "inputs": {
+                                                                                                              "VALUE-0": {
+                                                                                                                "block": {
+                                                                                                                  "type": "variableReferenceBlock",
+                                                                                                                  "id": "=_Z-4FoW2-m:KsW|[YVh",
+                                                                                                                  "extraState": {
+                                                                                                                    "isObjectVar": false
+                                                                                                                  },
+                                                                                                                  "fields": {
+                                                                                                                    "OBJECTTYPE": "Global",
+                                                                                                                    "VAR": {
+                                                                                                                      "id": "wNy%6`mCB3RKeeWT}eH("
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      },
+                                                                                                      "next": {
+                                                                                                        "block": {
+                                                                                                          "type": "UnspawnAllPlayers",
+                                                                                                          "id": "!3%10T|*H;D!|=}2U0hj",
+                                                                                                          "next": {
+                                                                                                            "block": {
+                                                                                                              "type": "EnablePlayerSpawning",
+                                                                                                              "id": "IA:T8=0iS1;Fuyn-2j9%",
+                                                                                                              "inputs": {
+                                                                                                                "VALUE-0": {
+                                                                                                                  "block": {
+                                                                                                                    "type": "Boolean",
+                                                                                                                    "id": "=]TgqI:US3;biMT#R-j3",
+                                                                                                                    "fields": {
+                                                                                                                      "BOOL": "FALSE"
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              },
+                                                                                                              "next": {
+                                                                                                                "block": {
+                                                                                                                  "type": "SetVariable",
+                                                                                                                  "id": "N,P!]CIrH.jdN++YQHuK",
+                                                                                                                  "inputs": {
+                                                                                                                    "VALUE-0": {
+                                                                                                                      "block": {
+                                                                                                                        "type": "variableReferenceBlock",
+                                                                                                                        "id": "fJ4LS,O2_]@U@v.6f}AE",
+                                                                                                                        "extraState": {
+                                                                                                                          "isObjectVar": false
+                                                                                                                        },
+                                                                                                                        "fields": {
+                                                                                                                          "OBJECTTYPE": "Global",
+                                                                                                                          "VAR": {
+                                                                                                                            "id": ";2]y+lLHsxSWFYjcQjhk"
+                                                                                                                          }
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    },
+                                                                                                                    "VALUE-1": {
+                                                                                                                      "block": {
+                                                                                                                        "type": "Number",
+                                                                                                                        "id": "?0XLKZ*,)4#es`-W,|WC",
+                                                                                                                        "fields": {
+                                                                                                                          "NUM": 1
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    }
+                                                                                                                  },
+                                                                                                                  "next": {
+                                                                                                                    "block": {
+                                                                                                                      "type": "SetVariable",
+                                                                                                                      "id": "|!C*L,pmi}Eq?Xw4RpR+",
+                                                                                                                      "inputs": {
+                                                                                                                        "VALUE-0": {
+                                                                                                                          "block": {
+                                                                                                                            "type": "variableReferenceBlock",
+                                                                                                                            "id": "eMLZFVD75:Z0,%rCM8_Q",
+                                                                                                                            "extraState": {
+                                                                                                                              "isObjectVar": false
+                                                                                                                            },
+                                                                                                                            "fields": {
+                                                                                                                              "OBJECTTYPE": "Global",
+                                                                                                                              "VAR": {
+                                                                                                                                "id": "w_^Ni+6S]Sp8=OOP4#,a"
+                                                                                                                              }
+                                                                                                                            }
+                                                                                                                          }
+                                                                                                                        },
+                                                                                                                        "VALUE-1": {
+                                                                                                                          "block": {
+                                                                                                                            "type": "EmptyArray",
+                                                                                                                            "id": "YPp)nq:7xtv5|K-K!72:"
+                                                                                                                          }
+                                                                                                                        }
+                                                                                                                      },
+                                                                                                                      "next": {
+                                                                                                                        "block": {
+                                                                                                                          "type": "subroutineInstanceBlock",
+                                                                                                                          "id": "j8vIyg^xQjp.CvgUOX(=",
+                                                                                                                          "extraState": {
+                                                                                                                            "subroutineName": "MapDetect",
+                                                                                                                            "parameters": []
+                                                                                                                          },
+                                                                                                                          "fields": {
+                                                                                                                            "SUBROUTINE_NAME": "MapDetect"
+                                                                                                                          },
+                                                                                                                          "next": {
+                                                                                                                            "block": {
+                                                                                                                              "type": "SetVariable",
+                                                                                                                              "id": "HjVx4N0;`4vbblr-#VV@",
+                                                                                                                              "inputs": {
+                                                                                                                                "VALUE-0": {
+                                                                                                                                  "block": {
+                                                                                                                                    "type": "variableReferenceBlock",
+                                                                                                                                    "id": "j10m_8gXSQG7bW{]Ao7j",
+                                                                                                                                    "extraState": {
+                                                                                                                                      "isObjectVar": false
+                                                                                                                                    },
+                                                                                                                                    "fields": {
+                                                                                                                                      "OBJECTTYPE": "Global",
+                                                                                                                                      "VAR": {
+                                                                                                                                        "id": "W?M=066mWT~Tf=[ON!`$"
+                                                                                                                                      }
+                                                                                                                                    }
+                                                                                                                                  }
+                                                                                                                                },
+                                                                                                                                "VALUE-1": {
+                                                                                                                                  "block": {
+                                                                                                                                    "type": "GetCapturePoint",
+                                                                                                                                    "id": "Q@,mF-V=zYJ:{_0%$kM-",
+                                                                                                                                    "inputs": {
+                                                                                                                                      "VALUE-0": {
+                                                                                                                                        "block": {
+                                                                                                                                          "type": "MCOMsItem",
+                                                                                                                                          "id": "z+jum4dO5r[t$[;mRpP}",
+                                                                                                                                          "fields": {
+                                                                                                                                            "VALUE-0": "MCOMs",
+                                                                                                                                            "VALUE-1": "C"
+                                                                                                                                          }
+                                                                                                                                        }
+                                                                                                                                      }
+                                                                                                                                    }
+                                                                                                                                  }
+                                                                                                                                }
+                                                                                                                              },
+                                                                                                                              "next": {
+                                                                                                                                "block": {
+                                                                                                                                  "type": "SetVariable",
+                                                                                                                                  "id": "hw+)DYAI=WnwIa2,oWh_",
+                                                                                                                                  "inputs": {
+                                                                                                                                    "VALUE-0": {
+                                                                                                                                      "block": {
+                                                                                                                                        "type": "variableReferenceBlock",
+                                                                                                                                        "id": "fXYV[J;r0)[s^3)sn5SM",
+                                                                                                                                        "extraState": {
+                                                                                                                                          "isObjectVar": false
+                                                                                                                                        },
+                                                                                                                                        "fields": {
+                                                                                                                                          "OBJECTTYPE": "Global",
+                                                                                                                                          "VAR": {
+                                                                                                                                            "id": "ZCBg+S5Y0?xD[@GpnRJ."
+                                                                                                                                          }
+                                                                                                                                        }
+                                                                                                                                      }
+                                                                                                                                    },
+                                                                                                                                    "VALUE-1": {
+                                                                                                                                      "block": {
+                                                                                                                                        "type": "GetCapturePoint",
+                                                                                                                                        "id": "kH[hm8VOT5;|^,%91;(A",
+                                                                                                                                        "inputs": {
+                                                                                                                                          "VALUE-0": {
+                                                                                                                                            "block": {
+                                                                                                                                              "type": "MCOMsItem",
+                                                                                                                                              "id": "B[w1_2ZEoBM1^!V6!nJE",
+                                                                                                                                              "fields": {
+                                                                                                                                                "VALUE-0": "MCOMs",
+                                                                                                                                                "VALUE-1": "D"
+                                                                                                                                              }
+                                                                                                                                            }
+                                                                                                                                          }
+                                                                                                                                        }
+                                                                                                                                      }
+                                                                                                                                    }
+                                                                                                                                  },
+                                                                                                                                  "next": {
+                                                                                                                                    "block": {
+                                                                                                                                      "type": "subroutineInstanceBlock",
+                                                                                                                                      "id": "x2%.vK]Tt/h]:P*{#RB@",
+                                                                                                                                      "extraState": {
+                                                                                                                                        "subroutineName": "MCOM_Setup",
+                                                                                                                                        "parameters": []
+                                                                                                                                      },
+                                                                                                                                      "fields": {
+                                                                                                                                        "SUBROUTINE_NAME": "MCOM_Setup"
+                                                                                                                                      },
+                                                                                                                                      "next": {
+                                                                                                                                        "block": {
+                                                                                                                                          "type": "Wait",
+                                                                                                                                          "id": "ew?@aW~E9rrNY_h(Gc8+",
+                                                                                                                                          "inputs": {
+                                                                                                                                            "VALUE-0": {
+                                                                                                                                              "block": {
+                                                                                                                                                "type": "Number",
+                                                                                                                                                "id": "I1p)SKb:6G@*gDrc]zx@",
+                                                                                                                                                "fields": {
+                                                                                                                                                  "NUM": 5
+                                                                                                                                                }
+                                                                                                                                              }
+                                                                                                                                            }
+                                                                                                                                          },
+                                                                                                                                          "next": {
+                                                                                                                                            "block": {
+                                                                                                                                              "type": "EnablePlayerSpawning",
+                                                                                                                                              "id": "xLC/X5{JUmior[#;rea;",
+                                                                                                                                              "inputs": {
+                                                                                                                                                "VALUE-0": {
+                                                                                                                                                  "block": {
+                                                                                                                                                    "type": "Boolean",
+                                                                                                                                                    "id": "K/$L_Z.#t8x.!D~#b!uE",
+                                                                                                                                                    "fields": {
+                                                                                                                                                      "BOOL": "TRUE"
+                                                                                                                                                    }
+                                                                                                                                                  }
+                                                                                                                                                }
+                                                                                                                                              },
+                                                                                                                                              "next": {
+                                                                                                                                                "block": {
+                                                                                                                                                  "type": "subroutineInstanceBlock",
+                                                                                                                                                  "id": "tvN04M,pK!E,r{e4JcEm",
+                                                                                                                                                  "extraState": {
+                                                                                                                                                    "subroutineName": "RoundTimer",
+                                                                                                                                                    "parameters": []
+                                                                                                                                                  },
+                                                                                                                                                  "fields": {
+                                                                                                                                                    "SUBROUTINE_NAME": "RoundTimer"
+                                                                                                                                                  }
+                                                                                                                                                }
+                                                                                                                                              }
+                                                                                                                                            }
+                                                                                                                                          }
+                                                                                                                                        }
+                                                                                                                                      }
+                                                                                                                                    }
+                                                                                                                                  }
+                                                                                                                                }
+                                                                                                                              }
+                                                                                                                            }
+                                                                                                                          }
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          },
+                                                                                          "IF1": {
+                                                                                            "block": {
+                                                                                              "type": "Equals",
+                                                                                              "id": "*%:x/RZGy#YM{egiw0Z^",
+                                                                                              "inputs": {
+                                                                                                "VALUE-0": {
+                                                                                                  "block": {
+                                                                                                    "type": "GetGamemodeScore",
+                                                                                                    "id": "LL|o@IbaB(sB*:%Ri]W{",
+                                                                                                    "inputs": {
+                                                                                                      "VALUE-0": {
+                                                                                                        "block": {
+                                                                                                          "type": "GetTeamId",
+                                                                                                          "id": "p!,$tp*@`!^:ZQZx(v^8",
+                                                                                                          "inputs": {
+                                                                                                            "VALUE-0": {
+                                                                                                              "block": {
+                                                                                                                "type": "Number",
+                                                                                                                "id": "Pb9MP~5G+0A|ws!^x_,q",
+                                                                                                                "fields": {
+                                                                                                                  "NUM": 2
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                },
+                                                                                                "VALUE-1": {
+                                                                                                  "block": {
+                                                                                                    "type": "Number",
+                                                                                                    "id": "+:7C7Wz7v|I0CnvfSTrt",
+                                                                                                    "fields": {
+                                                                                                      "NUM": 0
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          },
+                                                                                          "DO1": {
+                                                                                            "block": {
+                                                                                              "type": "EndRound",
+                                                                                              "id": "oFW2U5u[|gGPIRW]hZ^+",
+                                                                                              "inputs": {
+                                                                                                "VALUE-0": {
+                                                                                                  "block": {
+                                                                                                    "type": "GetTeamId",
+                                                                                                    "id": "a5U#4xz((gz1,/vB.7C2",
+                                                                                                    "inputs": {
+                                                                                                      "VALUE-0": {
+                                                                                                        "block": {
+                                                                                                          "type": "Number",
+                                                                                                          "id": "l1t8y_~~c9QC3|h6lkm(",
+                                                                                                          "fields": {
+                                                                                                            "NUM": 1
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          "next": {
+                                                                            "block": {
+                                                                              "type": "ruleBlock",
+                                                                              "id": "|Hl{wHWRaIV5v.+.gsbv",
+                                                                              "extraState": {
+                                                                                "isOngoingEvent": true
+                                                                              },
+                                                                              "fields": {
+                                                                                "NAME": "End Game for Team1",
+                                                                                "EVENTTYPE": "Ongoing",
+                                                                                "OBJECTTYPE": "Global"
+                                                                              },
+                                                                              "inputs": {
+                                                                                "CONDITIONS": {
+                                                                                  "block": {
+                                                                                    "type": "conditionBlock",
+                                                                                    "id": "setlx4lX%_i.;am]qr#m",
+                                                                                    "inputs": {
+                                                                                      "CONDITION": {
+                                                                                        "block": {
+                                                                                          "type": "Equals",
+                                                                                          "id": "@T!1NsvAEHg_{|:VjpWA",
+                                                                                          "inputs": {
+                                                                                            "VALUE-0": {
+                                                                                              "block": {
+                                                                                                "type": "GetVariable",
+                                                                                                "id": "]Lk.rAky]nY^c4Gi/s{!",
+                                                                                                "inputs": {
+                                                                                                  "VALUE-0": {
+                                                                                                    "block": {
+                                                                                                      "type": "variableReferenceBlock",
+                                                                                                      "id": "W+a+98mew%DKo!ts,DJ)",
+                                                                                                      "extraState": {
+                                                                                                        "isObjectVar": false
+                                                                                                      },
+                                                                                                      "fields": {
+                                                                                                        "OBJECTTYPE": "Global",
+                                                                                                        "VAR": {
+                                                                                                          "id": "=8OY*aWMGF4.T^k6uLUl"
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            },
+                                                                                            "VALUE-1": {
+                                                                                              "block": {
+                                                                                                "type": "GetVariable",
+                                                                                                "id": "}yu0]V@+_ryCE;-osbI]",
+                                                                                                "inputs": {
+                                                                                                  "VALUE-0": {
+                                                                                                    "block": {
+                                                                                                      "type": "variableReferenceBlock",
+                                                                                                      "id": "Ik-|[GvpgAUkkUjLn88`",
+                                                                                                      "extraState": {
+                                                                                                        "isObjectVar": false
+                                                                                                      },
+                                                                                                      "fields": {
+                                                                                                        "OBJECTTYPE": "Global",
+                                                                                                        "VAR": {
+                                                                                                          "id": "**%O*!0`FJS;40@p6=u|"
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    },
+                                                                                    "next": {
+                                                                                      "block": {
+                                                                                        "type": "conditionBlock",
+                                                                                        "id": "idpBt9W$wF~(u,fz|Ldd",
+                                                                                        "inputs": {
+                                                                                          "CONDITION": {
+                                                                                            "block": {
+                                                                                              "type": "Equals",
+                                                                                              "id": "0.MVNnkAS#t`I5t/~?Uq",
+                                                                                              "inputs": {
+                                                                                                "VALUE-0": {
+                                                                                                  "block": {
+                                                                                                    "type": "GetGamemodeScore",
+                                                                                                    "id": "GNKM49D[n-vl04ZtS*4_",
+                                                                                                    "inputs": {
+                                                                                                      "VALUE-0": {
+                                                                                                        "block": {
+                                                                                                          "type": "GetTeamId",
+                                                                                                          "id": "%d=1ci~w8i=AZ|s4):sh",
+                                                                                                          "inputs": {
+                                                                                                            "VALUE-0": {
+                                                                                                              "block": {
+                                                                                                                "type": "Number",
+                                                                                                                "id": "1d7dFCX@Byf79fkI7HV*",
+                                                                                                                "fields": {
+                                                                                                                  "NUM": 1
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                },
+                                                                                                "VALUE-1": {
+                                                                                                  "block": {
+                                                                                                    "type": "Number",
+                                                                                                    "id": "t,X3uZx`/MGjI}?G`e=E",
+                                                                                                    "fields": {
+                                                                                                      "NUM": 0
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                },
+                                                                                "ACTIONS": {
+                                                                                  "block": {
+                                                                                    "type": "EndRound",
+                                                                                    "id": "{K=X)d[~j41R}kM0=Cem",
+                                                                                    "inputs": {
+                                                                                      "VALUE-0": {
+                                                                                        "block": {
+                                                                                          "type": "GetTeamId",
+                                                                                          "id": "nZBcs?G@haRzj.l(}#cg",
+                                                                                          "inputs": {
+                                                                                            "VALUE-0": {
+                                                                                              "block": {
+                                                                                                "type": "Number",
+                                                                                                "id": "norr]/A^r@@X*moc[8+Q",
+                                                                                                "fields": {
+                                                                                                  "NUM": 2
                                                                                                 }
                                                                                               }
                                                                                             }
@@ -6742,8 +7966,8 @@
       {
         "type": "subroutineBlock",
         "id": "%%%F_nRKxl0V]hbt^]y+",
-        "x": 3921,
-        "y": 4465,
+        "x": 3937,
+        "y": 5633,
         "extraState": {
           "subroutineName": "CheckBoundaries",
           "parameters": [
@@ -8017,8 +9241,8 @@
       {
         "type": "subroutineBlock",
         "id": "aTm+^+K[SMP{dAg53{8B",
-        "x": 3921,
-        "y": 5953,
+        "x": 6358,
+        "y": 4656,
         "extraState": {
           "subroutineName": "yaw",
           "parameters": []
@@ -8182,7 +9406,6 @@
                                   "block": {
                                     "type": "AngleBetweenVectors",
                                     "id": "~1pm;7Y5!Ce5=fNLKs4e",
-                                    "inline": false,
                                     "inputs": {
                                       "VALUE-0": {
                                         "block": {
@@ -8199,7 +9422,6 @@
                                               "block": {
                                                 "type": "CreateVector",
                                                 "id": "#GWXjI;eDTZc}+QWjLfm",
-                                                "inline": false,
                                                 "inputs": {
                                                   "VALUE-0": {
                                                     "block": {
@@ -8375,7 +9597,6 @@
                                   "block": {
                                     "type": "Subtract",
                                     "id": "8f[5MbN6#Q!!]XVj{6TM",
-                                    "inline": false,
                                     "inputs": {
                                       "VALUE-0": {
                                         "block": {
@@ -8390,7 +9611,6 @@
                                         "block": {
                                           "type": "AngleBetweenVectors",
                                           "id": "D[6k(s3s~+X_Op4eYDl(",
-                                          "inline": false,
                                           "inputs": {
                                             "VALUE-0": {
                                               "block": {
@@ -8407,7 +9627,6 @@
                                                     "block": {
                                                       "type": "CreateVector",
                                                       "id": "d9)KV0|Jz2BP[npE`p60",
-                                                      "inline": false,
                                                       "inputs": {
                                                         "VALUE-0": {
                                                           "block": {
@@ -8559,8 +9778,8 @@
       {
         "type": "subroutineBlock",
         "id": "HqoKtBI,Z-g5p`5)-v*a",
-        "x": 3921,
-        "y": 7214,
+        "x": 3934,
+        "y": 7130,
         "extraState": {
           "subroutineName": "MCOM_Setup",
           "parameters": []
@@ -9606,8 +10825,8 @@
       {
         "type": "subroutineBlock",
         "id": "T%w/wk0?n^b^tqu{Sz0N",
-        "x": 3918,
-        "y": 10705,
+        "x": 3934,
+        "y": 8269,
         "extraState": {
           "subroutineName": "MCOMTracker",
           "parameters": []
@@ -9943,8 +11162,8 @@
       {
         "type": "subroutineBlock",
         "id": "m65)w39M+jnfmG8T}H/.",
-        "x": 3921,
-        "y": 9495,
+        "x": 3940,
+        "y": 9829,
         "extraState": {
           "subroutineName": "EveryTickGlobal",
           "parameters": []
@@ -9984,8 +11203,8 @@
       {
         "type": "subroutineBlock",
         "id": "ewJked[j(4W_OAGdTuI+",
-        "x": 3921,
-        "y": 9791,
+        "x": 4373,
+        "y": 9827,
         "extraState": {
           "subroutineName": "UI",
           "parameters": []
@@ -10542,6 +11761,81 @@
                                 }
                               }
                             }
+                          },
+                          "next": {
+                            "block": {
+                              "type": "DisplayCustomNotificationMessage",
+                              "id": "t3)lmIrx2are,HXyp/?l",
+                              "inputs": {
+                                "VALUE-0": {
+                                  "block": {
+                                    "type": "Message",
+                                    "id": "C~,-It}=@kx^iz|%%Xu?",
+                                    "inputs": {
+                                      "VALUE-0": {
+                                        "block": {
+                                          "type": "Text",
+                                          "id": "C0-JG90aF*}4.@crkJ#$",
+                                          "fields": {
+                                            "TEXT": "Spawn Becons: {}"
+                                          }
+                                        }
+                                      },
+                                      "VALUE-1": {
+                                        "block": {
+                                          "type": "CountOf",
+                                          "id": "m}%!5~Uhh@@dHA_AQQ,N",
+                                          "inputs": {
+                                            "VALUE-0": {
+                                              "block": {
+                                                "type": "GetVariable",
+                                                "id": ":uV*lDzalax3n2Eu(u#9",
+                                                "inputs": {
+                                                  "VALUE-0": {
+                                                    "block": {
+                                                      "type": "variableReferenceBlock",
+                                                      "id": "WST1]iV6s{.Uy_0+T*P3",
+                                                      "extraState": {
+                                                        "isObjectVar": false
+                                                      },
+                                                      "fields": {
+                                                        "OBJECTTYPE": "Global",
+                                                        "VAR": {
+                                                          "id": "w_^Ni+6S]Sp8=OOP4#,a"
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "VALUE-1": {
+                                  "block": {
+                                    "type": "CustomMessagesItem",
+                                    "id": "a72`F*2kGY_%=OT47r1!",
+                                    "fields": {
+                                      "VALUE-0": "CustomMessages",
+                                      "VALUE-1": "MessageText4"
+                                    }
+                                  }
+                                },
+                                "VALUE-2": {
+                                  "block": {
+                                    "type": "Number",
+                                    "id": "WIXo)3dewg.c_CLHwNa^",
+                                    "fields": {
+                                      "NUM": 1
+                                    }
+                                  }
+                                }
+                              }
+                            }
                           }
                         }
                       }
@@ -10556,8 +11850,8 @@
       {
         "type": "subroutineBlock",
         "id": "KCWW;~j)udT%Ppo_`FyW",
-        "x": 3922,
-        "y": 8375,
+        "x": 3934,
+        "y": 8845,
         "extraState": {
           "subroutineName": "RoundTimer",
           "parameters": []
@@ -10988,6 +12282,4906 @@
             }
           }
         }
+      },
+      {
+        "type": "subroutineBlock",
+        "id": "fYQu%C)(jM4/=8g,2INr",
+        "x": 3916,
+        "y": 11285,
+        "extraState": {
+          "subroutineName": "Specialist_Setup",
+          "parameters": []
+        },
+        "fields": {
+          "SUBROUTINE_NAME": "Specialist_Setup"
+        },
+        "inputs": {
+          "ACTIONS": {
+            "block": {
+              "type": "SetVariable",
+              "id": "OLYb@O#xwi(}`_b~JK0]",
+              "inputs": {
+                "VALUE-0": {
+                  "block": {
+                    "type": "variableReferenceBlock",
+                    "id": "p|(0WK(@!HoLX!eXx:D7",
+                    "extraState": {
+                      "isObjectVar": false
+                    },
+                    "fields": {
+                      "OBJECTTYPE": "Global",
+                      "VAR": {
+                        "id": "PQt,8tYaHP%Y^xyuN2vr"
+                      }
+                    }
+                  }
+                },
+                "VALUE-1": {
+                  "block": {
+                    "type": "EmptyArray",
+                    "id": "|b%g/l{:vlBt^A5yoD}~"
+                  }
+                }
+              },
+              "next": {
+                "block": {
+                  "type": "SetVariable",
+                  "id": "Q44_Bt(Vi?KMy2B=cP,A",
+                  "inputs": {
+                    "VALUE-0": {
+                      "block": {
+                        "type": "variableReferenceBlock",
+                        "id": "uQ;bp3IVlXjdXZs@4?x6",
+                        "extraState": {
+                          "isObjectVar": false
+                        },
+                        "fields": {
+                          "OBJECTTYPE": "Global",
+                          "VAR": {
+                            "id": "}Zluh/,.+*V:1v$3);ao"
+                          }
+                        }
+                      }
+                    },
+                    "VALUE-1": {
+                      "block": {
+                        "type": "EmptyArray",
+                        "id": "kA9)=.J9FEb|Rn:OX/@R"
+                      }
+                    }
+                  },
+                  "next": {
+                    "block": {
+                      "type": "SetVariable",
+                      "id": "{LOPLH%}4ef{ps445t{%",
+                      "inputs": {
+                        "VALUE-0": {
+                          "block": {
+                            "type": "variableReferenceBlock",
+                            "id": "B#_550]7TxU*xN|tuH05",
+                            "extraState": {
+                              "isObjectVar": false
+                            },
+                            "fields": {
+                              "OBJECTTYPE": "Global",
+                              "VAR": {
+                                "id": "%YI,HkG5QqE*1#EzZxjM"
+                              }
+                            }
+                          }
+                        },
+                        "VALUE-1": {
+                          "block": {
+                            "type": "EmptyArray",
+                            "id": "YH3ES31e%3sNwhi5CnGN"
+                          }
+                        }
+                      },
+                      "next": {
+                        "block": {
+                          "type": "SetVariable",
+                          "id": "0#u1[+{wUR|JP,[=-9K2",
+                          "inputs": {
+                            "VALUE-0": {
+                              "block": {
+                                "type": "variableReferenceBlock",
+                                "id": "#TH|N$k!7mIHb?b:A4(o",
+                                "extraState": {
+                                  "isObjectVar": false
+                                },
+                                "fields": {
+                                  "OBJECTTYPE": "Global",
+                                  "VAR": {
+                                    "id": "Oy^]7IX.zwi.UFR*ty79"
+                                  }
+                                }
+                              }
+                            },
+                            "VALUE-1": {
+                              "block": {
+                                "type": "EmptyArray",
+                                "id": "bU:)qy.u#lUC+t%Bxzls"
+                              }
+                            }
+                          },
+                          "next": {
+                            "block": {
+                              "type": "SetVariable",
+                              "id": "zKYcFd[XvMboHDJ/W4TS",
+                              "inputs": {
+                                "VALUE-0": {
+                                  "block": {
+                                    "type": "variableReferenceBlock",
+                                    "id": "P,;$(5XDqk#bC`F}WD+[",
+                                    "extraState": {
+                                      "isObjectVar": false
+                                    },
+                                    "fields": {
+                                      "OBJECTTYPE": "Global",
+                                      "VAR": {
+                                        "id": "hypM!0ohL^cA%HtBrJ7;"
+                                      }
+                                    }
+                                  }
+                                },
+                                "VALUE-1": {
+                                  "block": {
+                                    "type": "EmptyArray",
+                                    "id": "2d@p+)%yxHtS;tVBBs8z"
+                                  }
+                                }
+                              },
+                              "next": {
+                                "block": {
+                                  "type": "SetVariable",
+                                  "id": "$(xFvFqn}e.$gzXlbYSp",
+                                  "inputs": {
+                                    "VALUE-0": {
+                                      "block": {
+                                        "type": "variableReferenceBlock",
+                                        "id": "XBJ^o$0~0m?@}RGk^u~U",
+                                        "extraState": {
+                                          "isObjectVar": false
+                                        },
+                                        "fields": {
+                                          "OBJECTTYPE": "Global",
+                                          "VAR": {
+                                            "id": "}Zluh/,.+*V:1v$3);ao"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "VALUE-1": {
+                                      "block": {
+                                        "type": "AppendToArray",
+                                        "id": ")hXdoE*zt4D[3]1o2?|H",
+                                        "inputs": {
+                                          "VALUE-0": {
+                                            "block": {
+                                              "type": "GetVariable",
+                                              "id": "i^u_;F;fWjJ}l+Y()SR[",
+                                              "inputs": {
+                                                "VALUE-0": {
+                                                  "block": {
+                                                    "type": "variableReferenceBlock",
+                                                    "id": "Y|[jfaf%i7*~n/q}Gz7v",
+                                                    "extraState": {
+                                                      "isObjectVar": false
+                                                    },
+                                                    "fields": {
+                                                      "OBJECTTYPE": "Global",
+                                                      "VAR": {
+                                                        "id": "}Zluh/,.+*V:1v$3);ao"
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          },
+                                          "VALUE-1": {
+                                            "block": {
+                                              "type": "SoldierKitsItem",
+                                              "id": "rge}Yy-/(bekC{vTl]b=",
+                                              "fields": {
+                                                "VALUE-0": "BF2042",
+                                                "VALUE-1": "Alpha"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "next": {
+                                    "block": {
+                                      "type": "SetVariable",
+                                      "id": ",5FIr/YF^5mrmh0fgk%|",
+                                      "inputs": {
+                                        "VALUE-0": {
+                                          "block": {
+                                            "type": "variableReferenceBlock",
+                                            "id": "QqRD4oYT_i4B`tfh)`j@",
+                                            "extraState": {
+                                              "isObjectVar": false
+                                            },
+                                            "fields": {
+                                              "OBJECTTYPE": "Global",
+                                              "VAR": {
+                                                "id": "}Zluh/,.+*V:1v$3);ao"
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "VALUE-1": {
+                                          "block": {
+                                            "type": "AppendToArray",
+                                            "id": "_Lo#2|_[dnkDV):{+9,`",
+                                            "inputs": {
+                                              "VALUE-0": {
+                                                "block": {
+                                                  "type": "GetVariable",
+                                                  "id": "?r9.r_%$C:w4PO(gNkC,",
+                                                  "inputs": {
+                                                    "VALUE-0": {
+                                                      "block": {
+                                                        "type": "variableReferenceBlock",
+                                                        "id": "ca__J4@H${K$I$!9WGj{",
+                                                        "extraState": {
+                                                          "isObjectVar": false
+                                                        },
+                                                        "fields": {
+                                                          "OBJECTTYPE": "Global",
+                                                          "VAR": {
+                                                            "id": "}Zluh/,.+*V:1v$3);ao"
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              },
+                                              "VALUE-1": {
+                                                "block": {
+                                                  "type": "SoldierKitsItem",
+                                                  "id": "T}^InYrg_5Gi^F^e;aNh",
+                                                  "fields": {
+                                                    "VALUE-0": "BF2042",
+                                                    "VALUE-1": "Charlie"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "next": {
+                                        "block": {
+                                          "type": "SetVariable",
+                                          "id": "|FJqp5iDNDV^jC==l#s+",
+                                          "inputs": {
+                                            "VALUE-0": {
+                                              "block": {
+                                                "type": "variableReferenceBlock",
+                                                "id": "0@.vCpZKJ.-;pJ^jbp9T",
+                                                "extraState": {
+                                                  "isObjectVar": false
+                                                },
+                                                "fields": {
+                                                  "OBJECTTYPE": "Global",
+                                                  "VAR": {
+                                                    "id": "}Zluh/,.+*V:1v$3);ao"
+                                                  }
+                                                }
+                                              }
+                                            },
+                                            "VALUE-1": {
+                                              "block": {
+                                                "type": "AppendToArray",
+                                                "id": ")8//i7[+5S/l([GU#I@T",
+                                                "inputs": {
+                                                  "VALUE-0": {
+                                                    "block": {
+                                                      "type": "GetVariable",
+                                                      "id": "G5/MAV*1*qTTW@aL{Wxp",
+                                                      "inputs": {
+                                                        "VALUE-0": {
+                                                          "block": {
+                                                            "type": "variableReferenceBlock",
+                                                            "id": "H(#j:O=SdM`OOAK}zE#~",
+                                                            "extraState": {
+                                                              "isObjectVar": false
+                                                            },
+                                                            "fields": {
+                                                              "OBJECTTYPE": "Global",
+                                                              "VAR": {
+                                                                "id": "}Zluh/,.+*V:1v$3);ao"
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  },
+                                                  "VALUE-1": {
+                                                    "block": {
+                                                      "type": "SoldierKitsItem",
+                                                      "id": "Y*jvj+QN7},`Cu;1C9HF",
+                                                      "fields": {
+                                                        "VALUE-0": "BF2042",
+                                                        "VALUE-1": "Delta"
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          },
+                                          "next": {
+                                            "block": {
+                                              "type": "SetVariable",
+                                              "id": "A!/o#t-lfDiB/DRG?zN:",
+                                              "inputs": {
+                                                "VALUE-0": {
+                                                  "block": {
+                                                    "type": "variableReferenceBlock",
+                                                    "id": ".eYX.}K#?$P:d(_!8A3|",
+                                                    "extraState": {
+                                                      "isObjectVar": false
+                                                    },
+                                                    "fields": {
+                                                      "OBJECTTYPE": "Global",
+                                                      "VAR": {
+                                                        "id": "}Zluh/,.+*V:1v$3);ao"
+                                                      }
+                                                    }
+                                                  }
+                                                },
+                                                "VALUE-1": {
+                                                  "block": {
+                                                    "type": "AppendToArray",
+                                                    "id": ".*EMmA^i2XnE(G[Z7)4-",
+                                                    "inputs": {
+                                                      "VALUE-0": {
+                                                        "block": {
+                                                          "type": "GetVariable",
+                                                          "id": "x)[o|1Cf%Q9SmzEW%W7D",
+                                                          "inputs": {
+                                                            "VALUE-0": {
+                                                              "block": {
+                                                                "type": "variableReferenceBlock",
+                                                                "id": "`XS(`_]2Th||*wViaFvF",
+                                                                "extraState": {
+                                                                  "isObjectVar": false
+                                                                },
+                                                                "fields": {
+                                                                  "OBJECTTYPE": "Global",
+                                                                  "VAR": {
+                                                                    "id": "}Zluh/,.+*V:1v$3);ao"
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      },
+                                                      "VALUE-1": {
+                                                        "block": {
+                                                          "type": "SoldierKitsItem",
+                                                          "id": "W//:/s9DsPKjSbS51y.C",
+                                                          "fields": {
+                                                            "VALUE-0": "BF2042",
+                                                            "VALUE-1": "November"
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              },
+                                              "next": {
+                                                "block": {
+                                                  "type": "SetVariable",
+                                                  "id": ",s2+HeQRR(SzpPC[=gFw",
+                                                  "inputs": {
+                                                    "VALUE-0": {
+                                                      "block": {
+                                                        "type": "variableReferenceBlock",
+                                                        "id": "gJ*y)*nV5N$:C.6v@R7h",
+                                                        "extraState": {
+                                                          "isObjectVar": false
+                                                        },
+                                                        "fields": {
+                                                          "OBJECTTYPE": "Global",
+                                                          "VAR": {
+                                                            "id": "%YI,HkG5QqE*1#EzZxjM"
+                                                          }
+                                                        }
+                                                      }
+                                                    },
+                                                    "VALUE-1": {
+                                                      "block": {
+                                                        "type": "AppendToArray",
+                                                        "id": "=f05x!mE91}umJsMXbn#",
+                                                        "inputs": {
+                                                          "VALUE-0": {
+                                                            "block": {
+                                                              "type": "GetVariable",
+                                                              "id": "=srp,(GJ4H839MyM@4rS",
+                                                              "inputs": {
+                                                                "VALUE-0": {
+                                                                  "block": {
+                                                                    "type": "variableReferenceBlock",
+                                                                    "id": ")+eCMiR_o4o0KPo_/0t4",
+                                                                    "extraState": {
+                                                                      "isObjectVar": false
+                                                                    },
+                                                                    "fields": {
+                                                                      "OBJECTTYPE": "Global",
+                                                                      "VAR": {
+                                                                        "id": "%YI,HkG5QqE*1#EzZxjM"
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          },
+                                                          "VALUE-1": {
+                                                            "block": {
+                                                              "type": "SoldierKitsItem",
+                                                              "id": "wo:_NF?s3#mr%=A0C-CI",
+                                                              "fields": {
+                                                                "VALUE-0": "BF2042",
+                                                                "VALUE-1": "Juliet"
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  },
+                                                  "next": {
+                                                    "block": {
+                                                      "type": "SetVariable",
+                                                      "id": "IbO|7|9R%v[Hh(paS]es",
+                                                      "inputs": {
+                                                        "VALUE-0": {
+                                                          "block": {
+                                                            "type": "variableReferenceBlock",
+                                                            "id": "F6ecz`ZZ6v.a1%VJhF]S",
+                                                            "extraState": {
+                                                              "isObjectVar": false
+                                                            },
+                                                            "fields": {
+                                                              "OBJECTTYPE": "Global",
+                                                              "VAR": {
+                                                                "id": "%YI,HkG5QqE*1#EzZxjM"
+                                                              }
+                                                            }
+                                                          }
+                                                        },
+                                                        "VALUE-1": {
+                                                          "block": {
+                                                            "type": "AppendToArray",
+                                                            "id": "5*vX26%*h!h|Q7X!N-qR",
+                                                            "inputs": {
+                                                              "VALUE-0": {
+                                                                "block": {
+                                                                  "type": "GetVariable",
+                                                                  "id": "ii0Cl(S#xOJnrVmte3gX",
+                                                                  "inputs": {
+                                                                    "VALUE-0": {
+                                                                      "block": {
+                                                                        "type": "variableReferenceBlock",
+                                                                        "id": "02mZP;5q3jVK6R^b^^Eg",
+                                                                        "extraState": {
+                                                                          "isObjectVar": false
+                                                                        },
+                                                                        "fields": {
+                                                                          "OBJECTTYPE": "Global",
+                                                                          "VAR": {
+                                                                            "id": "%YI,HkG5QqE*1#EzZxjM"
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              },
+                                                              "VALUE-1": {
+                                                                "block": {
+                                                                  "type": "SoldierKitsItem",
+                                                                  "id": "-;4?B%ZjD/;PydLRO9=R",
+                                                                  "fields": {
+                                                                    "VALUE-0": "BF2042",
+                                                                    "VALUE-1": "Hotel"
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      },
+                                                      "next": {
+                                                        "block": {
+                                                          "type": "SetVariable",
+                                                          "id": "phCTsVL+)2:6L^JOGf!6",
+                                                          "inputs": {
+                                                            "VALUE-0": {
+                                                              "block": {
+                                                                "type": "variableReferenceBlock",
+                                                                "id": "s`kJi2g!V[EGR*bLMe%r",
+                                                                "extraState": {
+                                                                  "isObjectVar": false
+                                                                },
+                                                                "fields": {
+                                                                  "OBJECTTYPE": "Global",
+                                                                  "VAR": {
+                                                                    "id": "%YI,HkG5QqE*1#EzZxjM"
+                                                                  }
+                                                                }
+                                                              }
+                                                            },
+                                                            "VALUE-1": {
+                                                              "block": {
+                                                                "type": "AppendToArray",
+                                                                "id": "ZffncX}:D2)!+cWcb1NR",
+                                                                "inputs": {
+                                                                  "VALUE-0": {
+                                                                    "block": {
+                                                                      "type": "GetVariable",
+                                                                      "id": "`I^hw4g_U}54Q-C7j5y5",
+                                                                      "inputs": {
+                                                                        "VALUE-0": {
+                                                                          "block": {
+                                                                            "type": "variableReferenceBlock",
+                                                                            "id": "0(szu;.bPp.*|iW,FWXv",
+                                                                            "extraState": {
+                                                                              "isObjectVar": false
+                                                                            },
+                                                                            "fields": {
+                                                                              "OBJECTTYPE": "Global",
+                                                                              "VAR": {
+                                                                                "id": "%YI,HkG5QqE*1#EzZxjM"
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  "VALUE-1": {
+                                                                    "block": {
+                                                                      "type": "SoldierKitsItem",
+                                                                      "id": "IQTuK?,7lz{cfaPs%)$j",
+                                                                      "fields": {
+                                                                        "VALUE-0": "BF2042",
+                                                                        "VALUE-1": "Mike"
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          },
+                                                          "next": {
+                                                            "block": {
+                                                              "type": "SetVariable",
+                                                              "id": "g).T^{q!j@(/PYCJsiC0",
+                                                              "inputs": {
+                                                                "VALUE-0": {
+                                                                  "block": {
+                                                                    "type": "variableReferenceBlock",
+                                                                    "id": "/;YRG)E37YLy/p:vO5t.",
+                                                                    "extraState": {
+                                                                      "isObjectVar": false
+                                                                    },
+                                                                    "fields": {
+                                                                      "OBJECTTYPE": "Global",
+                                                                      "VAR": {
+                                                                        "id": "Oy^]7IX.zwi.UFR*ty79"
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                },
+                                                                "VALUE-1": {
+                                                                  "block": {
+                                                                    "type": "AppendToArray",
+                                                                    "id": "Cki[KyU*v,0R#8XQcpLD",
+                                                                    "inputs": {
+                                                                      "VALUE-0": {
+                                                                        "block": {
+                                                                          "type": "GetVariable",
+                                                                          "id": "[./w^(y*)_n|-BsYh!xh",
+                                                                          "inputs": {
+                                                                            "VALUE-0": {
+                                                                              "block": {
+                                                                                "type": "variableReferenceBlock",
+                                                                                "id": "(3*6am^}!Wc-o741}NqN",
+                                                                                "extraState": {
+                                                                                  "isObjectVar": false
+                                                                                },
+                                                                                "fields": {
+                                                                                  "OBJECTTYPE": "Global",
+                                                                                  "VAR": {
+                                                                                    "id": "Oy^]7IX.zwi.UFR*ty79"
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      },
+                                                                      "VALUE-1": {
+                                                                        "block": {
+                                                                          "type": "SoldierKitsItem",
+                                                                          "id": "Hl@CXZwZraB@3m@OD(!f",
+                                                                          "fields": {
+                                                                            "VALUE-0": "BF2042",
+                                                                            "VALUE-1": "Bravo"
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              },
+                                                              "next": {
+                                                                "block": {
+                                                                  "type": "SetVariable",
+                                                                  "id": "*3:6;4y+ZYXxti^X8Iv0",
+                                                                  "inputs": {
+                                                                    "VALUE-0": {
+                                                                      "block": {
+                                                                        "type": "variableReferenceBlock",
+                                                                        "id": "j{~ZPSop3y}D})Y8IK:`",
+                                                                        "extraState": {
+                                                                          "isObjectVar": false
+                                                                        },
+                                                                        "fields": {
+                                                                          "OBJECTTYPE": "Global",
+                                                                          "VAR": {
+                                                                            "id": "Oy^]7IX.zwi.UFR*ty79"
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    },
+                                                                    "VALUE-1": {
+                                                                      "block": {
+                                                                        "type": "AppendToArray",
+                                                                        "id": "fHY:).*d=Y@8,xYy.#]I",
+                                                                        "inputs": {
+                                                                          "VALUE-0": {
+                                                                            "block": {
+                                                                              "type": "GetVariable",
+                                                                              "id": "1574rFcXU|qI`U-}t{Wg",
+                                                                              "inputs": {
+                                                                                "VALUE-0": {
+                                                                                  "block": {
+                                                                                    "type": "variableReferenceBlock",
+                                                                                    "id": "Vg]Nu/C%*IjMRy0{;.8:",
+                                                                                    "extraState": {
+                                                                                      "isObjectVar": false
+                                                                                    },
+                                                                                    "fields": {
+                                                                                      "OBJECTTYPE": "Global",
+                                                                                      "VAR": {
+                                                                                        "id": "Oy^]7IX.zwi.UFR*ty79"
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          "VALUE-1": {
+                                                                            "block": {
+                                                                              "type": "SoldierKitsItem",
+                                                                              "id": "6@^V[{5ML(r3a_c_,dR{",
+                                                                              "fields": {
+                                                                                "VALUE-0": "BF2042",
+                                                                                "VALUE-1": "Foxtrot"
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  },
+                                                                  "next": {
+                                                                    "block": {
+                                                                      "type": "SetVariable",
+                                                                      "id": "?`Syw?!l:J}LQ%Yk$!cq",
+                                                                      "inputs": {
+                                                                        "VALUE-0": {
+                                                                          "block": {
+                                                                            "type": "variableReferenceBlock",
+                                                                            "id": ";%f*rnFe:,F.KgnE-+qh",
+                                                                            "extraState": {
+                                                                              "isObjectVar": false
+                                                                            },
+                                                                            "fields": {
+                                                                              "OBJECTTYPE": "Global",
+                                                                              "VAR": {
+                                                                                "id": "Oy^]7IX.zwi.UFR*ty79"
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        },
+                                                                        "VALUE-1": {
+                                                                          "block": {
+                                                                            "type": "AppendToArray",
+                                                                            "id": "jun]6X!]m-N#a{dz`0g}",
+                                                                            "inputs": {
+                                                                              "VALUE-0": {
+                                                                                "block": {
+                                                                                  "type": "GetVariable",
+                                                                                  "id": "VuO=6^/O;}N)((lGF7rk",
+                                                                                  "inputs": {
+                                                                                    "VALUE-0": {
+                                                                                      "block": {
+                                                                                        "type": "variableReferenceBlock",
+                                                                                        "id": "aiFNeGurJeh@l|Z-|^:|",
+                                                                                        "extraState": {
+                                                                                          "isObjectVar": false
+                                                                                        },
+                                                                                        "fields": {
+                                                                                          "OBJECTTYPE": "Global",
+                                                                                          "VAR": {
+                                                                                            "id": "Oy^]7IX.zwi.UFR*ty79"
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              },
+                                                                              "VALUE-1": {
+                                                                                "block": {
+                                                                                  "type": "SoldierKitsItem",
+                                                                                  "id": "G{O@|fRT/k1(u0SpMi%g",
+                                                                                  "fields": {
+                                                                                    "VALUE-0": "BF2042",
+                                                                                    "VALUE-1": "India"
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      },
+                                                                      "next": {
+                                                                        "block": {
+                                                                          "type": "SetVariable",
+                                                                          "id": "S7]c]/L$h)^T9Xz9I`YT",
+                                                                          "inputs": {
+                                                                            "VALUE-0": {
+                                                                              "block": {
+                                                                                "type": "variableReferenceBlock",
+                                                                                "id": "i)D=_J|0-Us!sD6^JV2q",
+                                                                                "extraState": {
+                                                                                  "isObjectVar": false
+                                                                                },
+                                                                                "fields": {
+                                                                                  "OBJECTTYPE": "Global",
+                                                                                  "VAR": {
+                                                                                    "id": "hypM!0ohL^cA%HtBrJ7;"
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            },
+                                                                            "VALUE-1": {
+                                                                              "block": {
+                                                                                "type": "AppendToArray",
+                                                                                "id": "/O,TqlA^ss@U^A-gnWYY",
+                                                                                "inputs": {
+                                                                                  "VALUE-0": {
+                                                                                    "block": {
+                                                                                      "type": "GetVariable",
+                                                                                      "id": "1=B0(!)/P+5BXpgwycyG",
+                                                                                      "inputs": {
+                                                                                        "VALUE-0": {
+                                                                                          "block": {
+                                                                                            "type": "variableReferenceBlock",
+                                                                                            "id": "*6^beq-8J!mD@37QyHj+",
+                                                                                            "extraState": {
+                                                                                              "isObjectVar": false
+                                                                                            },
+                                                                                            "fields": {
+                                                                                              "OBJECTTYPE": "Global",
+                                                                                              "VAR": {
+                                                                                                "id": "hypM!0ohL^cA%HtBrJ7;"
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  },
+                                                                                  "VALUE-1": {
+                                                                                    "block": {
+                                                                                      "type": "SoldierKitsItem",
+                                                                                      "id": "A3Dt5Zx)rG,wBOMVVcvv",
+                                                                                      "fields": {
+                                                                                        "VALUE-0": "BF2042",
+                                                                                        "VALUE-1": "Echo"
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          },
+                                                                          "next": {
+                                                                            "block": {
+                                                                              "type": "SetVariable",
+                                                                              "id": "~mU9YH{T]=3b_O#[:ig!",
+                                                                              "inputs": {
+                                                                                "VALUE-0": {
+                                                                                  "block": {
+                                                                                    "type": "variableReferenceBlock",
+                                                                                    "id": "+5f~weN1LyE]LFCNpm=L",
+                                                                                    "extraState": {
+                                                                                      "isObjectVar": false
+                                                                                    },
+                                                                                    "fields": {
+                                                                                      "OBJECTTYPE": "Global",
+                                                                                      "VAR": {
+                                                                                        "id": "hypM!0ohL^cA%HtBrJ7;"
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                },
+                                                                                "VALUE-1": {
+                                                                                  "block": {
+                                                                                    "type": "AppendToArray",
+                                                                                    "id": "m1;3JxTce#3E}i{SM}FT",
+                                                                                    "inputs": {
+                                                                                      "VALUE-0": {
+                                                                                        "block": {
+                                                                                          "type": "GetVariable",
+                                                                                          "id": "bFBN,|Tb#Y9xkiN9Nzl%",
+                                                                                          "inputs": {
+                                                                                            "VALUE-0": {
+                                                                                              "block": {
+                                                                                                "type": "variableReferenceBlock",
+                                                                                                "id": "Z{xqYD5fN=z@u8.smr~3",
+                                                                                                "extraState": {
+                                                                                                  "isObjectVar": false
+                                                                                                },
+                                                                                                "fields": {
+                                                                                                  "OBJECTTYPE": "Global",
+                                                                                                  "VAR": {
+                                                                                                    "id": "hypM!0ohL^cA%HtBrJ7;"
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      },
+                                                                                      "VALUE-1": {
+                                                                                        "block": {
+                                                                                          "type": "SoldierKitsItem",
+                                                                                          "id": "1rQZsc@kMI$:!@tG!*8j",
+                                                                                          "fields": {
+                                                                                            "VALUE-0": "BF2042",
+                                                                                            "VALUE-1": "Kilo"
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              },
+                                                                              "next": {
+                                                                                "block": {
+                                                                                  "type": "SetVariable",
+                                                                                  "id": "^z-Q~k}r`!JmtxC~a$Km",
+                                                                                  "inputs": {
+                                                                                    "VALUE-0": {
+                                                                                      "block": {
+                                                                                        "type": "variableReferenceBlock",
+                                                                                        "id": "nun=}QyU_|o.{naLTc$u",
+                                                                                        "extraState": {
+                                                                                          "isObjectVar": false
+                                                                                        },
+                                                                                        "fields": {
+                                                                                          "OBJECTTYPE": "Global",
+                                                                                          "VAR": {
+                                                                                            "id": "hypM!0ohL^cA%HtBrJ7;"
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    },
+                                                                                    "VALUE-1": {
+                                                                                      "block": {
+                                                                                        "type": "AppendToArray",
+                                                                                        "id": "nPL:9%zj_IDLy+vQq9Lb",
+                                                                                        "inputs": {
+                                                                                          "VALUE-0": {
+                                                                                            "block": {
+                                                                                              "type": "GetVariable",
+                                                                                              "id": "Uy%@29D=IgGt}1JwtsGf",
+                                                                                              "inputs": {
+                                                                                                "VALUE-0": {
+                                                                                                  "block": {
+                                                                                                    "type": "variableReferenceBlock",
+                                                                                                    "id": "XGl^yN{m!1TZ-UwEG;7d",
+                                                                                                    "extraState": {
+                                                                                                      "isObjectVar": false
+                                                                                                    },
+                                                                                                    "fields": {
+                                                                                                      "OBJECTTYPE": "Global",
+                                                                                                      "VAR": {
+                                                                                                        "id": "hypM!0ohL^cA%HtBrJ7;"
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          },
+                                                                                          "VALUE-1": {
+                                                                                            "block": {
+                                                                                              "type": "SoldierKitsItem",
+                                                                                              "id": ",$.wo|w!f+wIi7`:|-TF",
+                                                                                              "fields": {
+                                                                                                "VALUE-0": "BF2042",
+                                                                                                "VALUE-1": "Lima"
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  },
+                                                                                  "next": {
+                                                                                    "block": {
+                                                                                      "type": "SetVariable",
+                                                                                      "id": "gAZ*E}2G#h9@3h!+u^x=",
+                                                                                      "inputs": {
+                                                                                        "VALUE-0": {
+                                                                                          "block": {
+                                                                                            "type": "variableReferenceBlock",
+                                                                                            "id": "XTpZTU5II8g9E#;z-(?;",
+                                                                                            "extraState": {
+                                                                                              "isObjectVar": false
+                                                                                            },
+                                                                                            "fields": {
+                                                                                              "OBJECTTYPE": "Global",
+                                                                                              "VAR": {
+                                                                                                "id": "hypM!0ohL^cA%HtBrJ7;"
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        },
+                                                                                        "VALUE-1": {
+                                                                                          "block": {
+                                                                                            "type": "AppendToArray",
+                                                                                            "id": "|q4Tq=T_NtX-Sr]qrV^X",
+                                                                                            "inputs": {
+                                                                                              "VALUE-0": {
+                                                                                                "block": {
+                                                                                                  "type": "GetVariable",
+                                                                                                  "id": "/%I3{68K3l*40^]EC^%k",
+                                                                                                  "inputs": {
+                                                                                                    "VALUE-0": {
+                                                                                                      "block": {
+                                                                                                        "type": "variableReferenceBlock",
+                                                                                                        "id": "I?9KYq,Qm#Srnx.Ffl=,",
+                                                                                                        "extraState": {
+                                                                                                          "isObjectVar": false
+                                                                                                        },
+                                                                                                        "fields": {
+                                                                                                          "OBJECTTYPE": "Global",
+                                                                                                          "VAR": {
+                                                                                                            "id": "hypM!0ohL^cA%HtBrJ7;"
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              },
+                                                                                              "VALUE-1": {
+                                                                                                "block": {
+                                                                                                  "type": "SoldierKitsItem",
+                                                                                                  "id": "@S`f1#Tv*Ji$*_{sXEOV",
+                                                                                                  "fields": {
+                                                                                                    "VALUE-0": "BF2042",
+                                                                                                    "VALUE-1": "Oscar"
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      },
+                                                                                      "next": {
+                                                                                        "block": {
+                                                                                          "type": "SetVariable",
+                                                                                          "id": "y{i8+gV3.WZnPKzrAEcR",
+                                                                                          "inputs": {
+                                                                                            "VALUE-0": {
+                                                                                              "block": {
+                                                                                                "type": "variableReferenceBlock",
+                                                                                                "id": "qjm,$y$r=+O:pNb^Su2~",
+                                                                                                "extraState": {
+                                                                                                  "isObjectVar": false
+                                                                                                },
+                                                                                                "fields": {
+                                                                                                  "OBJECTTYPE": "Global",
+                                                                                                  "VAR": {
+                                                                                                    "id": "PQt,8tYaHP%Y^xyuN2vr"
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            },
+                                                                                            "VALUE-1": {
+                                                                                              "block": {
+                                                                                                "type": "AppendToArray",
+                                                                                                "id": ",3@rnl]75m_aJZ=#Y=5l",
+                                                                                                "inputs": {
+                                                                                                  "VALUE-0": {
+                                                                                                    "block": {
+                                                                                                      "type": "GetVariable",
+                                                                                                      "id": "8AjiK^KkI`UGut#}nyC1",
+                                                                                                      "inputs": {
+                                                                                                        "VALUE-0": {
+                                                                                                          "block": {
+                                                                                                            "type": "variableReferenceBlock",
+                                                                                                            "id": "4Q#Muhp-)uN64(ec?NX?",
+                                                                                                            "extraState": {
+                                                                                                              "isObjectVar": false
+                                                                                                            },
+                                                                                                            "fields": {
+                                                                                                              "OBJECTTYPE": "Global",
+                                                                                                              "VAR": {
+                                                                                                                "id": "PQt,8tYaHP%Y^xyuN2vr"
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  },
+                                                                                                  "VALUE-1": {
+                                                                                                    "block": {
+                                                                                                      "type": "GetVariable",
+                                                                                                      "id": "|A_Td=bG{:BW2Y?T`)RZ",
+                                                                                                      "inputs": {
+                                                                                                        "VALUE-0": {
+                                                                                                          "block": {
+                                                                                                            "type": "variableReferenceBlock",
+                                                                                                            "id": "-zCNU;lle0sogfW139+-",
+                                                                                                            "extraState": {
+                                                                                                              "isObjectVar": false
+                                                                                                            },
+                                                                                                            "fields": {
+                                                                                                              "OBJECTTYPE": "Global",
+                                                                                                              "VAR": {
+                                                                                                                "id": "}Zluh/,.+*V:1v$3);ao"
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          },
+                                                                                          "next": {
+                                                                                            "block": {
+                                                                                              "type": "SetVariable",
+                                                                                              "id": "u[6L@FJrcji=`c*/K1)J",
+                                                                                              "inputs": {
+                                                                                                "VALUE-0": {
+                                                                                                  "block": {
+                                                                                                    "type": "variableReferenceBlock",
+                                                                                                    "id": "6hjs=X`kd%{B!.1ERw!l",
+                                                                                                    "extraState": {
+                                                                                                      "isObjectVar": false
+                                                                                                    },
+                                                                                                    "fields": {
+                                                                                                      "OBJECTTYPE": "Global",
+                                                                                                      "VAR": {
+                                                                                                        "id": "PQt,8tYaHP%Y^xyuN2vr"
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                },
+                                                                                                "VALUE-1": {
+                                                                                                  "block": {
+                                                                                                    "type": "AppendToArray",
+                                                                                                    "id": "M~pJl!WmFoFraN~Me2$%",
+                                                                                                    "inputs": {
+                                                                                                      "VALUE-0": {
+                                                                                                        "block": {
+                                                                                                          "type": "GetVariable",
+                                                                                                          "id": "wlqQN@]bD{06B+{ckB}q",
+                                                                                                          "inputs": {
+                                                                                                            "VALUE-0": {
+                                                                                                              "block": {
+                                                                                                                "type": "variableReferenceBlock",
+                                                                                                                "id": "*miEi;9AXxP#1HDsPM:v",
+                                                                                                                "extraState": {
+                                                                                                                  "isObjectVar": false
+                                                                                                                },
+                                                                                                                "fields": {
+                                                                                                                  "OBJECTTYPE": "Global",
+                                                                                                                  "VAR": {
+                                                                                                                    "id": "PQt,8tYaHP%Y^xyuN2vr"
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      },
+                                                                                                      "VALUE-1": {
+                                                                                                        "block": {
+                                                                                                          "type": "GetVariable",
+                                                                                                          "id": "c~y?#YwU4rFzw]Y1^jNc",
+                                                                                                          "inputs": {
+                                                                                                            "VALUE-0": {
+                                                                                                              "block": {
+                                                                                                                "type": "variableReferenceBlock",
+                                                                                                                "id": "u^!4SwZpp,R^Zs/fmn`f",
+                                                                                                                "extraState": {
+                                                                                                                  "isObjectVar": false
+                                                                                                                },
+                                                                                                                "fields": {
+                                                                                                                  "OBJECTTYPE": "Global",
+                                                                                                                  "VAR": {
+                                                                                                                    "id": "%YI,HkG5QqE*1#EzZxjM"
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              },
+                                                                                              "next": {
+                                                                                                "block": {
+                                                                                                  "type": "SetVariable",
+                                                                                                  "id": "8Dv5axqGC0m)eQ2uI9Q#",
+                                                                                                  "inputs": {
+                                                                                                    "VALUE-0": {
+                                                                                                      "block": {
+                                                                                                        "type": "variableReferenceBlock",
+                                                                                                        "id": "]6qvT^)5eI3Nj.h*CM+v",
+                                                                                                        "extraState": {
+                                                                                                          "isObjectVar": false
+                                                                                                        },
+                                                                                                        "fields": {
+                                                                                                          "OBJECTTYPE": "Global",
+                                                                                                          "VAR": {
+                                                                                                            "id": "PQt,8tYaHP%Y^xyuN2vr"
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    },
+                                                                                                    "VALUE-1": {
+                                                                                                      "block": {
+                                                                                                        "type": "AppendToArray",
+                                                                                                        "id": "!G-k@v8,{L,75d?b4ph*",
+                                                                                                        "inputs": {
+                                                                                                          "VALUE-0": {
+                                                                                                            "block": {
+                                                                                                              "type": "GetVariable",
+                                                                                                              "id": "QZ-s8)[MRcx!DDjE5Sk*",
+                                                                                                              "inputs": {
+                                                                                                                "VALUE-0": {
+                                                                                                                  "block": {
+                                                                                                                    "type": "variableReferenceBlock",
+                                                                                                                    "id": "m9%bSABF~po_x${CxG*+",
+                                                                                                                    "extraState": {
+                                                                                                                      "isObjectVar": false
+                                                                                                                    },
+                                                                                                                    "fields": {
+                                                                                                                      "OBJECTTYPE": "Global",
+                                                                                                                      "VAR": {
+                                                                                                                        "id": "PQt,8tYaHP%Y^xyuN2vr"
+                                                                                                                      }
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          },
+                                                                                                          "VALUE-1": {
+                                                                                                            "block": {
+                                                                                                              "type": "GetVariable",
+                                                                                                              "id": "9q|lpM-nJzQTHP?`-HH$",
+                                                                                                              "inputs": {
+                                                                                                                "VALUE-0": {
+                                                                                                                  "block": {
+                                                                                                                    "type": "variableReferenceBlock",
+                                                                                                                    "id": "Vkz9Ru0ClO[,?8u!0b^2",
+                                                                                                                    "extraState": {
+                                                                                                                      "isObjectVar": false
+                                                                                                                    },
+                                                                                                                    "fields": {
+                                                                                                                      "OBJECTTYPE": "Global",
+                                                                                                                      "VAR": {
+                                                                                                                        "id": "Oy^]7IX.zwi.UFR*ty79"
+                                                                                                                      }
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  },
+                                                                                                  "next": {
+                                                                                                    "block": {
+                                                                                                      "type": "SetVariable",
+                                                                                                      "id": "dAKIqX%;m16*Gek#T`.$",
+                                                                                                      "inputs": {
+                                                                                                        "VALUE-0": {
+                                                                                                          "block": {
+                                                                                                            "type": "variableReferenceBlock",
+                                                                                                            "id": ".d`2C:)*[`2%9`!)F)JJ",
+                                                                                                            "extraState": {
+                                                                                                              "isObjectVar": false
+                                                                                                            },
+                                                                                                            "fields": {
+                                                                                                              "OBJECTTYPE": "Global",
+                                                                                                              "VAR": {
+                                                                                                                "id": "PQt,8tYaHP%Y^xyuN2vr"
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        },
+                                                                                                        "VALUE-1": {
+                                                                                                          "block": {
+                                                                                                            "type": "AppendToArray",
+                                                                                                            "id": "@z90ZN.,]AkGvUAEnbCI",
+                                                                                                            "inputs": {
+                                                                                                              "VALUE-0": {
+                                                                                                                "block": {
+                                                                                                                  "type": "GetVariable",
+                                                                                                                  "id": "px+O}r%VB5[w`tI?kS;H",
+                                                                                                                  "inputs": {
+                                                                                                                    "VALUE-0": {
+                                                                                                                      "block": {
+                                                                                                                        "type": "variableReferenceBlock",
+                                                                                                                        "id": ",:^o!cW%GDB-D^Uot3qj",
+                                                                                                                        "extraState": {
+                                                                                                                          "isObjectVar": false
+                                                                                                                        },
+                                                                                                                        "fields": {
+                                                                                                                          "OBJECTTYPE": "Global",
+                                                                                                                          "VAR": {
+                                                                                                                            "id": "PQt,8tYaHP%Y^xyuN2vr"
+                                                                                                                          }
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              },
+                                                                                                              "VALUE-1": {
+                                                                                                                "block": {
+                                                                                                                  "type": "GetVariable",
+                                                                                                                  "id": "*=j6GGF(L2kAg0_ux`Bp",
+                                                                                                                  "inputs": {
+                                                                                                                    "VALUE-0": {
+                                                                                                                      "block": {
+                                                                                                                        "type": "variableReferenceBlock",
+                                                                                                                        "id": "JgeL++2;[_k4vuQ2t4oM",
+                                                                                                                        "extraState": {
+                                                                                                                          "isObjectVar": false
+                                                                                                                        },
+                                                                                                                        "fields": {
+                                                                                                                          "OBJECTTYPE": "Global",
+                                                                                                                          "VAR": {
+                                                                                                                            "id": "hypM!0ohL^cA%HtBrJ7;"
+                                                                                                                          }
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    }
+                                                                                                                  }
+                                                                                                                }
+                                                                                                              }
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      }
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              }
+                                                                                            }
+                                                                                          }
+                                                                                        }
+                                                                                      }
+                                                                                    }
+                                                                                  }
+                                                                                }
+                                                                              }
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "subroutineBlock",
+        "id": "HRND5e/]OU,m!4q-YJ6s",
+        "x": 5932,
+        "y": 11255,
+        "extraState": {
+          "subroutineName": "Assault_Primary",
+          "parameters": []
+        },
+        "fields": {
+          "SUBROUTINE_NAME": "Assault_Primary"
+        },
+        "inputs": {
+          "ACTIONS": {
+            "block": {
+              "type": "SetVariable",
+              "id": "bedy!e#n,DG+yMEQTV7z",
+              "inputs": {
+                "VALUE-0": {
+                  "block": {
+                    "type": "variableReferenceBlock",
+                    "id": "L^N5;aCKgl;vN9`h$EsD",
+                    "extraState": {
+                      "isObjectVar": false
+                    },
+                    "fields": {
+                      "OBJECTTYPE": "Global",
+                      "VAR": {
+                        "id": ":dwZCT8I?YI$xG8BBgpE"
+                      }
+                    }
+                  }
+                },
+                "VALUE-1": {
+                  "block": {
+                    "type": "EmptyArray",
+                    "id": "i8{9{gN!N-nnZp`m_Hri"
+                  }
+                }
+              },
+              "next": {
+                "block": {
+                  "type": "SetVariable",
+                  "id": "1=O%:?zZ%vp6[!hBFpn_",
+                  "inputs": {
+                    "VALUE-0": {
+                      "block": {
+                        "type": "variableReferenceBlock",
+                        "id": "TK:rwB%RYj$d3g^h*zMS",
+                        "extraState": {
+                          "isObjectVar": false
+                        },
+                        "fields": {
+                          "OBJECTTYPE": "Global",
+                          "VAR": {
+                            "id": ":dwZCT8I?YI$xG8BBgpE"
+                          }
+                        }
+                      }
+                    },
+                    "VALUE-1": {
+                      "block": {
+                        "type": "AppendToArray",
+                        "id": "xbP[,SN@q0?-|,dw(;W#",
+                        "inputs": {
+                          "VALUE-0": {
+                            "block": {
+                              "type": "GetVariable",
+                              "id": "hPiLJJFb8#m:7`b1S%+-",
+                              "inputs": {
+                                "VALUE-0": {
+                                  "block": {
+                                    "type": "variableReferenceBlock",
+                                    "id": "V8XE|}@8/ZNNG@)NFCNc",
+                                    "extraState": {
+                                      "isObjectVar": false
+                                    },
+                                    "fields": {
+                                      "OBJECTTYPE": "Global",
+                                      "VAR": {
+                                        "id": ":dwZCT8I?YI$xG8BBgpE"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "VALUE-1": {
+                            "block": {
+                              "type": "PrimaryWeaponsItem",
+                              "id": "4M7qnqp}U`M5PNaCWXsr",
+                              "fields": {
+                                "VALUE-0": "PrimaryWeaponsKingston",
+                                "VALUE-1": "SLX Spear"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "next": {
+                    "block": {
+                      "type": "SetVariable",
+                      "id": "hy/W56X[R2MF8F!XNF?j",
+                      "inputs": {
+                        "VALUE-0": {
+                          "block": {
+                            "type": "variableReferenceBlock",
+                            "id": "Hb5*jgcIYz;$StO:Tky)",
+                            "extraState": {
+                              "isObjectVar": false
+                            },
+                            "fields": {
+                              "OBJECTTYPE": "Global",
+                              "VAR": {
+                                "id": ":dwZCT8I?YI$xG8BBgpE"
+                              }
+                            }
+                          }
+                        },
+                        "VALUE-1": {
+                          "block": {
+                            "type": "AppendToArray",
+                            "id": "K|2_CXUtFCVET@cOoLWj",
+                            "inputs": {
+                              "VALUE-0": {
+                                "block": {
+                                  "type": "GetVariable",
+                                  "id": "hg{U%*X+N*!6?Jhs!Y:5",
+                                  "inputs": {
+                                    "VALUE-0": {
+                                      "block": {
+                                        "type": "variableReferenceBlock",
+                                        "id": "Za1:1sb7gtgFs85fEJkE",
+                                        "extraState": {
+                                          "isObjectVar": false
+                                        },
+                                        "fields": {
+                                          "OBJECTTYPE": "Global",
+                                          "VAR": {
+                                            "id": ":dwZCT8I?YI$xG8BBgpE"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "VALUE-1": {
+                                "block": {
+                                  "type": "PrimaryWeaponsItem",
+                                  "id": "1(*]^,oiSV4}YLh@`f8W",
+                                  "fields": {
+                                    "VALUE-0": "PrimaryWeaponsKingston",
+                                    "VALUE-1": "RM68"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "next": {
+                        "block": {
+                          "type": "SetVariable",
+                          "id": "vB_w#P.W/8]mVVB_P%Q5",
+                          "inputs": {
+                            "VALUE-0": {
+                              "block": {
+                                "type": "variableReferenceBlock",
+                                "id": "s,Ym=i#F1@4Ak!X/pLuF",
+                                "extraState": {
+                                  "isObjectVar": false
+                                },
+                                "fields": {
+                                  "OBJECTTYPE": "Global",
+                                  "VAR": {
+                                    "id": ":dwZCT8I?YI$xG8BBgpE"
+                                  }
+                                }
+                              }
+                            },
+                            "VALUE-1": {
+                              "block": {
+                                "type": "AppendToArray",
+                                "id": "3`o%iDCSE/QAuq9Ql0}x",
+                                "inputs": {
+                                  "VALUE-0": {
+                                    "block": {
+                                      "type": "GetVariable",
+                                      "id": "!GV}0^UfZG4VDY$z0;]d",
+                                      "inputs": {
+                                        "VALUE-0": {
+                                          "block": {
+                                            "type": "variableReferenceBlock",
+                                            "id": "XT`a8*I!I@eMQrZC-/J2",
+                                            "extraState": {
+                                              "isObjectVar": false
+                                            },
+                                            "fields": {
+                                              "OBJECTTYPE": "Global",
+                                              "VAR": {
+                                                "id": ":dwZCT8I?YI$xG8BBgpE"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "VALUE-1": {
+                                    "block": {
+                                      "type": "PrimaryWeaponsItem",
+                                      "id": "LpN?xQju*hcn%i7~Z(Wr",
+                                      "fields": {
+                                        "VALUE-0": "PrimaryWeaponsKingston",
+                                        "VALUE-1": "G36C"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "next": {
+                            "block": {
+                              "type": "SetVariable",
+                              "id": "$1_Xu$I98GedtrH*NbkG",
+                              "inputs": {
+                                "VALUE-0": {
+                                  "block": {
+                                    "type": "variableReferenceBlock",
+                                    "id": "cuUoY+kvQk7N)3kZ#P8]",
+                                    "extraState": {
+                                      "isObjectVar": false
+                                    },
+                                    "fields": {
+                                      "OBJECTTYPE": "Global",
+                                      "VAR": {
+                                        "id": ":dwZCT8I?YI$xG8BBgpE"
+                                      }
+                                    }
+                                  }
+                                },
+                                "VALUE-1": {
+                                  "block": {
+                                    "type": "AppendToArray",
+                                    "id": "^X3,//17+:Vpw#KYF?N(",
+                                    "inputs": {
+                                      "VALUE-0": {
+                                        "block": {
+                                          "type": "GetVariable",
+                                          "id": "f0:CIkoq;xrVmSR)P//@",
+                                          "inputs": {
+                                            "VALUE-0": {
+                                              "block": {
+                                                "type": "variableReferenceBlock",
+                                                "id": "k]ZWbD2c-lr[UYR-(SHQ",
+                                                "extraState": {
+                                                  "isObjectVar": false
+                                                },
+                                                "fields": {
+                                                  "OBJECTTYPE": "Global",
+                                                  "VAR": {
+                                                    "id": ":dwZCT8I?YI$xG8BBgpE"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "VALUE-1": {
+                                        "block": {
+                                          "type": "PrimaryWeaponsItem",
+                                          "id": "J*$*]m)Rzk0v9l16PeTz",
+                                          "fields": {
+                                            "VALUE-0": "PrimaryWeaponsKingston",
+                                            "VALUE-1": "SCAR MK17"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "next": {
+                                "block": {
+                                  "type": "SetVariable",
+                                  "id": "elsP!FAcnUP@X.X0fS_s",
+                                  "inputs": {
+                                    "VALUE-0": {
+                                      "block": {
+                                        "type": "variableReferenceBlock",
+                                        "id": "VT])uW:kr!Rm-tdkbw#6",
+                                        "extraState": {
+                                          "isObjectVar": false
+                                        },
+                                        "fields": {
+                                          "OBJECTTYPE": "Global",
+                                          "VAR": {
+                                            "id": ":dwZCT8I?YI$xG8BBgpE"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "VALUE-1": {
+                                      "block": {
+                                        "type": "AppendToArray",
+                                        "id": "#[o,mzoGYF.-LKzyG:NE",
+                                        "inputs": {
+                                          "VALUE-0": {
+                                            "block": {
+                                              "type": "GetVariable",
+                                              "id": "s[WpbY~.CeHkf/JRURhz",
+                                              "inputs": {
+                                                "VALUE-0": {
+                                                  "block": {
+                                                    "type": "variableReferenceBlock",
+                                                    "id": ":lq5V0w4X8Z#nU_G@7R]",
+                                                    "extraState": {
+                                                      "isObjectVar": false
+                                                    },
+                                                    "fields": {
+                                                      "OBJECTTYPE": "Global",
+                                                      "VAR": {
+                                                        "id": ":dwZCT8I?YI$xG8BBgpE"
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          },
+                                          "VALUE-1": {
+                                            "block": {
+                                              "type": "GetVariable",
+                                              "id": "G_=jUg,wOv|;;$k0!7_X",
+                                              "inputs": {
+                                                "VALUE-0": {
+                                                  "block": {
+                                                    "type": "variableReferenceBlock",
+                                                    "id": "lp}s|q5$])a#fj5-9k2H",
+                                                    "extraState": {
+                                                      "isObjectVar": false
+                                                    },
+                                                    "fields": {
+                                                      "OBJECTTYPE": "Global",
+                                                      "VAR": {
+                                                        "id": "TZz#$wkTy%Zew*~8x`il"
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "subroutineBlock",
+        "id": "2-{f.E7yu|9/+1DJ0!N[",
+        "x": 5932,
+        "y": 11828,
+        "extraState": {
+          "subroutineName": "Medic_Primary",
+          "parameters": []
+        },
+        "fields": {
+          "SUBROUTINE_NAME": "Medic_Primary"
+        },
+        "inputs": {
+          "ACTIONS": {
+            "block": {
+              "type": "SetVariable",
+              "id": ",$rdN9fxKx:y*3G+}NJ#",
+              "inputs": {
+                "VALUE-0": {
+                  "block": {
+                    "type": "variableReferenceBlock",
+                    "id": "Wg7Y3c##x=h-9{j+`M-3",
+                    "extraState": {
+                      "isObjectVar": false
+                    },
+                    "fields": {
+                      "OBJECTTYPE": "Global",
+                      "VAR": {
+                        "id": "8KZJUhdwv+ncikdh;V-P"
+                      }
+                    }
+                  }
+                },
+                "VALUE-1": {
+                  "block": {
+                    "type": "EmptyArray",
+                    "id": "jbFH,F+T.~-}i58mr[}I"
+                  }
+                }
+              },
+              "next": {
+                "block": {
+                  "type": "SetVariable",
+                  "id": "ZKlgnLZH1U(4NrK0U$g8",
+                  "inputs": {
+                    "VALUE-0": {
+                      "block": {
+                        "type": "variableReferenceBlock",
+                        "id": "MCR#$1hmLzOuLpO{YL$h",
+                        "extraState": {
+                          "isObjectVar": false
+                        },
+                        "fields": {
+                          "OBJECTTYPE": "Global",
+                          "VAR": {
+                            "id": "8KZJUhdwv+ncikdh;V-P"
+                          }
+                        }
+                      }
+                    },
+                    "VALUE-1": {
+                      "block": {
+                        "type": "AppendToArray",
+                        "id": "azMCX3_c+~F^j4}9w$Y}",
+                        "inputs": {
+                          "VALUE-0": {
+                            "block": {
+                              "type": "GetVariable",
+                              "id": "c(2dqn5fJ1%%Y`HK|(a8",
+                              "inputs": {
+                                "VALUE-0": {
+                                  "block": {
+                                    "type": "variableReferenceBlock",
+                                    "id": "^9)|=UK3L`/_0{5TW`(C",
+                                    "extraState": {
+                                      "isObjectVar": false
+                                    },
+                                    "fields": {
+                                      "OBJECTTYPE": "Global",
+                                      "VAR": {
+                                        "id": "8KZJUhdwv+ncikdh;V-P"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "VALUE-1": {
+                            "block": {
+                              "type": "PrimaryWeaponsItem",
+                              "id": "`K%@EH-(65sPwc07c)Yi",
+                              "fields": {
+                                "VALUE-0": "PrimaryWeaponsKingston",
+                                "VALUE-1": "KrissVector"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "next": {
+                    "block": {
+                      "type": "SetVariable",
+                      "id": "{GS8/*/4{CPa+YS|BOUn",
+                      "inputs": {
+                        "VALUE-0": {
+                          "block": {
+                            "type": "variableReferenceBlock",
+                            "id": "wunvZT6s2]r]#bc*w5z=",
+                            "extraState": {
+                              "isObjectVar": false
+                            },
+                            "fields": {
+                              "OBJECTTYPE": "Global",
+                              "VAR": {
+                                "id": "8KZJUhdwv+ncikdh;V-P"
+                              }
+                            }
+                          }
+                        },
+                        "VALUE-1": {
+                          "block": {
+                            "type": "AppendToArray",
+                            "id": "M?I2OP={Pt.H|T-.d#8_",
+                            "inputs": {
+                              "VALUE-0": {
+                                "block": {
+                                  "type": "GetVariable",
+                                  "id": "XKI{m[%tbe-z_=IMD.[U",
+                                  "inputs": {
+                                    "VALUE-0": {
+                                      "block": {
+                                        "type": "variableReferenceBlock",
+                                        "id": "KN??yDU;3[yCUl$Z|H@k",
+                                        "extraState": {
+                                          "isObjectVar": false
+                                        },
+                                        "fields": {
+                                          "OBJECTTYPE": "Global",
+                                          "VAR": {
+                                            "id": "8KZJUhdwv+ncikdh;V-P"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "VALUE-1": {
+                                "block": {
+                                  "type": "PrimaryWeaponsItem",
+                                  "id": "ra%3s3C06n{bQ5RK9j9a",
+                                  "fields": {
+                                    "VALUE-0": "PrimaryWeaponsKingston",
+                                    "VALUE-1": "PP2000"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "next": {
+                        "block": {
+                          "type": "SetVariable",
+                          "id": "}*P:V=cu9G?Ax-6DyP-m",
+                          "inputs": {
+                            "VALUE-0": {
+                              "block": {
+                                "type": "variableReferenceBlock",
+                                "id": "QlN-A3itRL]SCP|qf@|O",
+                                "extraState": {
+                                  "isObjectVar": false
+                                },
+                                "fields": {
+                                  "OBJECTTYPE": "Global",
+                                  "VAR": {
+                                    "id": "8KZJUhdwv+ncikdh;V-P"
+                                  }
+                                }
+                              }
+                            },
+                            "VALUE-1": {
+                              "block": {
+                                "type": "AppendToArray",
+                                "id": ")$S02mrG68CTSWx7|~P_",
+                                "inputs": {
+                                  "VALUE-0": {
+                                    "block": {
+                                      "type": "GetVariable",
+                                      "id": "#[4wXO1dS9c1M|fWdXn{",
+                                      "inputs": {
+                                        "VALUE-0": {
+                                          "block": {
+                                            "type": "variableReferenceBlock",
+                                            "id": "P]QYZE[[4i9:O4dB)u6o",
+                                            "extraState": {
+                                              "isObjectVar": false
+                                            },
+                                            "fields": {
+                                              "OBJECTTYPE": "Global",
+                                              "VAR": {
+                                                "id": "8KZJUhdwv+ncikdh;V-P"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "VALUE-1": {
+                                    "block": {
+                                      "type": "PrimaryWeaponsItem",
+                                      "id": "nZ#Y/v1Lj,|Yx25z}xeV",
+                                      "fields": {
+                                        "VALUE-0": "PrimaryWeaponsKingston",
+                                        "VALUE-1": "SMG45"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "next": {
+                            "block": {
+                              "type": "SetVariable",
+                              "id": "nEQCvZH:R_(l`p[ZoxhE",
+                              "inputs": {
+                                "VALUE-0": {
+                                  "block": {
+                                    "type": "variableReferenceBlock",
+                                    "id": "`/U}blS,O#:LF[q)40C]",
+                                    "extraState": {
+                                      "isObjectVar": false
+                                    },
+                                    "fields": {
+                                      "OBJECTTYPE": "Global",
+                                      "VAR": {
+                                        "id": "8KZJUhdwv+ncikdh;V-P"
+                                      }
+                                    }
+                                  }
+                                },
+                                "VALUE-1": {
+                                  "block": {
+                                    "type": "AppendToArray",
+                                    "id": "G)bNgFwWEJ)8-|T3P]3q",
+                                    "inputs": {
+                                      "VALUE-0": {
+                                        "block": {
+                                          "type": "GetVariable",
+                                          "id": "NN*F.x#$r0yt@(u$|eLa",
+                                          "inputs": {
+                                            "VALUE-0": {
+                                              "block": {
+                                                "type": "variableReferenceBlock",
+                                                "id": "8ucu4_hn2NfH,oGj?K63",
+                                                "extraState": {
+                                                  "isObjectVar": false
+                                                },
+                                                "fields": {
+                                                  "OBJECTTYPE": "Global",
+                                                  "VAR": {
+                                                    "id": "8KZJUhdwv+ncikdh;V-P"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "VALUE-1": {
+                                        "block": {
+                                          "type": "PrimaryWeaponsItem",
+                                          "id": "TIK2f%n?1MS6pCX!s{#]",
+                                          "fields": {
+                                            "VALUE-0": "PrimaryWeaponsKingston",
+                                            "VALUE-1": "SMG45"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "next": {
+                                "block": {
+                                  "type": "SetVariable",
+                                  "id": "Q_G3+5RSb8qiDp;de/c#",
+                                  "inputs": {
+                                    "VALUE-0": {
+                                      "block": {
+                                        "type": "variableReferenceBlock",
+                                        "id": "ZmF+P|Ra)+YzL_8K}}r$",
+                                        "extraState": {
+                                          "isObjectVar": false
+                                        },
+                                        "fields": {
+                                          "OBJECTTYPE": "Global",
+                                          "VAR": {
+                                            "id": "8KZJUhdwv+ncikdh;V-P"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "VALUE-1": {
+                                      "block": {
+                                        "type": "AppendToArray",
+                                        "id": "2~00)]?/q,$jT`jY4oZ8",
+                                        "inputs": {
+                                          "VALUE-0": {
+                                            "block": {
+                                              "type": "GetVariable",
+                                              "id": "%Gf?zX=|y+0YineZl3(%",
+                                              "inputs": {
+                                                "VALUE-0": {
+                                                  "block": {
+                                                    "type": "variableReferenceBlock",
+                                                    "id": "JrewF=^~/3w)A;=1g!.Y",
+                                                    "extraState": {
+                                                      "isObjectVar": false
+                                                    },
+                                                    "fields": {
+                                                      "OBJECTTYPE": "Global",
+                                                      "VAR": {
+                                                        "id": "8KZJUhdwv+ncikdh;V-P"
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          },
+                                          "VALUE-1": {
+                                            "block": {
+                                              "type": "GetVariable",
+                                              "id": "U#8;n))%r5}4dV82vM(]",
+                                              "inputs": {
+                                                "VALUE-0": {
+                                                  "block": {
+                                                    "type": "variableReferenceBlock",
+                                                    "id": "uK7(Lf0JYk=,]me7nWF;",
+                                                    "extraState": {
+                                                      "isObjectVar": false
+                                                    },
+                                                    "fields": {
+                                                      "OBJECTTYPE": "Global",
+                                                      "VAR": {
+                                                        "id": "TZz#$wkTy%Zew*~8x`il"
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "subroutineBlock",
+        "id": "4nPxaR?th]loBN!/E7#E",
+        "x": 5933,
+        "y": 12406,
+        "extraState": {
+          "subroutineName": "Engineer_Primary",
+          "parameters": []
+        },
+        "fields": {
+          "SUBROUTINE_NAME": "Engineer_Primary"
+        },
+        "inputs": {
+          "ACTIONS": {
+            "block": {
+              "type": "SetVariable",
+              "id": "hA-zzJPfo`sZ%71xe*0;",
+              "inputs": {
+                "VALUE-0": {
+                  "block": {
+                    "type": "variableReferenceBlock",
+                    "id": "LKjQ:5MOxkHxTUrbZTa0",
+                    "extraState": {
+                      "isObjectVar": false
+                    },
+                    "fields": {
+                      "OBJECTTYPE": "Global",
+                      "VAR": {
+                        "id": "D_bDj446*hh;jK)W,t~:"
+                      }
+                    }
+                  }
+                },
+                "VALUE-1": {
+                  "block": {
+                    "type": "EmptyArray",
+                    "id": "+W!Mmp7@woiit,*~CS78"
+                  }
+                }
+              },
+              "next": {
+                "block": {
+                  "type": "SetVariable",
+                  "id": "PwpIKbO9+AZAu4}Eh_s?",
+                  "inputs": {
+                    "VALUE-0": {
+                      "block": {
+                        "type": "variableReferenceBlock",
+                        "id": "s^0]vRjEW+@~rqEMa2Fq",
+                        "extraState": {
+                          "isObjectVar": false
+                        },
+                        "fields": {
+                          "OBJECTTYPE": "Global",
+                          "VAR": {
+                            "id": "D_bDj446*hh;jK)W,t~:"
+                          }
+                        }
+                      }
+                    },
+                    "VALUE-1": {
+                      "block": {
+                        "type": "AppendToArray",
+                        "id": "FCf*R16mf}ns!-[Oe3Mw",
+                        "inputs": {
+                          "VALUE-0": {
+                            "block": {
+                              "type": "GetVariable",
+                              "id": "##XpDzpc~)/vVoI?Pa=6",
+                              "inputs": {
+                                "VALUE-0": {
+                                  "block": {
+                                    "type": "variableReferenceBlock",
+                                    "id": "?~L6z?SdLy_;}xS%24m:",
+                                    "extraState": {
+                                      "isObjectVar": false
+                                    },
+                                    "fields": {
+                                      "OBJECTTYPE": "Global",
+                                      "VAR": {
+                                        "id": "D_bDj446*hh;jK)W,t~:"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "VALUE-1": {
+                            "block": {
+                              "type": "PrimaryWeaponsItem",
+                              "id": "=r`{NpeUaba4UWk2{+4L",
+                              "fields": {
+                                "VALUE-0": "PrimaryWeaponsKingston",
+                                "VALUE-1": "RPT-31"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "next": {
+                    "block": {
+                      "type": "SetVariable",
+                      "id": "jA4CFeB#uS@l5,l~6}?=",
+                      "inputs": {
+                        "VALUE-0": {
+                          "block": {
+                            "type": "variableReferenceBlock",
+                            "id": "]cJIfufCHdrQR7?T010.",
+                            "extraState": {
+                              "isObjectVar": false
+                            },
+                            "fields": {
+                              "OBJECTTYPE": "Global",
+                              "VAR": {
+                                "id": "D_bDj446*hh;jK)W,t~:"
+                              }
+                            }
+                          }
+                        },
+                        "VALUE-1": {
+                          "block": {
+                            "type": "AppendToArray",
+                            "id": "N90iK:j-3-%zMx1^(-ne",
+                            "inputs": {
+                              "VALUE-0": {
+                                "block": {
+                                  "type": "GetVariable",
+                                  "id": "zrS]|k)5u).]vl:p5Y5:",
+                                  "inputs": {
+                                    "VALUE-0": {
+                                      "block": {
+                                        "type": "variableReferenceBlock",
+                                        "id": ".UfF[_W~6;%C1KXXHc*7",
+                                        "extraState": {
+                                          "isObjectVar": false
+                                        },
+                                        "fields": {
+                                          "OBJECTTYPE": "Global",
+                                          "VAR": {
+                                            "id": "D_bDj446*hh;jK)W,t~:"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "VALUE-1": {
+                                "block": {
+                                  "type": "PrimaryWeaponsItem",
+                                  "id": "^*DA^:=V56Oe!8g}|[EB",
+                                  "fields": {
+                                    "VALUE-0": "PrimaryWeaponsKingston",
+                                    "VALUE-1": "FN-Evolys"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "next": {
+                        "block": {
+                          "type": "SetVariable",
+                          "id": "9X04xiy_6l)9NZgbL/SW",
+                          "inputs": {
+                            "VALUE-0": {
+                              "block": {
+                                "type": "variableReferenceBlock",
+                                "id": "_6S^SW(b?]R/)1e*ERak",
+                                "extraState": {
+                                  "isObjectVar": false
+                                },
+                                "fields": {
+                                  "OBJECTTYPE": "Global",
+                                  "VAR": {
+                                    "id": "D_bDj446*hh;jK)W,t~:"
+                                  }
+                                }
+                              }
+                            },
+                            "VALUE-1": {
+                              "block": {
+                                "type": "AppendToArray",
+                                "id": "Lsq(q;1]p1e|JL,S;Oo,",
+                                "inputs": {
+                                  "VALUE-0": {
+                                    "block": {
+                                      "type": "GetVariable",
+                                      "id": "|4T0L/a).d~}_PB;o@F=",
+                                      "inputs": {
+                                        "VALUE-0": {
+                                          "block": {
+                                            "type": "variableReferenceBlock",
+                                            "id": "k]8e]{f}uC^xh7?JyyM:",
+                                            "extraState": {
+                                              "isObjectVar": false
+                                            },
+                                            "fields": {
+                                              "OBJECTTYPE": "Global",
+                                              "VAR": {
+                                                "id": "D_bDj446*hh;jK)W,t~:"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "VALUE-1": {
+                                    "block": {
+                                      "type": "PrimaryWeaponsItem",
+                                      "id": "5{cf;$R[5n~n*vN}o]m]",
+                                      "fields": {
+                                        "VALUE-0": "PrimaryWeaponsKingston",
+                                        "VALUE-1": "RPK"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "next": {
+                            "block": {
+                              "type": "SetVariable",
+                              "id": "X?eG{N5Ti$vw4lL%bds+",
+                              "inputs": {
+                                "VALUE-0": {
+                                  "block": {
+                                    "type": "variableReferenceBlock",
+                                    "id": "Y#p$b9D}%*#7#OX.2Y,;",
+                                    "extraState": {
+                                      "isObjectVar": false
+                                    },
+                                    "fields": {
+                                      "OBJECTTYPE": "Global",
+                                      "VAR": {
+                                        "id": "D_bDj446*hh;jK)W,t~:"
+                                      }
+                                    }
+                                  }
+                                },
+                                "VALUE-1": {
+                                  "block": {
+                                    "type": "AppendToArray",
+                                    "id": "o)]hjhb,F7Pu0[Uj~i$I",
+                                    "inputs": {
+                                      "VALUE-0": {
+                                        "block": {
+                                          "type": "GetVariable",
+                                          "id": "^~z-JT6Gb8E:Ex#mQUO=",
+                                          "inputs": {
+                                            "VALUE-0": {
+                                              "block": {
+                                                "type": "variableReferenceBlock",
+                                                "id": "`nqDS=aWaeS*a_5*;mpG",
+                                                "extraState": {
+                                                  "isObjectVar": false
+                                                },
+                                                "fields": {
+                                                  "OBJECTTYPE": "Global",
+                                                  "VAR": {
+                                                    "id": "D_bDj446*hh;jK)W,t~:"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "VALUE-1": {
+                                        "block": {
+                                          "type": "GetVariable",
+                                          "id": "IKIyDx2dj7Kv@16[cj*S",
+                                          "inputs": {
+                                            "VALUE-0": {
+                                              "block": {
+                                                "type": "variableReferenceBlock",
+                                                "id": "3W!+JHoj,kdR0rV`AL,_",
+                                                "extraState": {
+                                                  "isObjectVar": false
+                                                },
+                                                "fields": {
+                                                  "OBJECTTYPE": "Global",
+                                                  "VAR": {
+                                                    "id": "TZz#$wkTy%Zew*~8x`il"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "subroutineBlock",
+        "id": "?zI;7GFxn]r5;6frrJ#d",
+        "x": 5935,
+        "y": 12915,
+        "extraState": {
+          "subroutineName": "Scout_Primary",
+          "parameters": []
+        },
+        "fields": {
+          "SUBROUTINE_NAME": "Scout_Primary"
+        },
+        "inputs": {
+          "ACTIONS": {
+            "block": {
+              "type": "SetVariable",
+              "id": "[:fU%Hh!N2M*};mCk9Q/",
+              "inputs": {
+                "VALUE-0": {
+                  "block": {
+                    "type": "variableReferenceBlock",
+                    "id": "HvuZXVjRPcMhMm}sw?!K",
+                    "extraState": {
+                      "isObjectVar": false
+                    },
+                    "fields": {
+                      "OBJECTTYPE": "Global",
+                      "VAR": {
+                        "id": "m$B!wjne^r^hL]4q--Ll"
+                      }
+                    }
+                  }
+                },
+                "VALUE-1": {
+                  "block": {
+                    "type": "EmptyArray",
+                    "id": "cUwO+lZDxZ1W_pf*dk:c"
+                  }
+                }
+              },
+              "next": {
+                "block": {
+                  "type": "SetVariable",
+                  "id": "(7Et]H)~7!^*DGeFWb*`",
+                  "inputs": {
+                    "VALUE-0": {
+                      "block": {
+                        "type": "variableReferenceBlock",
+                        "id": "q5@2cVQLn_SgTkH6?]iZ",
+                        "extraState": {
+                          "isObjectVar": false
+                        },
+                        "fields": {
+                          "OBJECTTYPE": "Global",
+                          "VAR": {
+                            "id": "m$B!wjne^r^hL]4q--Ll"
+                          }
+                        }
+                      }
+                    },
+                    "VALUE-1": {
+                      "block": {
+                        "type": "AppendToArray",
+                        "id": "fu[8Y?,jIf=jc5p6(X0P",
+                        "inputs": {
+                          "VALUE-0": {
+                            "block": {
+                              "type": "GetVariable",
+                              "id": ".UH-aCvtITiH7]B~PN|K",
+                              "inputs": {
+                                "VALUE-0": {
+                                  "block": {
+                                    "type": "variableReferenceBlock",
+                                    "id": "+JakeP8m=hYEDfBh{dJf",
+                                    "extraState": {
+                                      "isObjectVar": false
+                                    },
+                                    "fields": {
+                                      "OBJECTTYPE": "Global",
+                                      "VAR": {
+                                        "id": "m$B!wjne^r^hL]4q--Ll"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "VALUE-1": {
+                            "block": {
+                              "type": "PrimaryWeaponsItem",
+                              "id": "DWRmC)9CVu8EH~~c@CV]",
+                              "fields": {
+                                "VALUE-0": "PrimaryWeaponsKingston",
+                                "VALUE-1": "DSR1"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "next": {
+                    "block": {
+                      "type": "SetVariable",
+                      "id": "Tyh:yPH9Ys8EXzB}p}I:",
+                      "inputs": {
+                        "VALUE-0": {
+                          "block": {
+                            "type": "variableReferenceBlock",
+                            "id": "yigC|fmhN%SL+cn-aHmW",
+                            "extraState": {
+                              "isObjectVar": false
+                            },
+                            "fields": {
+                              "OBJECTTYPE": "Global",
+                              "VAR": {
+                                "id": "m$B!wjne^r^hL]4q--Ll"
+                              }
+                            }
+                          }
+                        },
+                        "VALUE-1": {
+                          "block": {
+                            "type": "AppendToArray",
+                            "id": "v?+{p*aBn18=19XPT$Ie",
+                            "inputs": {
+                              "VALUE-0": {
+                                "block": {
+                                  "type": "GetVariable",
+                                  "id": "|?+*_M-:H^~reA0kP^[+",
+                                  "inputs": {
+                                    "VALUE-0": {
+                                      "block": {
+                                        "type": "variableReferenceBlock",
+                                        "id": "UUSpjEpG(G_%u?%*-0pI",
+                                        "extraState": {
+                                          "isObjectVar": false
+                                        },
+                                        "fields": {
+                                          "OBJECTTYPE": "Global",
+                                          "VAR": {
+                                            "id": "m$B!wjne^r^hL]4q--Ll"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "VALUE-1": {
+                                "block": {
+                                  "type": "PrimaryWeaponsItem",
+                                  "id": "muisVa!Q$5KGtK?#Ng#Z",
+                                  "fields": {
+                                    "VALUE-0": "PrimaryWeaponsKingston",
+                                    "VALUE-1": "TRGM10"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "next": {
+                        "block": {
+                          "type": "SetVariable",
+                          "id": "4~[{nO4h7}o?)q_Nnp*v",
+                          "inputs": {
+                            "VALUE-0": {
+                              "block": {
+                                "type": "variableReferenceBlock",
+                                "id": "*0D{lNFIcbHmMEucdiR`",
+                                "extraState": {
+                                  "isObjectVar": false
+                                },
+                                "fields": {
+                                  "OBJECTTYPE": "Global",
+                                  "VAR": {
+                                    "id": "m$B!wjne^r^hL]4q--Ll"
+                                  }
+                                }
+                              }
+                            },
+                            "VALUE-1": {
+                              "block": {
+                                "type": "AppendToArray",
+                                "id": ",HWR/d#-WadPW^wu*c%{",
+                                "inputs": {
+                                  "VALUE-0": {
+                                    "block": {
+                                      "type": "GetVariable",
+                                      "id": "BibDZ@GLtYDq{95-GQ%4",
+                                      "inputs": {
+                                        "VALUE-0": {
+                                          "block": {
+                                            "type": "variableReferenceBlock",
+                                            "id": "vP|Af{fLkdTz`VgJw8MJ",
+                                            "extraState": {
+                                              "isObjectVar": false
+                                            },
+                                            "fields": {
+                                              "OBJECTTYPE": "Global",
+                                              "VAR": {
+                                                "id": "m$B!wjne^r^hL]4q--Ll"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "VALUE-1": {
+                                    "block": {
+                                      "type": "PrimaryWeaponsItem",
+                                      "id": ",`{6rReQ=w$S_HM;$}qM",
+                                      "fields": {
+                                        "VALUE-0": "PrimaryWeaponsKingston",
+                                        "VALUE-1": "GOL"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "next": {
+                            "block": {
+                              "type": "SetVariable",
+                              "id": ":x-E;}r`d4|_B)BGar:x",
+                              "inputs": {
+                                "VALUE-0": {
+                                  "block": {
+                                    "type": "variableReferenceBlock",
+                                    "id": "F6,3i7SQV:mu1y*qKIcs",
+                                    "extraState": {
+                                      "isObjectVar": false
+                                    },
+                                    "fields": {
+                                      "OBJECTTYPE": "Global",
+                                      "VAR": {
+                                        "id": "m$B!wjne^r^hL]4q--Ll"
+                                      }
+                                    }
+                                  }
+                                },
+                                "VALUE-1": {
+                                  "block": {
+                                    "type": "AppendToArray",
+                                    "id": "3TZ{.GwKQ4A:m[!3zYFv",
+                                    "inputs": {
+                                      "VALUE-0": {
+                                        "block": {
+                                          "type": "GetVariable",
+                                          "id": "*05wfc;n]`0V%gcSNkn|",
+                                          "inputs": {
+                                            "VALUE-0": {
+                                              "block": {
+                                                "type": "variableReferenceBlock",
+                                                "id": "4`Oihow4i|WkXcY{?XCR",
+                                                "extraState": {
+                                                  "isObjectVar": false
+                                                },
+                                                "fields": {
+                                                  "OBJECTTYPE": "Global",
+                                                  "VAR": {
+                                                    "id": "m$B!wjne^r^hL]4q--Ll"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "VALUE-1": {
+                                        "block": {
+                                          "type": "GetVariable",
+                                          "id": "$M}$*u)DR4)#T:mfG2vI",
+                                          "inputs": {
+                                            "VALUE-0": {
+                                              "block": {
+                                                "type": "variableReferenceBlock",
+                                                "id": "@2i7TY69D55rHqY#k~o^",
+                                                "extraState": {
+                                                  "isObjectVar": false
+                                                },
+                                                "fields": {
+                                                  "OBJECTTYPE": "Global",
+                                                  "VAR": {
+                                                    "id": "TZz#$wkTy%Zew*~8x`il"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "subroutineBlock",
+        "id": "4AN?(vA7vci{#W{v6E3X",
+        "x": 5935,
+        "y": 13430,
+        "extraState": {
+          "subroutineName": "Other_Primary",
+          "parameters": []
+        },
+        "fields": {
+          "SUBROUTINE_NAME": "Other_Primary"
+        },
+        "inputs": {
+          "ACTIONS": {
+            "block": {
+              "type": "SetVariable",
+              "id": "1305RJ1^FrI5#rzr.vv2",
+              "inputs": {
+                "VALUE-0": {
+                  "block": {
+                    "type": "variableReferenceBlock",
+                    "id": "d=K3vf[]3sH%5E7$l(bN",
+                    "extraState": {
+                      "isObjectVar": false
+                    },
+                    "fields": {
+                      "OBJECTTYPE": "Global",
+                      "VAR": {
+                        "id": "TZz#$wkTy%Zew*~8x`il"
+                      }
+                    }
+                  }
+                },
+                "VALUE-1": {
+                  "block": {
+                    "type": "EmptyArray",
+                    "id": "YW1Uqa!f.F@aY/g8%SQk"
+                  }
+                }
+              },
+              "next": {
+                "block": {
+                  "type": "SetVariable",
+                  "id": "(/{M1M]ogH~`4G5EOQg!",
+                  "inputs": {
+                    "VALUE-0": {
+                      "block": {
+                        "type": "variableReferenceBlock",
+                        "id": "slok%*|Sg*EGaSdUHe/h",
+                        "extraState": {
+                          "isObjectVar": false
+                        },
+                        "fields": {
+                          "OBJECTTYPE": "Global",
+                          "VAR": {
+                            "id": "TZz#$wkTy%Zew*~8x`il"
+                          }
+                        }
+                      }
+                    },
+                    "VALUE-1": {
+                      "block": {
+                        "type": "AppendToArray",
+                        "id": "W*wF[8tef?NA8q-^i-Ry",
+                        "inputs": {
+                          "VALUE-0": {
+                            "block": {
+                              "type": "GetVariable",
+                              "id": "TKOXe/~tsyOqHeT1a~oX",
+                              "inputs": {
+                                "VALUE-0": {
+                                  "block": {
+                                    "type": "variableReferenceBlock",
+                                    "id": "z@S]]ayPz5`]0_CiLW0.",
+                                    "extraState": {
+                                      "isObjectVar": false
+                                    },
+                                    "fields": {
+                                      "OBJECTTYPE": "Global",
+                                      "VAR": {
+                                        "id": "TZz#$wkTy%Zew*~8x`il"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "VALUE-1": {
+                            "block": {
+                              "type": "PrimaryWeaponsItem",
+                              "id": "=-dUa_#L1Att.jL8:agm",
+                              "fields": {
+                                "VALUE-0": "PrimaryWeaponsKingston",
+                                "VALUE-1": "DDM4"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "next": {
+                    "block": {
+                      "type": "SetVariable",
+                      "id": "-k.]A.B)Aquz%J?([URP",
+                      "inputs": {
+                        "VALUE-0": {
+                          "block": {
+                            "type": "variableReferenceBlock",
+                            "id": "uuT!q.wT@G!7j|Z3}[K0",
+                            "extraState": {
+                              "isObjectVar": false
+                            },
+                            "fields": {
+                              "OBJECTTYPE": "Global",
+                              "VAR": {
+                                "id": "TZz#$wkTy%Zew*~8x`il"
+                              }
+                            }
+                          }
+                        },
+                        "VALUE-1": {
+                          "block": {
+                            "type": "AppendToArray",
+                            "id": "[2$h].)HX4@U%6NjWxgX",
+                            "inputs": {
+                              "VALUE-0": {
+                                "block": {
+                                  "type": "GetVariable",
+                                  "id": "ELiSS++GkUJ4|3X1$*2x",
+                                  "inputs": {
+                                    "VALUE-0": {
+                                      "block": {
+                                        "type": "variableReferenceBlock",
+                                        "id": "kzAscUDdX65kJsK?*;}/",
+                                        "extraState": {
+                                          "isObjectVar": false
+                                        },
+                                        "fields": {
+                                          "OBJECTTYPE": "Global",
+                                          "VAR": {
+                                            "id": "TZz#$wkTy%Zew*~8x`il"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "VALUE-1": {
+                                "block": {
+                                  "type": "PrimaryWeaponsItem",
+                                  "id": "-i.UApl*}I9ZxUa+.]]t",
+                                  "fields": {
+                                    "VALUE-0": "PrimaryWeaponsKingston",
+                                    "VALUE-1": "Chukavin"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "next": {
+                        "block": {
+                          "type": "SetVariable",
+                          "id": "DBt_(xuDrh^wN#l^l!lU",
+                          "inputs": {
+                            "VALUE-0": {
+                              "block": {
+                                "type": "variableReferenceBlock",
+                                "id": "QQ`w_2Nc{y8_Fd@LPk!+",
+                                "extraState": {
+                                  "isObjectVar": false
+                                },
+                                "fields": {
+                                  "OBJECTTYPE": "Global",
+                                  "VAR": {
+                                    "id": "TZz#$wkTy%Zew*~8x`il"
+                                  }
+                                }
+                              }
+                            },
+                            "VALUE-1": {
+                              "block": {
+                                "type": "AppendToArray",
+                                "id": "d]EH}AQ)ZHr[]Ate5mhy",
+                                "inputs": {
+                                  "VALUE-0": {
+                                    "block": {
+                                      "type": "GetVariable",
+                                      "id": "AYy5Dfz}k0${ax=WYobG",
+                                      "inputs": {
+                                        "VALUE-0": {
+                                          "block": {
+                                            "type": "variableReferenceBlock",
+                                            "id": "(2+(mw-dMu|p(c`},2r7",
+                                            "extraState": {
+                                              "isObjectVar": false
+                                            },
+                                            "fields": {
+                                              "OBJECTTYPE": "Global",
+                                              "VAR": {
+                                                "id": "TZz#$wkTy%Zew*~8x`il"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "VALUE-1": {
+                                    "block": {
+                                      "type": "PrimaryWeaponsItem",
+                                      "id": "pVs$$kC5%4dv=b0*@Yb{",
+                                      "fields": {
+                                        "VALUE-0": "PrimaryWeaponsKingston",
+                                        "VALUE-1": "Remington870"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "next": {
+                            "block": {
+                              "type": "SetVariable",
+                              "id": "%D95h5O-;K#CtgpL-eOe",
+                              "inputs": {
+                                "VALUE-0": {
+                                  "block": {
+                                    "type": "variableReferenceBlock",
+                                    "id": "]S}sJukJ**GcHPMz:!aJ",
+                                    "extraState": {
+                                      "isObjectVar": false
+                                    },
+                                    "fields": {
+                                      "OBJECTTYPE": "Global",
+                                      "VAR": {
+                                        "id": "TZz#$wkTy%Zew*~8x`il"
+                                      }
+                                    }
+                                  }
+                                },
+                                "VALUE-1": {
+                                  "block": {
+                                    "type": "AppendToArray",
+                                    "id": "!UO8ejwibI}St2wCK_cJ",
+                                    "inputs": {
+                                      "VALUE-0": {
+                                        "block": {
+                                          "type": "GetVariable",
+                                          "id": "C}Ly{11yNS9,xHrw$k8E",
+                                          "inputs": {
+                                            "VALUE-0": {
+                                              "block": {
+                                                "type": "variableReferenceBlock",
+                                                "id": "#jF2B:MB4Jw.J5Y%$5-*",
+                                                "extraState": {
+                                                  "isObjectVar": false
+                                                },
+                                                "fields": {
+                                                  "OBJECTTYPE": "Global",
+                                                  "VAR": {
+                                                    "id": "TZz#$wkTy%Zew*~8x`il"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "VALUE-1": {
+                                        "block": {
+                                          "type": "PrimaryWeaponsItem",
+                                          "id": "^H*jDu@o_-S#N~+[ri4G",
+                                          "fields": {
+                                            "VALUE-0": "PrimaryWeaponsKingston",
+                                            "VALUE-1": "Saiga12"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "subroutineBlock",
+        "id": "h(~~56z;j$LEOvJ@5)Rg",
+        "x": 3910,
+        "y": 13006,
+        "extraState": {
+          "subroutineName": "Replace",
+          "parameters": [
+            {
+              "types": "Enum_CharacterGadgets,Enum_ClassGadgets,Enum_PrimaryWeapons,Enum_SecondaryWeapons,Enum_OpenGadgets,Enum_Throwables,Enum_MeleeWeapons",
+              "name": "Inventory"
+            }
+          ]
+        },
+        "fields": {
+          "SUBROUTINE_NAME": "Replace"
+        },
+        "inputs": {
+          "ACTIONS": {
+            "block": {
+              "type": "AddSoldierWeapon",
+              "id": "vP^1|%QDu;](UHqNzX1v",
+              "inputs": {
+                "VALUE-0": {
+                  "block": {
+                    "type": "EventPlayer",
+                    "id": "9|Ap,M%Zc9sJ85kJ4Qj("
+                  }
+                },
+                "VALUE-1": {
+                  "block": {
+                    "type": "subroutineArgumentBlock",
+                    "id": "F9v=46R5Ew9eZ`a^zY0)",
+                    "fields": {
+                      "ARGUMENT_INDEX": "0"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "subroutineBlock",
+        "id": "FqqgLq@mfy3~RD=c6(Ij",
+        "x": 3908,
+        "y": 13306,
+        "extraState": {
+          "subroutineName": "Assault",
+          "parameters": []
+        },
+        "fields": {
+          "SUBROUTINE_NAME": "Assault"
+        },
+        "inputs": {
+          "ACTIONS": {
+            "block": {
+              "type": "subroutineInstanceBlock",
+              "id": "a}cNR-vv7|O`K:n0`HQE",
+              "extraState": {
+                "subroutineName": "Replace",
+                "parameters": [
+                  {
+                    "types": "Enum_CharacterGadgets,Enum_ClassGadgets,Enum_PrimaryWeapons,Enum_SecondaryWeapons,Enum_OpenGadgets,Enum_Throwables,Enum_MeleeWeapons",
+                    "name": "Inventory"
+                  }
+                ]
+              },
+              "fields": {
+                "SUBROUTINE_NAME": "Replace"
+              },
+              "inputs": {
+                "PARAM-0": {
+                  "block": {
+                    "type": "RandomValueInArray",
+                    "id": "#((-|mOB}+~!Wwt-wI$L",
+                    "inputs": {
+                      "VALUE-0": {
+                        "block": {
+                          "type": "GetVariable",
+                          "id": "EH$i_dT)JJU(p0Bt73*#",
+                          "inputs": {
+                            "VALUE-0": {
+                              "block": {
+                                "type": "variableReferenceBlock",
+                                "id": "4O^8#s.mfm34$Gu315_B",
+                                "extraState": {
+                                  "isObjectVar": false
+                                },
+                                "fields": {
+                                  "OBJECTTYPE": "Global",
+                                  "VAR": {
+                                    "id": ":dwZCT8I?YI$xG8BBgpE"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "subroutineBlock",
+        "id": ";s;kS5u_X;S@EJ4z,Kfa",
+        "x": 3912,
+        "y": 13817,
+        "extraState": {
+          "subroutineName": "Medic",
+          "parameters": []
+        },
+        "icons": {
+          "comment": {
+            "text": "BF3 Defib added so AI correctly revive",
+            "pinned": true,
+            "height": 51,
+            "width": 456
+          }
+        },
+        "fields": {
+          "SUBROUTINE_NAME": "Medic"
+        },
+        "inputs": {
+          "ACTIONS": {
+            "block": {
+              "type": "subroutineInstanceBlock",
+              "id": "p:V=Wab^+nRkLkL53U/@",
+              "extraState": {
+                "subroutineName": "Replace",
+                "parameters": [
+                  {
+                    "types": "Enum_CharacterGadgets,Enum_ClassGadgets,Enum_PrimaryWeapons,Enum_SecondaryWeapons,Enum_OpenGadgets,Enum_Throwables,Enum_MeleeWeapons",
+                    "name": "Inventory"
+                  }
+                ]
+              },
+              "fields": {
+                "SUBROUTINE_NAME": "Replace"
+              },
+              "inputs": {
+                "PARAM-0": {
+                  "block": {
+                    "type": "RandomValueInArray",
+                    "id": "?c)$-HksmAP]uOW_A|Ho",
+                    "inputs": {
+                      "VALUE-0": {
+                        "block": {
+                          "type": "GetVariable",
+                          "id": "T_j+;Vz#NB8?nvfL33s#",
+                          "inputs": {
+                            "VALUE-0": {
+                              "block": {
+                                "type": "variableReferenceBlock",
+                                "id": "Q?K6V:#^0S)oP6Of^5@Y",
+                                "extraState": {
+                                  "isObjectVar": false
+                                },
+                                "fields": {
+                                  "OBJECTTYPE": "Global",
+                                  "VAR": {
+                                    "id": "8KZJUhdwv+ncikdh;V-P"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "subroutineBlock",
+        "id": "iCC=eSTP2S1F*n@u{Hc7",
+        "x": 3909,
+        "y": 14324,
+        "extraState": {
+          "subroutineName": "Engineer",
+          "parameters": []
+        },
+        "fields": {
+          "SUBROUTINE_NAME": "Engineer"
+        },
+        "inputs": {
+          "ACTIONS": {
+            "block": {
+              "type": "subroutineInstanceBlock",
+              "id": "^O+zswaAVt^HA^m0IZM1",
+              "extraState": {
+                "subroutineName": "Replace",
+                "parameters": [
+                  {
+                    "types": "Enum_CharacterGadgets,Enum_ClassGadgets,Enum_PrimaryWeapons,Enum_SecondaryWeapons,Enum_OpenGadgets,Enum_Throwables,Enum_MeleeWeapons",
+                    "name": "Inventory"
+                  }
+                ]
+              },
+              "fields": {
+                "SUBROUTINE_NAME": "Replace"
+              },
+              "inputs": {
+                "PARAM-0": {
+                  "block": {
+                    "type": "RandomValueInArray",
+                    "id": ":cHD_QtM8haK{6=KOGn+",
+                    "inputs": {
+                      "VALUE-0": {
+                        "block": {
+                          "type": "GetVariable",
+                          "id": "^[)[}eEnqsRLn,P#cqmn",
+                          "inputs": {
+                            "VALUE-0": {
+                              "block": {
+                                "type": "variableReferenceBlock",
+                                "id": "u|27}lb/4b]DE(pwUfg;",
+                                "extraState": {
+                                  "isObjectVar": false
+                                },
+                                "fields": {
+                                  "OBJECTTYPE": "Global",
+                                  "VAR": {
+                                    "id": "D_bDj446*hh;jK)W,t~:"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "subroutineBlock",
+        "id": "a{f*i?OfE$/GqHf:YIq(",
+        "x": 3909,
+        "y": 14894,
+        "extraState": {
+          "subroutineName": "Scout",
+          "parameters": []
+        },
+        "fields": {
+          "SUBROUTINE_NAME": "Scout"
+        },
+        "inputs": {
+          "ACTIONS": {
+            "block": {
+              "type": "subroutineInstanceBlock",
+              "id": "0==Zg}E8*rF+JsWRO4bz",
+              "extraState": {
+                "subroutineName": "Replace",
+                "parameters": [
+                  {
+                    "types": "Enum_CharacterGadgets,Enum_ClassGadgets,Enum_PrimaryWeapons,Enum_SecondaryWeapons,Enum_OpenGadgets,Enum_Throwables,Enum_MeleeWeapons",
+                    "name": "Inventory"
+                  }
+                ]
+              },
+              "fields": {
+                "SUBROUTINE_NAME": "Replace"
+              },
+              "inputs": {
+                "PARAM-0": {
+                  "block": {
+                    "type": "RandomValueInArray",
+                    "id": "D|zSlE.d+g5LRWo$[dNf",
+                    "inputs": {
+                      "VALUE-0": {
+                        "block": {
+                          "type": "GetVariable",
+                          "id": "hA=8KU64,cYBiozOq*6t",
+                          "inputs": {
+                            "VALUE-0": {
+                              "block": {
+                                "type": "variableReferenceBlock",
+                                "id": "V.G!#?^j_#v?QTx`W.Yj",
+                                "extraState": {
+                                  "isObjectVar": false
+                                },
+                                "fields": {
+                                  "OBJECTTYPE": "Global",
+                                  "VAR": {
+                                    "id": "m$B!wjne^r^hL]4q--Ll"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "subroutineInstanceBlock",
+        "id": "ds)#A@a2d%D:4_cL#8@P",
+        "x": 5139,
+        "y": 14457,
+        "extraState": {
+          "subroutineName": "Replace",
+          "parameters": [
+            {
+              "types": "Enum_CharacterGadgets,Enum_ClassGadgets,Enum_PrimaryWeapons,Enum_SecondaryWeapons,Enum_OpenGadgets,Enum_Throwables,Enum_MeleeWeapons",
+              "name": "Inventory"
+            }
+          ]
+        },
+        "fields": {
+          "SUBROUTINE_NAME": "Replace"
+        },
+        "inputs": {
+          "PARAM-0": {
+            "block": {
+              "type": "RandomValueInArray",
+              "id": "dTwgK{ZT`R+e(urKDx^(",
+              "inputs": {
+                "VALUE-0": {
+                  "block": {
+                    "type": "GetVariable",
+                    "id": "%RY-#+SKz`7]G4d4$e_4",
+                    "inputs": {
+                      "VALUE-0": {
+                        "block": {
+                          "type": "variableReferenceBlock",
+                          "id": "5G@,~az8aP-Fl;c)OS4l",
+                          "extraState": {
+                            "isObjectVar": false
+                          },
+                          "fields": {
+                            "OBJECTTYPE": "Global",
+                            "VAR": {
+                              "id": "s)!_%~(8mBe0;~W6Q=xu"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "next": {
+          "block": {
+            "type": "subroutineInstanceBlock",
+            "id": "H-OI$tobpU*LU)eW7JHF",
+            "extraState": {
+              "subroutineName": "Replace",
+              "parameters": [
+                {
+                  "types": "Enum_CharacterGadgets,Enum_ClassGadgets,Enum_PrimaryWeapons,Enum_SecondaryWeapons,Enum_OpenGadgets,Enum_Throwables,Enum_MeleeWeapons",
+                  "name": "Inventory"
+                }
+              ]
+            },
+            "fields": {
+              "SUBROUTINE_NAME": "Replace"
+            },
+            "inputs": {
+              "PARAM-0": {
+                "block": {
+                  "type": "ClassGadgetsItem",
+                  "id": "O9_MpsNi[(,1K~d(*v?4",
+                  "fields": {
+                    "VALUE-0": "ClassGadgetsKingston",
+                    "VALUE-1": "RepairTool"
+                  }
+                }
+              }
+            },
+            "next": {
+              "block": {
+                "type": "subroutineInstanceBlock",
+                "id": "9qwv/Si(f@pOXEVOKK!K",
+                "extraState": {
+                  "subroutineName": "Replace",
+                  "parameters": [
+                    {
+                      "types": "Enum_CharacterGadgets,Enum_ClassGadgets,Enum_PrimaryWeapons,Enum_SecondaryWeapons,Enum_OpenGadgets,Enum_Throwables,Enum_MeleeWeapons",
+                      "name": "Inventory"
+                    }
+                  ]
+                },
+                "fields": {
+                  "SUBROUTINE_NAME": "Replace"
+                },
+                "inputs": {
+                  "PARAM-0": {
+                    "block": {
+                      "type": "ThrowablesItem",
+                      "id": "2jA^KwHI%e]HGopQVW|b",
+                      "fields": {
+                        "VALUE-0": "ThrowablesKingston",
+                        "VALUE-1": "FragGrenade"
+                      }
+                    }
+                  }
+                },
+                "next": {
+                  "block": {
+                    "type": "subroutineInstanceBlock",
+                    "id": "oj3^L,3A1O8[06`!|s?k",
+                    "extraState": {
+                      "subroutineName": "Replace",
+                      "parameters": [
+                        {
+                          "types": "Enum_CharacterGadgets,Enum_ClassGadgets,Enum_PrimaryWeapons,Enum_SecondaryWeapons,Enum_OpenGadgets,Enum_Throwables,Enum_MeleeWeapons",
+                          "name": "Inventory"
+                        }
+                      ]
+                    },
+                    "fields": {
+                      "SUBROUTINE_NAME": "Replace"
+                    },
+                    "inputs": {
+                      "PARAM-0": {
+                        "block": {
+                          "type": "CharacterGadgetsItem",
+                          "id": "bJ6H{[V0*j@r!KEX7DrV",
+                          "fields": {
+                            "VALUE-0": "CharacterGadgetsKingston",
+                            "VALUE-1": "AutoTurret"
+                          }
+                        }
+                      }
+                    },
+                    "next": {
+                      "block": {
+                        "type": "subroutineInstanceBlock",
+                        "id": "%312/mB)N2Up`l+Y9i8u",
+                        "extraState": {
+                          "subroutineName": "Replace",
+                          "parameters": [
+                            {
+                              "types": "Enum_CharacterGadgets,Enum_ClassGadgets,Enum_PrimaryWeapons,Enum_SecondaryWeapons,Enum_OpenGadgets,Enum_Throwables,Enum_MeleeWeapons",
+                              "name": "Inventory"
+                            }
+                          ]
+                        },
+                        "fields": {
+                          "SUBROUTINE_NAME": "Replace"
+                        },
+                        "inputs": {
+                          "PARAM-0": {
+                            "block": {
+                              "type": "OpenGadgetsItem",
+                              "id": "aj7grSt3ZU6XZ;~4ro:]",
+                              "fields": {
+                                "VALUE-0": "OpenGadgetsKingston",
+                                "VALUE-1": "ArmorPiece"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "subroutineInstanceBlock",
+        "id": "yN,PbmI,|`OFT!Ll`coT",
+        "x": 5132,
+        "y": 15016,
+        "extraState": {
+          "subroutineName": "Replace",
+          "parameters": [
+            {
+              "types": "Enum_CharacterGadgets,Enum_ClassGadgets,Enum_PrimaryWeapons,Enum_SecondaryWeapons,Enum_OpenGadgets,Enum_Throwables,Enum_MeleeWeapons",
+              "name": "Inventory"
+            }
+          ]
+        },
+        "fields": {
+          "SUBROUTINE_NAME": "Replace"
+        },
+        "inputs": {
+          "PARAM-0": {
+            "block": {
+              "type": "ClassGadgetsItem",
+              "id": "$.@Xjzf:-`CCwp^`H$(W",
+              "fields": {
+                "VALUE-0": "ClassGadgetsKingston",
+                "VALUE-1": "Med Pen"
+              }
+            }
+          }
+        },
+        "next": {
+          "block": {
+            "type": "subroutineInstanceBlock",
+            "id": "K`%Z?Bb)}x=$-~y!noYd",
+            "extraState": {
+              "subroutineName": "Replace",
+              "parameters": [
+                {
+                  "types": "Enum_CharacterGadgets,Enum_ClassGadgets,Enum_PrimaryWeapons,Enum_SecondaryWeapons,Enum_OpenGadgets,Enum_Throwables,Enum_MeleeWeapons",
+                  "name": "Inventory"
+                }
+              ]
+            },
+            "fields": {
+              "SUBROUTINE_NAME": "Replace"
+            },
+            "inputs": {
+              "PARAM-0": {
+                "block": {
+                  "type": "OpenGadgetsItem",
+                  "id": "!SUJ_-lGoyp@e-k%U++R",
+                  "fields": {
+                    "VALUE-0": "OpenGadgetsKingston",
+                    "VALUE-1": "MotionMine"
+                  }
+                }
+              }
+            },
+            "next": {
+              "block": {
+                "type": "subroutineInstanceBlock",
+                "id": "*AUGpjc_PXd?@T]BU;d5",
+                "extraState": {
+                  "subroutineName": "Replace",
+                  "parameters": [
+                    {
+                      "types": "Enum_CharacterGadgets,Enum_ClassGadgets,Enum_PrimaryWeapons,Enum_SecondaryWeapons,Enum_OpenGadgets,Enum_Throwables,Enum_MeleeWeapons",
+                      "name": "Inventory"
+                    }
+                  ]
+                },
+                "fields": {
+                  "SUBROUTINE_NAME": "Replace"
+                },
+                "inputs": {
+                  "PARAM-0": {
+                    "block": {
+                      "type": "ThrowablesItem",
+                      "id": "%LJ,XQe|x_/$RWB@y0aw",
+                      "fields": {
+                        "VALUE-0": "ThrowablesKingston",
+                        "VALUE-1": "ConcussionGrenade"
+                      }
+                    }
+                  }
+                },
+                "next": {
+                  "block": {
+                    "type": "subroutineInstanceBlock",
+                    "id": "cC.Uyq:nbZ*+O+YBV#Yl",
+                    "extraState": {
+                      "subroutineName": "Replace",
+                      "parameters": [
+                        {
+                          "types": "Enum_CharacterGadgets,Enum_ClassGadgets,Enum_PrimaryWeapons,Enum_SecondaryWeapons,Enum_OpenGadgets,Enum_Throwables,Enum_MeleeWeapons",
+                          "name": "Inventory"
+                        }
+                      ]
+                    },
+                    "fields": {
+                      "SUBROUTINE_NAME": "Replace"
+                    },
+                    "inputs": {
+                      "PARAM-0": {
+                        "block": {
+                          "type": "CharacterGadgetsItem",
+                          "id": "3t0QyGkKWu-|#5Ha~F:f",
+                          "fields": {
+                            "VALUE-0": "CharacterGadgetsKingston",
+                            "VALUE-1": "Signal Jammer"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "subroutineInstanceBlock",
+        "id": "AFQ:a.?s3D;uGg`aJdRN",
+        "x": 5094,
+        "y": 14078,
+        "extraState": {
+          "subroutineName": "Replace",
+          "parameters": [
+            {
+              "types": "Enum_CharacterGadgets,Enum_ClassGadgets,Enum_PrimaryWeapons,Enum_SecondaryWeapons,Enum_OpenGadgets,Enum_Throwables,Enum_MeleeWeapons",
+              "name": "Inventory"
+            }
+          ]
+        },
+        "fields": {
+          "SUBROUTINE_NAME": "Replace"
+        },
+        "inputs": {
+          "PARAM-0": {
+            "block": {
+              "type": "ClassGadgetsItem",
+              "id": "z0,]e`%iHVoIR%6$+~CS",
+              "fields": {
+                "VALUE-0": "ClassGadgetsKingston",
+                "VALUE-1": "Defibrillator"
+              }
+            }
+          }
+        },
+        "next": {
+          "block": {
+            "type": "subroutineInstanceBlock",
+            "id": "ljQ=)Ry?sJ^,Ai[Ltded",
+            "extraState": {
+              "subroutineName": "Replace",
+              "parameters": [
+                {
+                  "types": "Enum_CharacterGadgets,Enum_ClassGadgets,Enum_PrimaryWeapons,Enum_SecondaryWeapons,Enum_OpenGadgets,Enum_Throwables,Enum_MeleeWeapons",
+                  "name": "Inventory"
+                }
+              ]
+            },
+            "fields": {
+              "SUBROUTINE_NAME": "Replace"
+            },
+            "inputs": {
+              "PARAM-0": {
+                "block": {
+                  "type": "CharacterGadgetsItem",
+                  "id": "bcC{Z=f4%}16QJ%$gsN4",
+                  "fields": {
+                    "VALUE-0": "CharacterGadgetsAlexandria",
+                    "VALUE-1": "MedicBag_ALX"
+                  }
+                }
+              }
+            },
+            "next": {
+              "block": {
+                "type": "subroutineInstanceBlock",
+                "id": "n?D25|fV6)W%Y1GQ)-Re",
+                "extraState": {
+                  "subroutineName": "Replace",
+                  "parameters": [
+                    {
+                      "types": "Enum_CharacterGadgets,Enum_ClassGadgets,Enum_PrimaryWeapons,Enum_SecondaryWeapons,Enum_OpenGadgets,Enum_Throwables,Enum_MeleeWeapons",
+                      "name": "Inventory"
+                    }
+                  ]
+                },
+                "fields": {
+                  "SUBROUTINE_NAME": "Replace"
+                },
+                "inputs": {
+                  "PARAM-0": {
+                    "block": {
+                      "type": "OpenGadgetsItem",
+                      "id": "p?9UCtBJk%e4uc?B@FNv",
+                      "fields": {
+                        "VALUE-0": "OpenGadgetsAlexandria",
+                        "VALUE-1": "Defibrillator_ALX"
+                      }
+                    }
+                  }
+                },
+                "next": {
+                  "block": {
+                    "type": "subroutineInstanceBlock",
+                    "id": "dJ0MHV6CJ7?Op}RA!vXF",
+                    "extraState": {
+                      "subroutineName": "Replace",
+                      "parameters": [
+                        {
+                          "types": "Enum_CharacterGadgets,Enum_ClassGadgets,Enum_PrimaryWeapons,Enum_SecondaryWeapons,Enum_OpenGadgets,Enum_Throwables,Enum_MeleeWeapons",
+                          "name": "Inventory"
+                        }
+                      ]
+                    },
+                    "fields": {
+                      "SUBROUTINE_NAME": "Replace"
+                    },
+                    "inputs": {
+                      "PARAM-0": {
+                        "block": {
+                          "type": "ThrowablesItem",
+                          "id": "Z.vIa4h.mv4+BQJIDnai",
+                          "fields": {
+                            "VALUE-0": "ThrowablesKingston",
+                            "VALUE-1": "SmokeGrenade"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "subroutineInstanceBlock",
+        "id": "TsK?:{}-{OYpGW|]^84u",
+        "x": 5070,
+        "y": 13600,
+        "extraState": {
+          "subroutineName": "Replace",
+          "parameters": [
+            {
+              "types": "Enum_CharacterGadgets,Enum_ClassGadgets,Enum_PrimaryWeapons,Enum_SecondaryWeapons,Enum_OpenGadgets,Enum_Throwables,Enum_MeleeWeapons",
+              "name": "Inventory"
+            }
+          ]
+        },
+        "fields": {
+          "SUBROUTINE_NAME": "Replace"
+        },
+        "inputs": {
+          "PARAM-0": {
+            "block": {
+              "type": "ClassGadgetsItem",
+              "id": "DLhoTc:#}Y/.m3b3rsW{",
+              "fields": {
+                "VALUE-0": "ClassGadgetsKingston",
+                "VALUE-1": "Med Pen"
+              }
+            }
+          }
+        },
+        "next": {
+          "block": {
+            "type": "subroutineInstanceBlock",
+            "id": "y{v+aRIy^.|{h#28~u],",
+            "extraState": {
+              "subroutineName": "Replace",
+              "parameters": [
+                {
+                  "types": "Enum_CharacterGadgets,Enum_ClassGadgets,Enum_PrimaryWeapons,Enum_SecondaryWeapons,Enum_OpenGadgets,Enum_Throwables,Enum_MeleeWeapons",
+                  "name": "Inventory"
+                }
+              ]
+            },
+            "fields": {
+              "SUBROUTINE_NAME": "Replace"
+            },
+            "inputs": {
+              "PARAM-0": {
+                "block": {
+                  "type": "OpenGadgetsItem",
+                  "id": "CX^ej+}GT.$V31(bcOeI",
+                  "fields": {
+                    "VALUE-0": "OpenGadgetsKingston",
+                    "VALUE-1": "C4"
+                  }
+                }
+              }
+            },
+            "next": {
+              "block": {
+                "type": "subroutineInstanceBlock",
+                "id": "QB^%a|%y!K`X4LpwuVSD",
+                "extraState": {
+                  "subroutineName": "Replace",
+                  "parameters": [
+                    {
+                      "types": "Enum_CharacterGadgets,Enum_ClassGadgets,Enum_PrimaryWeapons,Enum_SecondaryWeapons,Enum_OpenGadgets,Enum_Throwables,Enum_MeleeWeapons",
+                      "name": "Inventory"
+                    }
+                  ]
+                },
+                "fields": {
+                  "SUBROUTINE_NAME": "Replace"
+                },
+                "inputs": {
+                  "PARAM-0": {
+                    "block": {
+                      "type": "ThrowablesItem",
+                      "id": "qX50^D`(:6f?c*PGWAuu",
+                      "fields": {
+                        "VALUE-0": "ThrowablesKingston",
+                        "VALUE-1": "FragGrenade"
+                      }
+                    }
+                  }
+                },
+                "next": {
+                  "block": {
+                    "type": "subroutineInstanceBlock",
+                    "id": "WQ02a|uG-R(-z-2jHf(1",
+                    "extraState": {
+                      "subroutineName": "Replace",
+                      "parameters": [
+                        {
+                          "types": "Enum_CharacterGadgets,Enum_ClassGadgets,Enum_PrimaryWeapons,Enum_SecondaryWeapons,Enum_OpenGadgets,Enum_Throwables,Enum_MeleeWeapons",
+                          "name": "Inventory"
+                        }
+                      ]
+                    },
+                    "fields": {
+                      "SUBROUTINE_NAME": "Replace"
+                    },
+                    "inputs": {
+                      "PARAM-0": {
+                        "block": {
+                          "type": "CharacterGadgetsItem",
+                          "id": "0}_T6pjFZWNaZX,T!iz^",
+                          "fields": {
+                            "VALUE-0": "CharacterGadgetsAlexandria",
+                            "VALUE-1": "AmmoBag_ALX"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "subroutineBlock",
+        "id": "mE2Y}9io()`U.aW`Z]w:",
+        "x": 5929,
+        "y": 13960,
+        "extraState": {
+          "subroutineName": "Engineer_Equipment",
+          "parameters": []
+        },
+        "fields": {
+          "SUBROUTINE_NAME": "Engineer_Equipment"
+        },
+        "inputs": {
+          "ACTIONS": {
+            "block": {
+              "type": "SetVariable",
+              "id": "Qd^64=0O*1bt`1]:SUhS",
+              "inputs": {
+                "VALUE-0": {
+                  "block": {
+                    "type": "variableReferenceBlock",
+                    "id": "!v/ri:Dx5x4uf)eB}VW}",
+                    "extraState": {
+                      "isObjectVar": false
+                    },
+                    "fields": {
+                      "OBJECTTYPE": "Global",
+                      "VAR": {
+                        "id": "s)!_%~(8mBe0;~W6Q=xu"
+                      }
+                    }
+                  }
+                },
+                "VALUE-1": {
+                  "block": {
+                    "type": "EmptyArray",
+                    "id": "?t,~3h_{4,k%Q@PG3$yv"
+                  }
+                }
+              },
+              "next": {
+                "block": {
+                  "type": "SetVariable",
+                  "id": "LOoy`6]3}~etohE?9q)h",
+                  "inputs": {
+                    "VALUE-0": {
+                      "block": {
+                        "type": "variableReferenceBlock",
+                        "id": "!UQ~!VyhN!%3s?``^2IA",
+                        "extraState": {
+                          "isObjectVar": false
+                        },
+                        "fields": {
+                          "OBJECTTYPE": "Global",
+                          "VAR": {
+                            "id": "s)!_%~(8mBe0;~W6Q=xu"
+                          }
+                        }
+                      }
+                    },
+                    "VALUE-1": {
+                      "block": {
+                        "type": "AppendToArray",
+                        "id": "zeXPa:*?Kgb5*T,Ia?n_",
+                        "inputs": {
+                          "VALUE-0": {
+                            "block": {
+                              "type": "GetVariable",
+                              "id": "0-:0v}hE:4rT.S-:|y{S",
+                              "inputs": {
+                                "VALUE-0": {
+                                  "block": {
+                                    "type": "variableReferenceBlock",
+                                    "id": "t.1#}a7N(R#iV].1`paK",
+                                    "extraState": {
+                                      "isObjectVar": false
+                                    },
+                                    "fields": {
+                                      "OBJECTTYPE": "Global",
+                                      "VAR": {
+                                        "id": "s)!_%~(8mBe0;~W6Q=xu"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "VALUE-1": {
+                            "block": {
+                              "type": "OpenGadgetsItem",
+                              "id": ":#Hyr1##[a%B?Yt?G[lV",
+                              "fields": {
+                                "VALUE-0": "OpenGadgetsKingston",
+                                "VALUE-1": "CarlGustav"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "next": {
+                    "block": {
+                      "type": "SetVariable",
+                      "id": "4h,+WN8a9BqL4HwC%m1y",
+                      "inputs": {
+                        "VALUE-0": {
+                          "block": {
+                            "type": "variableReferenceBlock",
+                            "id": "w`$X`~Z.{9mEfL9Ve%7+",
+                            "extraState": {
+                              "isObjectVar": false
+                            },
+                            "fields": {
+                              "OBJECTTYPE": "Global",
+                              "VAR": {
+                                "id": "s)!_%~(8mBe0;~W6Q=xu"
+                              }
+                            }
+                          }
+                        },
+                        "VALUE-1": {
+                          "block": {
+                            "type": "AppendToArray",
+                            "id": "Pr5UP_R3_;p1(9$ZglU5",
+                            "inputs": {
+                              "VALUE-0": {
+                                "block": {
+                                  "type": "GetVariable",
+                                  "id": "[iBSH9wP-0T8Tb`EnTLZ",
+                                  "inputs": {
+                                    "VALUE-0": {
+                                      "block": {
+                                        "type": "variableReferenceBlock",
+                                        "id": "GlXrT:XpUr/^C$BUrU|X",
+                                        "extraState": {
+                                          "isObjectVar": false
+                                        },
+                                        "fields": {
+                                          "OBJECTTYPE": "Global",
+                                          "VAR": {
+                                            "id": "s)!_%~(8mBe0;~W6Q=xu"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              },
+                              "VALUE-1": {
+                                "block": {
+                                  "type": "OpenGadgetsItem",
+                                  "id": "Qj9,?C|J,)nhEpvbM/@3",
+                                  "fields": {
+                                    "VALUE-0": "OpenGadgetsKingston",
+                                    "VALUE-1": "Stinger"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "next": {
+                        "block": {
+                          "type": "SetVariable",
+                          "id": "x^Lxwv|zZ~|t/lhvr8#E",
+                          "inputs": {
+                            "VALUE-0": {
+                              "block": {
+                                "type": "variableReferenceBlock",
+                                "id": ",FX#wVf,6pij%=,/JZqV",
+                                "extraState": {
+                                  "isObjectVar": false
+                                },
+                                "fields": {
+                                  "OBJECTTYPE": "Global",
+                                  "VAR": {
+                                    "id": "s)!_%~(8mBe0;~W6Q=xu"
+                                  }
+                                }
+                              }
+                            },
+                            "VALUE-1": {
+                              "block": {
+                                "type": "AppendToArray",
+                                "id": "j$|@6@uv]|G$2,)]yOu4",
+                                "inputs": {
+                                  "VALUE-0": {
+                                    "block": {
+                                      "type": "GetVariable",
+                                      "id": "xDo~C~h/M-argu={]iix",
+                                      "inputs": {
+                                        "VALUE-0": {
+                                          "block": {
+                                            "type": "variableReferenceBlock",
+                                            "id": "bzb`SG.hY|E+N1zTFebc",
+                                            "extraState": {
+                                              "isObjectVar": false
+                                            },
+                                            "fields": {
+                                              "OBJECTTYPE": "Global",
+                                              "VAR": {
+                                                "id": "s)!_%~(8mBe0;~W6Q=xu"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "VALUE-1": {
+                                    "block": {
+                                      "type": "OpenGadgetsItem",
+                                      "id": "=]13,R%NS%g,s:3PnF$4",
+                                      "fields": {
+                                        "VALUE-0": "OpenGadgetsKingston",
+                                        "VALUE-1": "RPG7V2"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "subroutineBlock",
+        "id": "wcWygC;CR9/EnV}{EFNR",
+        "x": 6363,
+        "y": 3487,
+        "extraState": {
+          "subroutineName": "Teleport",
+          "parameters": []
+        },
+        "fields": {
+          "SUBROUTINE_NAME": "Teleport"
+        },
+        "inputs": {
+          "ACTIONS": {
+            "block": {
+              "type": "subroutineInstanceBlock",
+              "id": "AIVNK?{_6-{ud5..N,z2",
+              "extraState": {
+                "subroutineName": "Spawn_Rotation_Calculator",
+                "parameters": [
+                  {
+                    "types": "Vector",
+                    "name": "Source"
+                  },
+                  {
+                    "types": "Vector",
+                    "name": "Target"
+                  }
+                ]
+              },
+              "fields": {
+                "SUBROUTINE_NAME": "Spawn_Rotation_Calculator"
+              },
+              "inputs": {
+                "PARAM-0": {
+                  "block": {
+                    "type": "GetVariable",
+                    "id": "][,4XKzWkP|w+jJ(U8WT",
+                    "inputs": {
+                      "VALUE-0": {
+                        "block": {
+                          "type": "variableReferenceBlock",
+                          "id": "i9~+`5[-Dx.?+Sco3uue",
+                          "extraState": {
+                            "isObjectVar": true
+                          },
+                          "fields": {
+                            "OBJECTTYPE": "TeamId",
+                            "VAR": {
+                              "id": ")85N/!w[yu2n1i{J:kG%"
+                            }
+                          },
+                          "inputs": {
+                            "OBJECT": {
+                              "block": {
+                                "type": "GetTeamId",
+                                "id": "nN[n,)`@i(]:T5-Mv:8-",
+                                "inputs": {
+                                  "VALUE-0": {
+                                    "block": {
+                                      "type": "EventPlayer",
+                                      "id": "3*{-4#/.:O0IY11tA`_d"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "PARAM-1": {
+                  "block": {
+                    "type": "GetVariable",
+                    "id": "hThapc.(A=)fVjzYV)0m",
+                    "inputs": {
+                      "VALUE-0": {
+                        "block": {
+                          "type": "variableReferenceBlock",
+                          "id": "xe~EaH$q}_^0ynQAP4G|",
+                          "extraState": {
+                            "isObjectVar": false
+                          },
+                          "fields": {
+                            "OBJECTTYPE": "Global",
+                            "VAR": {
+                              "id": "]dWwQ+kkD!f)85rwAEAQ"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "next": {
+                "block": {
+                  "type": "Teleport",
+                  "id": "RL/rU=USxC#]|0P#QtlM",
+                  "inputs": {
+                    "VALUE-0": {
+                      "block": {
+                        "type": "EventPlayer",
+                        "id": "]E_OC]RhXxf*sF?ka%P}"
+                      }
+                    },
+                    "VALUE-1": {
+                      "block": {
+                        "type": "GetVariable",
+                        "id": "};KKMs881)?|5n2p$psO",
+                        "inputs": {
+                          "VALUE-0": {
+                            "block": {
+                              "type": "variableReferenceBlock",
+                              "id": "dXVFnQ)wP4N]1=062:=K",
+                              "extraState": {
+                                "isObjectVar": true
+                              },
+                              "fields": {
+                                "OBJECTTYPE": "TeamId",
+                                "VAR": {
+                                  "id": ")85N/!w[yu2n1i{J:kG%"
+                                }
+                              },
+                              "inputs": {
+                                "OBJECT": {
+                                  "block": {
+                                    "type": "GetTeamId",
+                                    "id": "RoC^x6PIVhY7-aCt24r1",
+                                    "inputs": {
+                                      "VALUE-0": {
+                                        "block": {
+                                          "type": "EventPlayer",
+                                          "id": "S^0V{l-|_]T+S!q=b)[9"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "VALUE-2": {
+                      "block": {
+                        "type": "GetVariable",
+                        "id": "T|QnquFcHRDYHTy;Ok*J",
+                        "inputs": {
+                          "VALUE-0": {
+                            "block": {
+                              "type": "variableReferenceBlock",
+                              "id": "N2.B1d831*Vj[%[K9*wC",
+                              "extraState": {
+                                "isObjectVar": false
+                              },
+                              "fields": {
+                                "OBJECTTYPE": "Global",
+                                "VAR": {
+                                  "id": "9!i2$sZFWZtrj+Z85P.`"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      {
+        "type": "subroutineBlock",
+        "id": "-?;H46dmB`/7K_7QB]:`",
+        "x": 6360,
+        "y": 3896,
+        "extraState": {
+          "subroutineName": "Spawn_Rotation_Calculator",
+          "parameters": [
+            {
+              "types": "Vector",
+              "name": "Source"
+            },
+            {
+              "types": "Vector",
+              "name": "Target"
+            }
+          ]
+        },
+        "fields": {
+          "SUBROUTINE_NAME": "Spawn_Rotation_Calculator"
+        },
+        "inputs": {
+          "ACTIONS": {
+            "block": {
+              "type": "If",
+              "id": "OlpP,uSbdcvkt!`_b,Km",
+              "extraState": {},
+              "inputs": {
+                "VALUE-0": {
+                  "block": {
+                    "type": "NotEqualTo",
+                    "id": "A3.9vkSRaUUib0-7tX]g",
+                    "inputs": {
+                      "VALUE-0": {
+                        "block": {
+                          "type": "subroutineArgumentBlock",
+                          "id": "Yuf{]a73r1if.}]@4#XB",
+                          "fields": {
+                            "ARGUMENT_INDEX": "0"
+                          }
+                        }
+                      },
+                      "VALUE-1": {
+                        "block": {
+                          "type": "CreateVector",
+                          "id": "C};g-5PH.x8i(JHn3:F`",
+                          "inputs": {
+                            "VALUE-0": {
+                              "block": {
+                                "type": "Number",
+                                "id": "cOnG0L%}nPyoJl;Ktv]G",
+                                "fields": {
+                                  "NUM": 0
+                                }
+                              }
+                            },
+                            "VALUE-1": {
+                              "block": {
+                                "type": "Number",
+                                "id": "fBxe}Zx(g*We9^1zR|.}",
+                                "fields": {
+                                  "NUM": 0
+                                }
+                              }
+                            },
+                            "VALUE-2": {
+                              "block": {
+                                "type": "Number",
+                                "id": "[axFkZZBPX=}|1o/Q.[3",
+                                "fields": {
+                                  "NUM": 0
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "DO": {
+                  "block": {
+                    "type": "SetVariable",
+                    "id": "1ay^sc,qnuQDG?X6FfGG",
+                    "inputs": {
+                      "VALUE-0": {
+                        "block": {
+                          "type": "variableReferenceBlock",
+                          "id": "ni#Uaa;E@p+:--(dZRdV",
+                          "extraState": {
+                            "isObjectVar": false
+                          },
+                          "fields": {
+                            "OBJECTTYPE": "Global",
+                            "VAR": {
+                              "id": "9!i2$sZFWZtrj+Z85P.`"
+                            }
+                          }
+                        }
+                      },
+                      "VALUE-1": {
+                        "block": {
+                          "type": "DirectionTowards",
+                          "id": "2H(apO56ePzqv9Q:N,50",
+                          "inputs": {
+                            "VALUE-0": {
+                              "block": {
+                                "type": "CreateVector",
+                                "id": "U[.LQ25U@0nGxI]7J!i:",
+                                "inputs": {
+                                  "VALUE-0": {
+                                    "block": {
+                                      "type": "XComponentOf",
+                                      "id": "ScQy6M)Wb~SMlDA_4VHf",
+                                      "inputs": {
+                                        "VALUE-0": {
+                                          "block": {
+                                            "type": "subroutineArgumentBlock",
+                                            "id": "?(C(T.sU!w2fB%]dll:_",
+                                            "fields": {
+                                              "ARGUMENT_INDEX": "0"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "VALUE-1": {
+                                    "block": {
+                                      "type": "Number",
+                                      "id": "tGB7Nm-Yh!:+r^3FGA/e",
+                                      "fields": {
+                                        "NUM": 0
+                                      }
+                                    }
+                                  },
+                                  "VALUE-2": {
+                                    "block": {
+                                      "type": "ZComponentOf",
+                                      "id": "}Eo}F2M}|E,Ro6gD6G:h",
+                                      "inputs": {
+                                        "VALUE-0": {
+                                          "block": {
+                                            "type": "subroutineArgumentBlock",
+                                            "id": "^i#9IqHs,[%U%fVBM?r?",
+                                            "fields": {
+                                              "ARGUMENT_INDEX": "0"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "VALUE-1": {
+                              "block": {
+                                "type": "CreateVector",
+                                "id": "W7GUj}bW%,W`%zr9p*BJ",
+                                "inputs": {
+                                  "VALUE-0": {
+                                    "block": {
+                                      "type": "XComponentOf",
+                                      "id": "YXkAQd*lkU#P)}T${A]b",
+                                      "inputs": {
+                                        "VALUE-0": {
+                                          "block": {
+                                            "type": "subroutineArgumentBlock",
+                                            "id": ")1uC5h^VQezy=Tv1%K~E",
+                                            "fields": {
+                                              "ARGUMENT_INDEX": "1"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "VALUE-1": {
+                                    "block": {
+                                      "type": "Number",
+                                      "id": "7/|XnvfHKbikNWfE?:{J",
+                                      "fields": {
+                                        "NUM": 0
+                                      }
+                                    }
+                                  },
+                                  "VALUE-2": {
+                                    "block": {
+                                      "type": "ZComponentOf",
+                                      "id": "KiO0Y%D%eHx}~hB9X~No",
+                                      "inputs": {
+                                        "VALUE-0": {
+                                          "block": {
+                                            "type": "subroutineArgumentBlock",
+                                            "id": "cu]-e,$5bzW!_5Gl4;6{",
+                                            "fields": {
+                                              "ARGUMENT_INDEX": "1"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "next": {
+                      "block": {
+                        "type": "If",
+                        "id": "W93x]//_0UTW=lJc,69!",
+                        "extraState": {
+                          "elseif": 0,
+                          "else": 1
+                        },
+                        "inputs": {
+                          "VALUE-0": {
+                            "block": {
+                              "type": "LessThan",
+                              "id": "h:HefT`]Cf.K^:8;i/(T",
+                              "inputs": {
+                                "VALUE-0": {
+                                  "block": {
+                                    "type": "XComponentOf",
+                                    "id": "}VGu5A`c7E]:p;`W^j5.",
+                                    "inputs": {
+                                      "VALUE-0": {
+                                        "block": {
+                                          "type": "GetVariable",
+                                          "id": "b+e/PjH_Htu${:@CEMH4",
+                                          "inputs": {
+                                            "VALUE-0": {
+                                              "block": {
+                                                "type": "variableReferenceBlock",
+                                                "id": "cyR}]-EUQ3(B07iwUS%v",
+                                                "extraState": {
+                                                  "isObjectVar": false
+                                                },
+                                                "fields": {
+                                                  "OBJECTTYPE": "Global",
+                                                  "VAR": {
+                                                    "id": "9!i2$sZFWZtrj+Z85P.`"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "VALUE-1": {
+                                  "block": {
+                                    "type": "Number",
+                                    "id": "rQZ-$HT(Tl5,Z3`snH@P",
+                                    "fields": {
+                                      "NUM": 0
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "DO": {
+                            "block": {
+                              "type": "SetVariable",
+                              "id": "p]En4=r?c=j{kBC#P(Jn",
+                              "inputs": {
+                                "VALUE-0": {
+                                  "block": {
+                                    "type": "variableReferenceBlock",
+                                    "id": "@RXq2h|/I)f26zJ;{{Ia",
+                                    "extraState": {
+                                      "isObjectVar": false
+                                    },
+                                    "fields": {
+                                      "OBJECTTYPE": "Global",
+                                      "VAR": {
+                                        "id": "9!i2$sZFWZtrj+Z85P.`"
+                                      }
+                                    }
+                                  }
+                                },
+                                "VALUE-1": {
+                                  "block": {
+                                    "type": "Subtract",
+                                    "id": "}tcy.9?zoU%x~sJ(aUJE",
+                                    "inputs": {
+                                      "VALUE-0": {
+                                        "block": {
+                                          "type": "Number",
+                                          "id": "U=n*_:GkiEs-Kia{S$,b",
+                                          "fields": {
+                                            "NUM": 360
+                                          }
+                                        }
+                                      },
+                                      "VALUE-1": {
+                                        "block": {
+                                          "type": "AngleBetweenVectors",
+                                          "id": "X%ub*zH8p-tW[i:,tNL-",
+                                          "inputs": {
+                                            "VALUE-0": {
+                                              "block": {
+                                                "type": "BackwardVector",
+                                                "id": "@S0V=ujF^g`*78[qUxE2"
+                                              }
+                                            },
+                                            "VALUE-1": {
+                                              "block": {
+                                                "type": "Normalize",
+                                                "id": "r/?Ie2%Moj$Pw*herN2E",
+                                                "inputs": {
+                                                  "VALUE-0": {
+                                                    "block": {
+                                                      "type": "CreateVector",
+                                                      "id": "f`~Y7{iZjMi1dtR~elCl",
+                                                      "inputs": {
+                                                        "VALUE-0": {
+                                                          "block": {
+                                                            "type": "XComponentOf",
+                                                            "id": ")M7vrp#,7{55_//K|Gx{",
+                                                            "inputs": {
+                                                              "VALUE-0": {
+                                                                "block": {
+                                                                  "type": "GetVariable",
+                                                                  "id": "!U0*y=Aqzn|_TRA^?Nc]",
+                                                                  "inputs": {
+                                                                    "VALUE-0": {
+                                                                      "block": {
+                                                                        "type": "variableReferenceBlock",
+                                                                        "id": "$I$g~_$g^h|zrXH#p8vB",
+                                                                        "extraState": {
+                                                                          "isObjectVar": false
+                                                                        },
+                                                                        "fields": {
+                                                                          "OBJECTTYPE": "Global",
+                                                                          "VAR": {
+                                                                            "id": "9!i2$sZFWZtrj+Z85P.`"
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        },
+                                                        "VALUE-1": {
+                                                          "block": {
+                                                            "type": "Number",
+                                                            "id": "gaKvdgQ}]VO;A2RTLh]X",
+                                                            "fields": {
+                                                              "NUM": 0
+                                                            }
+                                                          }
+                                                        },
+                                                        "VALUE-2": {
+                                                          "block": {
+                                                            "type": "ZComponentOf",
+                                                            "id": "gyj|@...(onp_oA4oAN-",
+                                                            "inputs": {
+                                                              "VALUE-0": {
+                                                                "block": {
+                                                                  "type": "GetVariable",
+                                                                  "id": "Qz@{#(;B8;aI(xPtmO1[",
+                                                                  "inputs": {
+                                                                    "VALUE-0": {
+                                                                      "block": {
+                                                                        "type": "variableReferenceBlock",
+                                                                        "id": "*|h,fRtFA#y%hjf=#hYv",
+                                                                        "extraState": {
+                                                                          "isObjectVar": false
+                                                                        },
+                                                                        "fields": {
+                                                                          "OBJECTTYPE": "Global",
+                                                                          "VAR": {
+                                                                            "id": "9!i2$sZFWZtrj+Z85P.`"
+                                                                          }
+                                                                        }
+                                                                      }
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "ELSE": {
+                            "block": {
+                              "type": "SetVariable",
+                              "id": "9bYz8=]Z{Go6iF@/Qpc7",
+                              "inputs": {
+                                "VALUE-0": {
+                                  "block": {
+                                    "type": "variableReferenceBlock",
+                                    "id": "-H9eFd`ozg.-Qm$#mx?_",
+                                    "extraState": {
+                                      "isObjectVar": false
+                                    },
+                                    "fields": {
+                                      "OBJECTTYPE": "Global",
+                                      "VAR": {
+                                        "id": "9!i2$sZFWZtrj+Z85P.`"
+                                      }
+                                    }
+                                  }
+                                },
+                                "VALUE-1": {
+                                  "block": {
+                                    "type": "AngleBetweenVectors",
+                                    "id": "Gjma{l1Z{VMSEok1WBRm",
+                                    "inputs": {
+                                      "VALUE-0": {
+                                        "block": {
+                                          "type": "BackwardVector",
+                                          "id": ".plAw_P,ER[R8_Ce$1C6"
+                                        }
+                                      },
+                                      "VALUE-1": {
+                                        "block": {
+                                          "type": "Normalize",
+                                          "id": "tkK]0o`G$.9smtB7Hs1{",
+                                          "inputs": {
+                                            "VALUE-0": {
+                                              "block": {
+                                                "type": "CreateVector",
+                                                "id": "x7Lu6r8y$]L!Yg.gWj?p",
+                                                "inputs": {
+                                                  "VALUE-0": {
+                                                    "block": {
+                                                      "type": "XComponentOf",
+                                                      "id": "O4E?#3zNGvwaF{.A*XI8",
+                                                      "inputs": {
+                                                        "VALUE-0": {
+                                                          "block": {
+                                                            "type": "GetVariable",
+                                                            "id": "{YMf86xGukN!dJ#j~,nF",
+                                                            "inputs": {
+                                                              "VALUE-0": {
+                                                                "block": {
+                                                                  "type": "variableReferenceBlock",
+                                                                  "id": "||}Pjuw_q{P/.R~(bF`O",
+                                                                  "extraState": {
+                                                                    "isObjectVar": false
+                                                                  },
+                                                                  "fields": {
+                                                                    "OBJECTTYPE": "Global",
+                                                                    "VAR": {
+                                                                      "id": "9!i2$sZFWZtrj+Z85P.`"
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  },
+                                                  "VALUE-1": {
+                                                    "block": {
+                                                      "type": "Number",
+                                                      "id": "[R13JjhlUA(35.:7`Xhm",
+                                                      "fields": {
+                                                        "NUM": 0
+                                                      }
+                                                    }
+                                                  },
+                                                  "VALUE-2": {
+                                                    "block": {
+                                                      "type": "ZComponentOf",
+                                                      "id": "FZd+ct+HMHk,v)l@k__T",
+                                                      "inputs": {
+                                                        "VALUE-0": {
+                                                          "block": {
+                                                            "type": "GetVariable",
+                                                            "id": "$+1.KGgR7s,4K0JO*NfT",
+                                                            "inputs": {
+                                                              "VALUE-0": {
+                                                                "block": {
+                                                                  "type": "variableReferenceBlock",
+                                                                  "id": "TCq)x#1SLb^Nd}@`j!J1",
+                                                                  "extraState": {
+                                                                    "isObjectVar": false
+                                                                  },
+                                                                  "fields": {
+                                                                    "OBJECTTYPE": "Global",
+                                                                    "VAR": {
+                                                                      "id": "9!i2$sZFWZtrj+Z85P.`"
+                                                                    }
+                                                                  }
+                                                                }
+                                                              }
+                                                            }
+                                                          }
+                                                        }
+                                                      }
+                                                    }
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "next": {
+                          "block": {
+                            "type": "SetVariable",
+                            "id": ",+wd#fXovjlqh*cmB(3w",
+                            "inputs": {
+                              "VALUE-0": {
+                                "block": {
+                                  "type": "variableReferenceBlock",
+                                  "id": "PF*!WRzUr^zw?}6+o+[9",
+                                  "extraState": {
+                                    "isObjectVar": false
+                                  },
+                                  "fields": {
+                                    "OBJECTTYPE": "Global",
+                                    "VAR": {
+                                      "id": "9!i2$sZFWZtrj+Z85P.`"
+                                    }
+                                  }
+                                }
+                              },
+                              "VALUE-1": {
+                                "block": {
+                                  "type": "DegreesToRadians",
+                                  "id": "M)U=o2T%u6j(s3hU*33T",
+                                  "inputs": {
+                                    "VALUE-0": {
+                                      "block": {
+                                        "type": "GetVariable",
+                                        "id": "T-ydmb}FQa.Uf]FKBG2,",
+                                        "inputs": {
+                                          "VALUE-0": {
+                                            "block": {
+                                              "type": "variableReferenceBlock",
+                                              "id": "l@4V7n(B/O+w3Lz6WQ|s",
+                                              "extraState": {
+                                                "isObjectVar": false
+                                              },
+                                              "fields": {
+                                                "OBJECTTYPE": "Global",
+                                                "VAR": {
+                                                  "id": "9!i2$sZFWZtrj+Z85P.`"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
       }
     ]
   },
@@ -11150,6 +17344,76 @@
     {
       "name": "DEBUG_PlayDefence",
       "id": "}^*LIdpxV;$%E-l3ayo=",
+      "type": "Global"
+    },
+    {
+      "name": "Specialist",
+      "id": "PQt,8tYaHP%Y^xyuN2vr",
+      "type": "Global"
+    },
+    {
+      "name": "Assault",
+      "id": "}Zluh/,.+*V:1v$3);ao",
+      "type": "Global"
+    },
+    {
+      "name": "Engineer",
+      "id": "%YI,HkG5QqE*1#EzZxjM",
+      "type": "Global"
+    },
+    {
+      "name": "Medic",
+      "id": "Oy^]7IX.zwi.UFR*ty79",
+      "type": "Global"
+    },
+    {
+      "name": "Scout",
+      "id": "hypM!0ohL^cA%HtBrJ7;",
+      "type": "Global"
+    },
+    {
+      "name": "AssaultPrimary",
+      "id": ":dwZCT8I?YI$xG8BBgpE",
+      "type": "Global"
+    },
+    {
+      "name": "MedicPrimary",
+      "id": "8KZJUhdwv+ncikdh;V-P",
+      "type": "Global"
+    },
+    {
+      "name": "EngineerPrimary",
+      "id": "D_bDj446*hh;jK)W,t~:",
+      "type": "Global"
+    },
+    {
+      "name": "ScoutPrimary",
+      "id": "m$B!wjne^r^hL]4q--Ll",
+      "type": "Global"
+    },
+    {
+      "name": "EngineerOpenGadgets",
+      "id": "s)!_%~(8mBe0;~W6Q=xu",
+      "type": "Global"
+    },
+    {
+      "name": "SharedWeapons",
+      "id": "TZz#$wkTy%Zew*~8x`il",
+      "type": "Global"
+    },
+    {
+      "name": "SpawnBeconLocations",
+      "id": "w_^Ni+6S]Sp8=OOP4#,a",
+      "type": "Global"
+    },
+    {
+      "name": "Rotation",
+      "id": "9!i2$sZFWZtrj+Z85P.`",
+      "type": "Global"
+    },
+    {
+      "name": "AttackerReinforcments",
+      "id": "wNy%6`mCB3RKeeWT}eH(",
       "type": "Global"
     }
   ]


### PR DESCRIPTION
Added ability to set classes/weapon and equipment. Currently only set for weapons however can be adapted.
Added scoring for team 2
Added ability to deploy on spawn beckons by storing the location and checking deploy distance. Maximum of 20 has been set for now do stop an infinite check when deploying.
The array for spawn beckons is cleared when changing sector so players cannot spawn out of bounds